### PR TITLE
Wait for splitwell to see allocations in test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
@@ -419,19 +419,22 @@ class TokenStandardAllocationIntegrationTest
       }
     }
 
-    clue("Wait for allocations to be ingested by splitwell participant") {
+    clue(s"Wait for allocation ${aliceAllocationId} to be ingested by splitwell participant") {
       eventuallySucceeds() {
         splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
           .awaitJava(amuletallocationCodegen.AmuletAllocation.COMPANION)(
             venueParty,
             predicate = c => c.id == aliceAllocationId,
           )
-        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
-          .awaitJava(amuletallocationCodegen.AmuletAllocation.COMPANION)(
-            venueParty,
-            predicate = c => c.id == bobAllocationId,
-          )
       }
+    }
+
+    clue(s"Wait for allocation ${bobAllocationId} to be ingested by splitwell participant") {
+      splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+        .awaitJava(amuletallocationCodegen.AmuletAllocation.COMPANION)(
+          venueParty,
+          predicate = c => c.id == bobAllocationId,
+        )
     }
 
     AllocatedOtcTrade(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
@@ -419,6 +419,21 @@ class TokenStandardAllocationIntegrationTest
       }
     }
 
+    clue("Wait for allocations to be ingested by splitwell participant") {
+      eventuallySucceeds() {
+        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+          .awaitJava(amuletallocationCodegen.AmuletAllocation.COMPANION)(
+            venueParty,
+            predicate = c => c.id == aliceAllocationId,
+          )
+        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+          .awaitJava(amuletallocationCodegen.AmuletAllocation.COMPANION)(
+            venueParty,
+            predicate = c => c.id == bobAllocationId,
+          )
+      }
+    }
+
     AllocatedOtcTrade(
       venueParty = venueParty,
       aliceParty = aliceParty,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -10,6 +10,7 @@ import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
 import java.time.Duration
 import java.util.UUID
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amuletallocation
 import org.lfdecentralizedtrust.splice.codegen.java.splice.api.token.{
   allocationrequestv1,
   allocationv1,
@@ -824,6 +825,21 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       eventuallySucceeds() {
         sv1ScanBackend.getAllocationCancelContext(aliceAllocationId)
         sv1ScanBackend.getAllocationCancelContext(bobAllocationId)
+      }
+    }
+
+    clue("Wait for allocations to be ingested by splitwell participant") {
+      eventuallySucceeds() {
+        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+          .awaitJava(amuletallocation.AmuletAllocation.COMPANION)(
+            venueParty,
+            predicate = c => c.id == aliceAllocationId,
+          )
+        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+          .awaitJava(amuletallocation.AmuletAllocation.COMPANION)(
+            venueParty,
+            predicate = c => c.id == bobAllocationId,
+          )
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -828,19 +828,21 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       }
     }
 
-    clue("Wait for allocations to be ingested by splitwell participant") {
+    clue(s"Wait for allocation ${aliceAllocationId} to be ingested by splitwell participant") {
       eventuallySucceeds() {
         splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
           .awaitJava(amuletallocation.AmuletAllocation.COMPANION)(
             venueParty,
             predicate = c => c.id == aliceAllocationId,
           )
-        splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
-          .awaitJava(amuletallocation.AmuletAllocation.COMPANION)(
-            venueParty,
-            predicate = c => c.id == bobAllocationId,
-          )
       }
+    }
+    clue(s"Wait for allocation ${bobAllocationId} to be ingested by splitwell participant") {
+      splitwellValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
+        .awaitJava(amuletallocation.AmuletAllocation.COMPANION)(
+          venueParty,
+          predicate = c => c.id == bobAllocationId,
+        )
     }
 
     clue("Settlement venue settles the trade") {


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/8784

The command submission on the splitwell participant fails with `CONTRACT_NOT_FOUND`.