### PR TITLE
Add the ability to restrict whitelisting only to the required hosts

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -310,6 +310,7 @@ infra:
         key: value
         anotherKey: anotherValue
   istio:
+    enableGeneralIpWhitelist: false
     istiodValues: # example istiod overrides
       global:
         proxy:

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -291,6 +291,7 @@ infra:
         key: value
         anotherKey: anotherValue
   istio:
+    enableGeneralIpWhitelist: false
     istiodValues: # example istiod overrides
       global:
         proxy:

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1931,7 +1931,7 @@
         "meshConfig": {
           "accessLogEncoding": "JSON",
           "accessLogFile": "",
-          "accessLogFormat": "{\"trace_id\":\"%REQ(traceparent)%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"bytes_received\":\"%BYTES_RECEIVED%\",\"bytes_sent\":\"%BYTES_SENT%\",\"downstream_local_address\":\"%DOWNSTREAM_LOCAL_ADDRESS%\",\"downstream_remote_address\":\"%DOWNSTREAM_REMOTE_ADDRESS%\",\"duration\":\"%DURATION%\",\"method\":\"%REQ(:METHOD)%\",\"path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\"protocol\":\"%PROTOCOL%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"requested_server_name\":\"%REQUESTED_SERVER_NAME%\",\"response_code\":\"%RESPONSE_CODE%\",\"response_code_details\":\"%RESPONSE_CODE_DETAILS%\",\"response_flags\":\"%RESPONSE_FLAGS%\",\"start_time\":\"%START_TIME%\",\"upstream_cluster\":\"%UPSTREAM_CLUSTER%\",\"upstream_host\":\"%UPSTREAM_HOST%\",\"upstream_local_address\":\"%UPSTREAM_LOCAL_ADDRESS%\",\"upstream_service_time\":\"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"x_forwarded_for\":\"%REQ(X-FORWARDED-FOR)%\"}",
+          "accessLogFormat": "{\"trace_id\":\"%REQ(traceparent)%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"bytes_received\":\"%BYTES_RECEIVED%\",\"bytes_sent\":\"%BYTES_SENT%\",\"downstream_local_address\":\"%DOWNSTREAM_LOCAL_ADDRESS%\",\"downstream_remote_address\":\"%DOWNSTREAM_REMOTE_ADDRESS%\",\"duration\":\"%DURATION%\",\"method\":\"%REQ(:METHOD)%\",\"path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\"protocol\":\"%PROTOCOL%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"requested_server_name\":\"%REQUESTED_SERVER_NAME%\",\"response_code\":\"%RESPONSE_CODE%\",\"response_code_details\":\"%RESPONSE_CODE_DETAILS%\",\"response_flags\":\"%RESPONSE_FLAGS%\",\"start_time\":\"%START_TIME%\",\"upstream_cluster\":\"%UPSTREAM_CLUSTER%\",\"upstream_host\":\"%UPSTREAM_HOST%\",\"upstream_local_address\":\"%UPSTREAM_LOCAL_ADDRESS%\",\"upstream_service_time\":\"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"x_forwarded_for\":\"%REQ(X-FORWARDED-FOR)%\",\"local_rate_limited\":\"%RESP(x-local-rate-limit)%\",\"rate_limit_limit\":\"%RESP(x-ratelimit-limit)%\",\"rate_limit_remaining\":\"%RESP(x-ratelimit-remaining)%\",\"rate_limit_reset\":\"%RESP(x-ratelimit-reset)%\"}",
           "defaultConfig": {
             "gatewayTopology": {
               "numTrustedProxies": 0
@@ -1946,7 +1946,10 @@
           "defaultHttpRetryPolicy": {
             "attempts": 0
           },
-          "enablePrometheusMerge": false
+          "enablePrometheusMerge": false,
+          "pathNormalization": {
+            "normalization": "MERGE_SLASHES"
+          }
         },
         "telemetry": {
           "enabled": true,
@@ -2439,17 +2442,29 @@
                 "operation": {
                   "hosts": [
                     "sequencer-p2p-9.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-2.mock.network.canton.global:*",
                     "sequencer-p2p-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-p2p-10.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-2.mock.network.canton.global:*",
                     "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-p2p-9.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-1.mock.network.canton.global:*",
                     "sequencer-p2p-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-p2p-10.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-1.mock.network.canton.global:*",
                     "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-p2p-9.sv.mock.network.canton.global",
+                    "sequencer-p2p-9.sv.mock.network.canton.global:*",
                     "sequencer-p2p-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-p2p-10.sv.mock.network.canton.global",
-                    "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com"
+                    "sequencer-p2p-10.sv.mock.network.canton.global:*",
+                    "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com:*"
                   ]
                 }
               }
@@ -2505,29 +2520,53 @@
                 "operation": {
                   "hosts": [
                     "sequencer-9.sv-2.mock.network.canton.global",
+                    "sequencer-9.sv-2.mock.network.canton.global:*",
                     "sequencer-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-8.sv-2.mock.network.canton.global",
+                    "sequencer-8.sv-2.mock.network.canton.global:*",
                     "sequencer-8.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-7.sv-2.mock.network.canton.global",
+                    "sequencer-7.sv-2.mock.network.canton.global:*",
                     "sequencer-7.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-10.sv-2.mock.network.canton.global",
+                    "sequencer-10.sv-2.mock.network.canton.global:*",
                     "sequencer-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-2.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-9.sv-1.mock.network.canton.global",
+                    "sequencer-9.sv-1.mock.network.canton.global:*",
                     "sequencer-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-8.sv-1.mock.network.canton.global",
+                    "sequencer-8.sv-1.mock.network.canton.global:*",
                     "sequencer-8.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-7.sv-1.mock.network.canton.global",
+                    "sequencer-7.sv-1.mock.network.canton.global:*",
                     "sequencer-7.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-10.sv-1.mock.network.canton.global",
+                    "sequencer-10.sv-1.mock.network.canton.global:*",
                     "sequencer-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-1.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-9.sv.mock.network.canton.global",
+                    "sequencer-9.sv.mock.network.canton.global:*",
                     "sequencer-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-8.sv.mock.network.canton.global",
+                    "sequencer-8.sv.mock.network.canton.global:*",
                     "sequencer-8.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-7.sv.mock.network.canton.global",
+                    "sequencer-7.sv.mock.network.canton.global:*",
                     "sequencer-7.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv.mock.global.canton.network.digitalasset.com:*",
                     "sequencer-10.sv.mock.network.canton.global",
-                    "sequencer-10.sv.mock.global.canton.network.digitalasset.com"
+                    "sequencer-10.sv.mock.network.canton.global:*",
+                    "sequencer-10.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv.mock.global.canton.network.digitalasset.com:*"
                   ]
                 }
               }
@@ -2544,6 +2583,48 @@
     "name": "sequencer-pub-ip-whitelist-0",
     "provider": "",
     "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "EnvoyFilter",
+      "metadata": {
+        "name": "strip-rate-limit-headers",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "configPatches": [
+          {
+            "applyTo": "ROUTE_CONFIGURATION",
+            "match": {
+              "context": "GATEWAY"
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "response_headers_to_remove": [
+                  "x-local-rate-limit",
+                  "x-ratelimit-limit",
+                  "x-ratelimit-remaining",
+                  "x-ratelimit-reset",
+                  "x-envoy-ratelimited"
+                ]
+              }
+            }
+          }
+        ],
+        "workloadSelector": {
+          "labels": {
+            "istio": "ingress"
+          }
+        }
+      }
+    },
+    "name": "strip-rate-limit-headers",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:EnvoyFilter"
   },
   {
     "custom": true,

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1292,16 +1292,6 @@
                 "source": {
                   "remoteIpBlocks": [
                     "<internal IPs>",
-                    "1.2.3.4/32",
-                    "5.6.7.8/32",
-                    "11.12.13.14/32",
-                    "4.3.2.1/32",
-                    "8.7.6.5/32",
-                    "8.7.6.4/32",
-                    "9.8.7.6/32",
-                    "11.22.33.45/32",
-                    "12.34.56.78/32",
-                    "2.3.4.5/32",
                     "10.160.0.0/16"
                   ]
                 }
@@ -2248,6 +2238,72 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "scan-sv-app-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "4.3.2.1/32",
+                    "8.7.6.5/32",
+                    "8.7.6.4/32",
+                    "9.8.7.6/32",
+                    "11.22.33.45/32",
+                    "12.34.56.78/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "scan.sv-2.mock.network.canton.global",
+                    "sv.sv-2.mock.network.canton.global",
+                    "scan.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-2.mock.global.canton.network.digitalasset.com",
+                    "scan.sv-1.mock.network.canton.global",
+                    "sv.sv-1.mock.network.canton.global",
+                    "scan.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-1.mock.global.canton.network.digitalasset.com",
+                    "scan.sv.mock.network.canton.global",
+                    "sv.sv.mock.network.canton.global",
+                    "scan.sv.mock.global.canton.network.digitalasset.com",
+                    "sv.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "scan-sv-app-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "EnvoyFilter",
       "metadata": {
@@ -2320,6 +2376,144 @@
     "name": "sequencer-flow-control",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1alpha3:EnvoyFilter"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "sequencer-p2p-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sequencer-p2p-9.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv.mock.network.canton.global",
+                    "sequencer-p2p-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv.mock.network.canton.global",
+                    "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "sequencer-p2p-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "sequencer-pub-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "4.3.2.1/32",
+                    "8.7.6.5/32",
+                    "8.7.6.4/32",
+                    "9.8.7.6/32",
+                    "11.22.33.45/32",
+                    "12.34.56.78/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sequencer-9.sv-2.mock.network.canton.global",
+                    "sequencer-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-2.mock.network.canton.global",
+                    "sequencer-8.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-2.mock.network.canton.global",
+                    "sequencer-7.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-2.mock.network.canton.global",
+                    "sequencer-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv-1.mock.network.canton.global",
+                    "sequencer-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-1.mock.network.canton.global",
+                    "sequencer-8.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-1.mock.network.canton.global",
+                    "sequencer-7.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-1.mock.network.canton.global",
+                    "sequencer-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv.mock.network.canton.global",
+                    "sequencer-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv.mock.network.canton.global",
+                    "sequencer-8.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv.mock.network.canton.global",
+                    "sequencer-7.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv.mock.network.canton.global",
+                    "sequencer-10.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "sequencer-pub-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },
   {
     "custom": true,

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1288,16 +1288,6 @@
                 "source": {
                   "remoteIpBlocks": [
                     "<internal IPs>",
-                    "1.2.3.4/32",
-                    "5.6.7.8/32",
-                    "11.12.13.14/32",
-                    "4.3.2.1/32",
-                    "8.7.6.5/32",
-                    "8.7.6.4/32",
-                    "9.8.7.6/32",
-                    "11.22.33.45/32",
-                    "12.34.56.78/32",
-                    "2.3.4.5/32",
                     "10.160.0.0/16"
                   ]
                 }
@@ -1941,7 +1931,7 @@
         "meshConfig": {
           "accessLogEncoding": "JSON",
           "accessLogFile": "",
-          "accessLogFormat": "{\"trace_id\":\"%REQ(traceparent)%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"bytes_received\":\"%BYTES_RECEIVED%\",\"bytes_sent\":\"%BYTES_SENT%\",\"downstream_local_address\":\"%DOWNSTREAM_LOCAL_ADDRESS%\",\"downstream_remote_address\":\"%DOWNSTREAM_REMOTE_ADDRESS%\",\"duration\":\"%DURATION%\",\"method\":\"%REQ(:METHOD)%\",\"path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\"protocol\":\"%PROTOCOL%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"requested_server_name\":\"%REQUESTED_SERVER_NAME%\",\"response_code\":\"%RESPONSE_CODE%\",\"response_code_details\":\"%RESPONSE_CODE_DETAILS%\",\"response_flags\":\"%RESPONSE_FLAGS%\",\"start_time\":\"%START_TIME%\",\"upstream_cluster\":\"%UPSTREAM_CLUSTER%\",\"upstream_host\":\"%UPSTREAM_HOST%\",\"upstream_local_address\":\"%UPSTREAM_LOCAL_ADDRESS%\",\"upstream_service_time\":\"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"x_forwarded_for\":\"%REQ(X-FORWARDED-FOR)%\",\"local_rate_limited\":\"%RESP(x-local-rate-limit)%\",\"rate_limit_limit\":\"%RESP(x-ratelimit-limit)%\",\"rate_limit_remaining\":\"%RESP(x-ratelimit-remaining)%\",\"rate_limit_reset\":\"%RESP(x-ratelimit-reset)%\"}",
+          "accessLogFormat": "{\"trace_id\":\"%REQ(traceparent)%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"bytes_received\":\"%BYTES_RECEIVED%\",\"bytes_sent\":\"%BYTES_SENT%\",\"downstream_local_address\":\"%DOWNSTREAM_LOCAL_ADDRESS%\",\"downstream_remote_address\":\"%DOWNSTREAM_REMOTE_ADDRESS%\",\"duration\":\"%DURATION%\",\"method\":\"%REQ(:METHOD)%\",\"path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\"protocol\":\"%PROTOCOL%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"requested_server_name\":\"%REQUESTED_SERVER_NAME%\",\"response_code\":\"%RESPONSE_CODE%\",\"response_code_details\":\"%RESPONSE_CODE_DETAILS%\",\"response_flags\":\"%RESPONSE_FLAGS%\",\"start_time\":\"%START_TIME%\",\"upstream_cluster\":\"%UPSTREAM_CLUSTER%\",\"upstream_host\":\"%UPSTREAM_HOST%\",\"upstream_local_address\":\"%UPSTREAM_LOCAL_ADDRESS%\",\"upstream_service_time\":\"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"x_forwarded_for\":\"%REQ(X-FORWARDED-FOR)%\"}",
           "defaultConfig": {
             "gatewayTopology": {
               "numTrustedProxies": 0
@@ -1956,10 +1946,7 @@
           "defaultHttpRetryPolicy": {
             "attempts": 0
           },
-          "enablePrometheusMerge": false,
-          "pathNormalization": {
-            "normalization": "MERGE_SLASHES"
-          }
+          "enablePrometheusMerge": false
         },
         "telemetry": {
           "enabled": true,
@@ -2252,6 +2239,72 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "scan-sv-app-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "4.3.2.1/32",
+                    "8.7.6.5/32",
+                    "8.7.6.4/32",
+                    "9.8.7.6/32",
+                    "11.22.33.45/32",
+                    "12.34.56.78/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "scan.sv-2.mock.network.canton.global",
+                    "sv.sv-2.mock.network.canton.global",
+                    "scan.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-2.mock.global.canton.network.digitalasset.com",
+                    "scan.sv-1.mock.network.canton.global",
+                    "sv.sv-1.mock.network.canton.global",
+                    "scan.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-1.mock.global.canton.network.digitalasset.com",
+                    "scan.sv.mock.network.canton.global",
+                    "sv.sv.mock.network.canton.global",
+                    "scan.sv.mock.global.canton.network.digitalasset.com",
+                    "sv.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "scan-sv-app-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "EnvoyFilter",
       "metadata": {
@@ -2358,43 +2411,139 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "apiVersion": "networking.istio.io/v1alpha3",
-      "kind": "EnvoyFilter",
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
       "metadata": {
-        "name": "strip-rate-limit-headers",
+        "name": "sequencer-p2p-ip-whitelist-0",
         "namespace": "cluster-ingress"
       },
       "spec": {
-        "configPatches": [
+        "action": "ALLOW",
+        "rules": [
           {
-            "applyTo": "ROUTE_CONFIGURATION",
-            "match": {
-              "context": "GATEWAY"
-            },
-            "patch": {
-              "operation": "MERGE",
-              "value": {
-                "response_headers_to_remove": [
-                  "x-local-rate-limit",
-                  "x-ratelimit-limit",
-                  "x-ratelimit-remaining",
-                  "x-ratelimit-reset",
-                  "x-envoy-ratelimited"
-                ]
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "2.3.4.5/32"
+                  ]
+                }
               }
-            }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sequencer-p2p-9.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-2.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv-1.mock.network.canton.global",
+                    "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-9.sv.mock.network.canton.global",
+                    "sequencer-p2p-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-p2p-10.sv.mock.network.canton.global",
+                    "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
           }
         ],
-        "workloadSelector": {
-          "labels": {
-            "istio": "ingress"
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
           }
         }
       }
     },
-    "name": "strip-rate-limit-headers",
+    "name": "sequencer-p2p-ip-whitelist-0",
     "provider": "",
-    "type": "kubernetes:networking.istio.io/v1alpha3:EnvoyFilter"
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "sequencer-pub-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "4.3.2.1/32",
+                    "8.7.6.5/32",
+                    "8.7.6.4/32",
+                    "9.8.7.6/32",
+                    "11.22.33.45/32",
+                    "12.34.56.78/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sequencer-9.sv-2.mock.network.canton.global",
+                    "sequencer-9.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-2.mock.network.canton.global",
+                    "sequencer-8.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-2.mock.network.canton.global",
+                    "sequencer-7.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-2.mock.network.canton.global",
+                    "sequencer-10.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv-1.mock.network.canton.global",
+                    "sequencer-9.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv-1.mock.network.canton.global",
+                    "sequencer-8.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv-1.mock.network.canton.global",
+                    "sequencer-7.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv-1.mock.network.canton.global",
+                    "sequencer-10.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sequencer-9.sv.mock.network.canton.global",
+                    "sequencer-9.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-8.sv.mock.network.canton.global",
+                    "sequencer-8.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-7.sv.mock.network.canton.global",
+                    "sequencer-7.sv.mock.global.canton.network.digitalasset.com",
+                    "sequencer-10.sv.mock.network.canton.global",
+                    "sequencer-10.sv.mock.global.canton.network.digitalasset.com"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "sequencer-pub-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },
   {
     "custom": true,

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -1,13 +1,8 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as pulumi from '@pulumi/pulumi';
-import {
-  config,
-  loadJsonFromFile,
-  externalIpRangesFile,
-} from '@canton-network/splice-pulumi-common';
+import { config } from '@canton-network/splice-pulumi-common';
 import { clusterYamlConfig } from '@canton-network/splice-pulumi-common/src/config/config';
-import { getSecretVersionOutput } from '@pulumi/gcp/secretmanager';
 import util from 'node:util';
 import { z } from 'zod';
 
@@ -58,6 +53,7 @@ export const InfraConfigSchema = z.object({
       enableIngressAccessLogging: z.boolean(),
       enableClusterAccessLogging: z.boolean().default(false),
       enablePublicTokenRegistry: z.boolean().default(false),
+      enableGeneralIpWhitelist: z.boolean().default(true),
       istiodValues: z.object({}).catchall(z.any()).default({}),
       sequencerFlowControl: z.object({
         initialStreamWindowSize: z.int(),
@@ -86,47 +82,3 @@ console.error(
 
 export const infraConfig = fullConfig.infra;
 export const cloudArmorConfig: CloudArmorConfig = fullConfig.cloudArmor;
-
-type IpRangesDict = { [key: string]: IpRangesDict } | string[];
-
-function extractIpRanges(x: IpRangesDict, svsOnly: boolean = false): string[] {
-  if (svsOnly) {
-    if (Array.isArray(x)) {
-      throw new Error('Cannot distinguish SV IP ranges from non-SV IP ranges in an array');
-    }
-    return extractIpRanges(x['svs'], false);
-  } else {
-    return Array.isArray(x)
-      ? x
-      : Object.keys(x).reduce((acc: string[], k: string) => acc.concat(extractIpRanges(x[k])), []);
-  }
-}
-
-export function loadIPRanges(svsOnly: boolean = false): pulumi.Output<string[]> {
-  const file = externalIpRangesFile();
-  const externalIpRanges = file ? extractIpRanges(loadJsonFromFile(file), svsOnly) : [];
-
-  const internalWhitelistedIps = getSecretVersionOutput({
-    secret: 'pulumi-internal-whitelists',
-  }).apply(whitelists => {
-    const secretData = whitelists.secretData;
-    const json = JSON.parse(secretData);
-    const ret: string[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    json.forEach((ip: any) => {
-      ret.push(ip);
-    });
-    return ret;
-  });
-
-  const configWhitelistedIps = infraConfig.ipWhitelisting?.extraWhitelistedIngress || [];
-  const excludedIps = infraConfig.ipWhitelisting?.excludedIps || [];
-
-  return internalWhitelistedIps.apply(whitelists => {
-    const ips = whitelists
-      .concat(externalIpRanges)
-      .concat(configWhitelistedIps)
-      .filter(ip => excludedIps.indexOf(ip) < 0);
-    return [...new Set(ips)];
-  });
-}

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -3,13 +3,11 @@
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
-import * as assert from 'assert/strict';
 import {
   allSvsToDeployBasic,
   coreSvsToDeployBasic,
 } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 import { cometBFTExternalPort } from '@canton-network/splice-pulumi-common-sv/src/synchronizer/cometbftConfig';
-import { spliceConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { mergeWith } from 'lodash';
 
 import {
@@ -25,7 +23,11 @@ import {
   isDevNet,
   isMainNet,
 } from '../../common';
-import { clusterBasename, infraConfig, loadIPRanges } from './config';
+import { clusterBasename, infraConfig } from './config';
+import { configureIstioGatewayPolicies, installAppWhitelisting } from './whitelisting';
+import { loadInternalWhitelistedIps, loadIPRanges } from './whitelisting/ipRanges';
+import { configurePublicInfo } from './whitelisting/publicInfo';
+import { configurePublicTokenRegistry } from './whitelisting/publicTokenRegistry';
 
 interface ConfiguredIstio {
   allResources: pulumi.Resource[];
@@ -230,13 +232,17 @@ function configureInternalGatewayService(
   // The loopback traffic would be prevented by our policy. To still allow it, we
   // add the node pool ip ranges to the list.
   // eslint-disable-next-line promise/prefer-await-to-then
-  const internalIPRanges = cluster.then(c =>
+  const gcpInternalIPRanges = cluster.then(c =>
     c.nodePools.map(p => p.networkConfigs.map(c => c.podIpv4CidrBlock)).flat()
   );
-  const externalIPRanges = loadIPRanges();
+  const gatewayIPRanges = infraConfig.istio.enableGeneralIpWhitelist
+    ? pulumi.all([loadIPRanges(), gcpInternalIPRanges]).apply(([a, b]) => a.concat(b))
+    : pulumi
+        .all([loadInternalWhitelistedIps(), gcpInternalIPRanges])
+        .apply(([a, b]) => a.concat(b));
   return configureGatewayService(
     ingressNs,
-    pulumi.all([externalIPRanges, internalIPRanges]).apply(([a, b]) => a.concat(b)),
+    gatewayIPRanges,
     ingress.viaGKEL7
       ? { type: 'ClusterIP' }
       : {
@@ -301,82 +307,6 @@ function configureCometBFTGatewayService(
   );
 }
 
-/**
- * There doesn't seem to be an istio-level limit on number of IP lists but at
- * some point we probably hit some k8s limits on the size of a definition so we
- * split it into 100-500 IP ranges per policy.
- *
- * For 100k IPs, the difference between a chunk size of 100 vs 500 from scratch
- * is 20min in pulumi vs 130min in pulumi. But we're still concerned about k8s
- * limits on definition size. So if we break 10000 we'll gradually increase
- * the chunk size, 20 IPs at a time, until reaching 500 chunk size for 50k IPs,
- * which at least is tested for up to 100k IPs.
- *
- * Why 20? Too small jumps makes much noisier Pulumi previews. Too large, and we
- * might jump right into a limit only revealed after extensive testing without
- * really knowing where that limit is. 20 is a compromise: only jumps every 200
- * IPs so realignment updates are rare.
- */
-function istioAccessPolicyChunkSize(ipRangesLength: number) {
-  assert.ok(ipRangesLength >= 0, 'nonsense');
-  assert.ok(
-    ipRangesLength < 250000,
-    `${ipRangesLength} IPs untested, consider testing & increasing maximum chunk size`
-  );
-  const stepSize = 20;
-  return Math.max(100, Math.min(500, Math.ceil(ipRangesLength / (stepSize * 100)) * stepSize));
-}
-
-const istioApiVersion = 'security.istio.io/v1beta1';
-
-function istioAccessPolicies(
-  ingressNs: k8s.core.v1.Namespace,
-  externalIPRanges: pulumi.Output<string[]>,
-  suffix: string
-) {
-  const selector = {
-    matchLabels: {
-      app: `istio-ingress${suffix}`,
-    },
-  };
-  const defaultDenyAll = new k8s.apiextensions.CustomResource(
-    `istio-access-policy-deny-all${suffix}`,
-    {
-      apiVersion: istioApiVersion,
-      kind: 'AuthorizationPolicy',
-      metadata: {
-        name: `istio-access-policy-deny-all${suffix}`,
-        namespace: ingressNs.metadata.name,
-      },
-      // empty spec is deny all
-      spec: { selector },
-    }
-  );
-  return externalIPRanges.apply(ipRanges => {
-    const chunkSize = istioAccessPolicyChunkSize(ipRanges.length);
-    const chunks = Array.from({ length: Math.ceil(ipRanges.length / chunkSize) }, (_, i) =>
-      ipRanges.slice(i * chunkSize, i * chunkSize + chunkSize)
-    );
-    const policies = chunks.map(
-      (chunk, i) =>
-        new k8s.apiextensions.CustomResource(`istio-access-policy-allow${suffix}-${i}`, {
-          apiVersion: istioApiVersion,
-          kind: 'AuthorizationPolicy',
-          metadata: {
-            name: `istio-access-policy-allow${suffix}-${i}`,
-            namespace: ingressNs.metadata.name,
-          },
-          spec: {
-            selector,
-            action: 'ALLOW',
-            rules: [{ from: [{ source: { remoteIpBlocks: chunk } }] }],
-          },
-        })
-    );
-    return [defaultDenyAll].concat(policies);
-  });
-}
-
 // how gateway is configured: https://github.com/istio/istio/blob/master/manifests/charts/gateway/templates/service.yaml
 type IstioGatewayVariant =
   | {
@@ -404,8 +334,7 @@ function configureGatewayService(
   // - For cometbft traffic, which is tcp traffic, we failed to use istio policies, so we route it through a dedicated
   //   LoadBalancer service that uses loadBalancerSourceRanges. The size limit is not an issue as we need only SV IPs.
   //   These IPs should be provided in externalIPRangesInLB.
-
-  const istioPolicies = istioAccessPolicies(ingressNs, externalIPRangesInIstio, suffix);
+  const istioPolicies = configureIstioGatewayPolicies(ingressNs, externalIPRangesInIstio, suffix);
 
   const { serviceValues, deploymentValues } =
     gatewayVariant.type === 'LoadBalancer'
@@ -715,84 +644,6 @@ function configureDocsAndReleases(
   ];
 }
 
-function configurePublicInfo(ingressNs: k8s.core.v1.Namespace): k8s.apiextensions.CustomResource[] {
-  return spliceConfig.pulumiProjectConfig.hasPublicInfo
-    ? [
-        new k8s.apiextensions.CustomResource('allow-sv-info', {
-          apiVersion: 'security.istio.io/v1beta1',
-          kind: 'AuthorizationPolicy',
-          metadata: {
-            name: 'allow-sv-info',
-            namespace: ingressNs.metadata.name,
-          },
-          spec: {
-            selector: {
-              matchLabels: {
-                istio: 'ingress',
-              },
-            },
-            action: 'ALLOW',
-            rules: [
-              {
-                to: [
-                  {
-                    operation: {
-                      hosts: [
-                        // We could also have done `info.sv*.whatever` here but enumerating what we expect seems slightly more secure
-                        ...new Set(
-                          allSvsToDeployBasic
-                            .map(sv => [
-                              `info.${sv.ingressName}.${getDnsNames().cantonDnsName}`,
-                              `info.${sv.ingressName}.${getDnsNames().daDnsName}`,
-                            ])
-                            .flat()
-                        ),
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        }),
-      ]
-    : [];
-}
-
-function configurePublicTokenRegistry(
-  ingressNs: k8s.core.v1.Namespace
-): k8s.apiextensions.CustomResource[] {
-  return [
-    new k8s.apiextensions.CustomResource('allow-public-token-registry', {
-      apiVersion: istioApiVersion,
-      kind: 'AuthorizationPolicy',
-      metadata: {
-        name: 'allow-public-token-registry',
-        namespace: ingressNs.metadata.name,
-      },
-      spec: {
-        selector: {
-          matchLabels: {
-            app: 'istio-ingress',
-          },
-        },
-        action: 'ALLOW',
-        rules: [
-          {
-            to: [
-              {
-                operation: {
-                  paths: ['/registry/*'],
-                },
-              },
-            ],
-          },
-        ],
-      },
-    }),
-  ];
-}
-
 function configureSequencerHighPerformanceGrpcDestinationRules(
   ingressNs: k8s.core.v1.Namespace
 ): Array<k8s.apiextensions.CustomResource> {
@@ -975,6 +826,7 @@ export function configureIstio(
     ingressNs.ns
   );
   const sequencerFlowControl = configureSequencerFlowControl(ingressNs.ns);
+  installAppWhitelisting();
   return {
     allResources: [
       ...gateways,

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -880,7 +880,7 @@ export function configureIstio(
     ingressNs.ns
   );
   const sequencerFlowControl = configureSequencerFlowControl(ingressNs.ns);
-  installAppWhitelisting();
+  installAppWhitelisting(ingressNs.ns);
   const rateLimitHeaderStripping = stripRateLimitHeaders(ingressNs.ns, gwSvc);
   return {
     allResources: [

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -3,13 +3,11 @@
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
-import * as assert from 'assert/strict';
 import {
   allSvsToDeployBasic,
   coreSvsToDeployBasic,
 } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 import { cometBFTExternalPort } from '@canton-network/splice-pulumi-common-sv/src/synchronizer/cometbftConfig';
-import { spliceConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { rateLimitResponseHeaders } from '@canton-network/splice-pulumi-common/src/ratelimit/rateLimitHeaders';
 import { mergeWith } from 'lodash';
 
@@ -26,7 +24,11 @@ import {
   isDevNet,
   isMainNet,
 } from '../../common';
-import { clusterBasename, infraConfig, loadIPRanges } from './config';
+import { clusterBasename, infraConfig } from './config';
+import { configureIstioGatewayPolicies, installAppWhitelisting } from './whitelisting';
+import { loadInternalWhitelistedIps, loadIPRanges } from './whitelisting/ipRanges';
+import { configurePublicInfo } from './whitelisting/publicInfo';
+import { configurePublicTokenRegistry } from './whitelisting/publicTokenRegistry';
 
 interface ConfiguredIstio {
   allResources: pulumi.Resource[];
@@ -247,13 +249,17 @@ function configureInternalGatewayService(
   // The loopback traffic would be prevented by our policy. To still allow it, we
   // add the node pool ip ranges to the list.
   // eslint-disable-next-line promise/prefer-await-to-then
-  const internalIPRanges = cluster.then(c =>
+  const gcpInternalIPRanges = cluster.then(c =>
     c.nodePools.map(p => p.networkConfigs.map(c => c.podIpv4CidrBlock)).flat()
   );
-  const externalIPRanges = loadIPRanges();
+  const gatewayIPRanges = infraConfig.istio.enableGeneralIpWhitelist
+    ? pulumi.all([loadIPRanges(), gcpInternalIPRanges]).apply(([a, b]) => a.concat(b))
+    : pulumi
+        .all([loadInternalWhitelistedIps(), gcpInternalIPRanges])
+        .apply(([a, b]) => a.concat(b));
   return configureGatewayService(
     ingressNs,
-    pulumi.all([externalIPRanges, internalIPRanges]).apply(([a, b]) => a.concat(b)),
+    gatewayIPRanges,
     ingress.viaGKEL7
       ? { type: 'ClusterIP' }
       : {
@@ -318,82 +324,6 @@ function configureCometBFTGatewayService(
   );
 }
 
-/**
- * There doesn't seem to be an istio-level limit on number of IP lists but at
- * some point we probably hit some k8s limits on the size of a definition so we
- * split it into 100-500 IP ranges per policy.
- *
- * For 100k IPs, the difference between a chunk size of 100 vs 500 from scratch
- * is 20min in pulumi vs 130min in pulumi. But we're still concerned about k8s
- * limits on definition size. So if we break 10000 we'll gradually increase
- * the chunk size, 20 IPs at a time, until reaching 500 chunk size for 50k IPs,
- * which at least is tested for up to 100k IPs.
- *
- * Why 20? Too small jumps makes much noisier Pulumi previews. Too large, and we
- * might jump right into a limit only revealed after extensive testing without
- * really knowing where that limit is. 20 is a compromise: only jumps every 200
- * IPs so realignment updates are rare.
- */
-function istioAccessPolicyChunkSize(ipRangesLength: number) {
-  assert.ok(ipRangesLength >= 0, 'nonsense');
-  assert.ok(
-    ipRangesLength < 250000,
-    `${ipRangesLength} IPs untested, consider testing & increasing maximum chunk size`
-  );
-  const stepSize = 20;
-  return Math.max(100, Math.min(500, Math.ceil(ipRangesLength / (stepSize * 100)) * stepSize));
-}
-
-const istioApiVersion = 'security.istio.io/v1beta1';
-
-function istioAccessPolicies(
-  ingressNs: k8s.core.v1.Namespace,
-  externalIPRanges: pulumi.Output<string[]>,
-  suffix: string
-) {
-  const selector = {
-    matchLabels: {
-      app: `istio-ingress${suffix}`,
-    },
-  };
-  const defaultDenyAll = new k8s.apiextensions.CustomResource(
-    `istio-access-policy-deny-all${suffix}`,
-    {
-      apiVersion: istioApiVersion,
-      kind: 'AuthorizationPolicy',
-      metadata: {
-        name: `istio-access-policy-deny-all${suffix}`,
-        namespace: ingressNs.metadata.name,
-      },
-      // empty spec is deny all
-      spec: { selector },
-    }
-  );
-  return externalIPRanges.apply(ipRanges => {
-    const chunkSize = istioAccessPolicyChunkSize(ipRanges.length);
-    const chunks = Array.from({ length: Math.ceil(ipRanges.length / chunkSize) }, (_, i) =>
-      ipRanges.slice(i * chunkSize, i * chunkSize + chunkSize)
-    );
-    const policies = chunks.map(
-      (chunk, i) =>
-        new k8s.apiextensions.CustomResource(`istio-access-policy-allow${suffix}-${i}`, {
-          apiVersion: istioApiVersion,
-          kind: 'AuthorizationPolicy',
-          metadata: {
-            name: `istio-access-policy-allow${suffix}-${i}`,
-            namespace: ingressNs.metadata.name,
-          },
-          spec: {
-            selector,
-            action: 'ALLOW',
-            rules: [{ from: [{ source: { remoteIpBlocks: chunk } }] }],
-          },
-        })
-    );
-    return [defaultDenyAll].concat(policies);
-  });
-}
-
 // how gateway is configured: https://github.com/istio/istio/blob/master/manifests/charts/gateway/templates/service.yaml
 type IstioGatewayVariant =
   | {
@@ -421,8 +351,7 @@ function configureGatewayService(
   // - For cometbft traffic, which is tcp traffic, we failed to use istio policies, so we route it through a dedicated
   //   LoadBalancer service that uses loadBalancerSourceRanges. The size limit is not an issue as we need only SV IPs.
   //   These IPs should be provided in externalIPRangesInLB.
-
-  const istioPolicies = istioAccessPolicies(ingressNs, externalIPRangesInIstio, suffix);
+  const istioPolicies = configureIstioGatewayPolicies(ingressNs, externalIPRangesInIstio, suffix);
 
   const { serviceValues, deploymentValues } =
     gatewayVariant.type === 'LoadBalancer'
@@ -732,84 +661,6 @@ function configureDocsAndReleases(
   ];
 }
 
-function configurePublicInfo(ingressNs: k8s.core.v1.Namespace): k8s.apiextensions.CustomResource[] {
-  return spliceConfig.pulumiProjectConfig.hasPublicInfo
-    ? [
-        new k8s.apiextensions.CustomResource('allow-sv-info', {
-          apiVersion: 'security.istio.io/v1beta1',
-          kind: 'AuthorizationPolicy',
-          metadata: {
-            name: 'allow-sv-info',
-            namespace: ingressNs.metadata.name,
-          },
-          spec: {
-            selector: {
-              matchLabels: {
-                istio: 'ingress',
-              },
-            },
-            action: 'ALLOW',
-            rules: [
-              {
-                to: [
-                  {
-                    operation: {
-                      hosts: [
-                        // We could also have done `info.sv*.whatever` here but enumerating what we expect seems slightly more secure
-                        ...new Set(
-                          allSvsToDeployBasic
-                            .map(sv => [
-                              `info.${sv.ingressName}.${getDnsNames().cantonDnsName}`,
-                              `info.${sv.ingressName}.${getDnsNames().daDnsName}`,
-                            ])
-                            .flat()
-                        ),
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-        }),
-      ]
-    : [];
-}
-
-function configurePublicTokenRegistry(
-  ingressNs: k8s.core.v1.Namespace
-): k8s.apiextensions.CustomResource[] {
-  return [
-    new k8s.apiextensions.CustomResource('allow-public-token-registry', {
-      apiVersion: istioApiVersion,
-      kind: 'AuthorizationPolicy',
-      metadata: {
-        name: 'allow-public-token-registry',
-        namespace: ingressNs.metadata.name,
-      },
-      spec: {
-        selector: {
-          matchLabels: {
-            app: 'istio-ingress',
-          },
-        },
-        action: 'ALLOW',
-        rules: [
-          {
-            to: [
-              {
-                operation: {
-                  paths: ['/registry/*'],
-                },
-              },
-            ],
-          },
-        ],
-      },
-    }),
-  ];
-}
-
 function configureSequencerHighPerformanceGrpcDestinationRules(
   ingressNs: k8s.core.v1.Namespace
 ): Array<k8s.apiextensions.CustomResource> {
@@ -1029,6 +880,7 @@ export function configureIstio(
     ingressNs.ns
   );
   const sequencerFlowControl = configureSequencerFlowControl(ingressNs.ns);
+  installAppWhitelisting();
   const rateLimitHeaderStripping = stripRateLimitHeaders(ingressNs.ns, gwSvc);
   return {
     allResources: [

--- a/cluster/pulumi/infra/src/whitelisting/gateway.ts
+++ b/cluster/pulumi/infra/src/whitelisting/gateway.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
+
+import { createIstioIpAllowPolicies, istioApiVersion } from './policies';
+
+export function configureGatewayAccessPolicies(
+  ingressNs: k8s.core.v1.Namespace,
+  ipRanges: pulumi.Output<string[]>,
+  suffix: string
+): pulumi.Output<pulumi.Resource[]> {
+  const selector = {
+    matchLabels: {
+      app: `istio-ingress${suffix}`,
+    },
+  };
+  const defaultDenyAll = new k8s.apiextensions.CustomResource(
+    `istio-access-policy-deny-all${suffix}`,
+    {
+      apiVersion: istioApiVersion,
+      kind: 'AuthorizationPolicy',
+      metadata: {
+        name: `istio-access-policy-deny-all${suffix}`,
+        namespace: ingressNs.metadata.name,
+      },
+      // empty spec is deny all
+      spec: { selector },
+    }
+  );
+  return createIstioIpAllowPolicies({
+    namePrefix: `istio-access-policy-allow${suffix}`,
+    namespace: ingressNs.metadata.name,
+    selector,
+    ipRanges,
+  }).apply(policies => [defaultDenyAll, ...policies]);
+}

--- a/cluster/pulumi/infra/src/whitelisting/index.ts
+++ b/cluster/pulumi/infra/src/whitelisting/index.ts
@@ -8,11 +8,13 @@ import { configureGatewayAccessPolicies } from './gateway';
 import { configureScanAndSvAppWhitelist } from './scanAndSvApp';
 import { configureSequencerWhitelist } from './sequencer';
 
-export function installAppWhitelisting(): pulumi.Output<pulumi.Resource[]>[] {
+export function installAppWhitelisting(
+  namespace: k8s.core.v1.Namespace
+): pulumi.Output<pulumi.Resource[]>[] {
   if (infraConfig.istio.enableGeneralIpWhitelist) {
     return [];
   }
-  return [configureScanAndSvAppWhitelist(), ...configureSequencerWhitelist()];
+  return [configureScanAndSvAppWhitelist(namespace), ...configureSequencerWhitelist(namespace)];
 }
 
 export function configureIstioGatewayPolicies(

--- a/cluster/pulumi/infra/src/whitelisting/index.ts
+++ b/cluster/pulumi/infra/src/whitelisting/index.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
+
+import { infraConfig } from '../config';
+import { configureGatewayAccessPolicies } from './gateway';
+import { configureScanAndSvAppWhitelist } from './scanAndSvApp';
+import { configureSequencerWhitelist } from './sequencer';
+
+export function installAppWhitelisting(): pulumi.Output<pulumi.Resource[]>[] {
+  if (infraConfig.istio.enableGeneralIpWhitelist) {
+    return [];
+  }
+  return [configureScanAndSvAppWhitelist(), ...configureSequencerWhitelist()];
+}
+
+export function configureIstioGatewayPolicies(
+  ingressNs: k8s.core.v1.Namespace,
+  externalIPRangesInIstio: pulumi.Output<string[]>,
+  suffix: string
+): pulumi.Output<pulumi.Resource[]> {
+  return configureGatewayAccessPolicies(ingressNs, externalIPRangesInIstio, suffix);
+}

--- a/cluster/pulumi/infra/src/whitelisting/ipRanges.ts
+++ b/cluster/pulumi/infra/src/whitelisting/ipRanges.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as pulumi from '@pulumi/pulumi';
+import { externalIpRangesFile, loadJsonFromFile } from '@canton-network/splice-pulumi-common';
+import { getSecretVersionOutput } from '@pulumi/gcp/secretmanager';
+
+import { infraConfig } from '../config';
+
+type IpRangesDict = { [key: string]: IpRangesDict } | string[];
+
+function extractIpRanges(x: IpRangesDict, svsOnly: boolean = false): string[] {
+  if (svsOnly) {
+    if (Array.isArray(x)) {
+      throw new Error('Cannot distinguish SV IP ranges from non-SV IP ranges in an array');
+    }
+    return extractIpRanges(x['svs'], false);
+  } else {
+    return Array.isArray(x)
+      ? x
+      : Object.keys(x).reduce((acc: string[], k: string) => acc.concat(extractIpRanges(x[k])), []);
+  }
+}
+
+export function loadInternalWhitelistedIps(): pulumi.Output<string[]> {
+  const excludedIps = infraConfig.ipWhitelisting?.excludedIps || [];
+
+  return getSecretVersionOutput({
+    secret: 'pulumi-internal-whitelists',
+  }).apply(whitelists => {
+    const secretData = whitelists.secretData;
+    const json = JSON.parse(secretData);
+    const ret: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    json.forEach((ip: any) => {
+      ret.push(ip);
+    });
+    const ips = ret.filter(ip => excludedIps.indexOf(ip) < 0);
+    return [...new Set(ips)];
+  });
+}
+
+export function loadIPRanges(svsOnly: boolean = false): pulumi.Output<string[]> {
+  const file = externalIpRangesFile();
+  const externalIpRanges = file ? extractIpRanges(loadJsonFromFile(file), svsOnly) : [];
+
+  const configWhitelistedIps = infraConfig.ipWhitelisting?.extraWhitelistedIngress || [];
+  const excludedIps = infraConfig.ipWhitelisting?.excludedIps || [];
+
+  return loadInternalWhitelistedIps().apply(whitelists => {
+    const ips = whitelists
+      .concat(externalIpRanges)
+      .concat(configWhitelistedIps)
+      .filter(ip => excludedIps.indexOf(ip) < 0);
+    return [...new Set(ips)];
+  });
+}

--- a/cluster/pulumi/infra/src/whitelisting/policies.ts
+++ b/cluster/pulumi/infra/src/whitelisting/policies.ts
@@ -5,9 +5,6 @@ import * as pulumi from '@pulumi/pulumi';
 import * as assert from 'assert/strict';
 
 export const istioApiVersion = 'security.istio.io/v1beta1';
-
-export const CLUSTER_INGRESS_NS = 'cluster-ingress';
-
 export const istioIngressSelector = { matchLabels: { app: 'istio-ingress' } };
 
 /**

--- a/cluster/pulumi/infra/src/whitelisting/policies.ts
+++ b/cluster/pulumi/infra/src/whitelisting/policies.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
+import * as assert from 'assert/strict';
+
+export const istioApiVersion = 'security.istio.io/v1beta1';
+
+export const CLUSTER_INGRESS_NS = 'cluster-ingress';
+
+export const istioIngressSelector = { matchLabels: { app: 'istio-ingress' } };
+
+/**
+ * There doesn't seem to be an istio-level limit on number of IP lists but at
+ * some point we probably hit some k8s limits on the size of a definition so we
+ * split it into 100-500 IP ranges per policy.
+ *
+ * For 100k IPs, the difference between a chunk size of 100 vs 500 from scratch
+ * is 20min in pulumi vs 130min in pulumi. But we're still concerned about k8s
+ * limits on definition size. So if we break 10000 we'll gradually increase
+ * the chunk size, 20 IPs at a time, until reaching 500 chunk size for 50k IPs,
+ * which at least is tested for up to 100k IPs.
+ *
+ * Why 20? Too small jumps makes much noisier Pulumi previews. Too large, and we
+ * might jump right into a limit only revealed after extensive testing without
+ * really knowing where that limit is. 20 is a compromise: only jumps every 200
+ * IPs so realignment updates are rare.
+ */
+export function istioAccessPolicyChunkSize(ipRangesLength: number): number {
+  assert.ok(ipRangesLength >= 0, 'nonsense');
+  assert.ok(
+    ipRangesLength < 250000,
+    `${ipRangesLength} IPs untested, consider testing & increasing maximum chunk size`
+  );
+  const stepSize = 20;
+  return Math.max(100, Math.min(500, Math.ceil(ipRangesLength / (stepSize * 100)) * stepSize));
+}
+
+function chunkIpRanges(ipRanges: string[]): string[][] {
+  const chunkSize = istioAccessPolicyChunkSize(ipRanges.length);
+  return Array.from({ length: Math.ceil(ipRanges.length / chunkSize) }, (_, i) =>
+    ipRanges.slice(i * chunkSize, i * chunkSize + chunkSize)
+  );
+}
+
+export interface IstioIpAllowPolicyArgs {
+  namePrefix: string;
+  namespace: pulumi.Input<string>;
+  selector: object;
+  ipRanges: pulumi.Output<string[]>;
+  to?: object[];
+  opts?: pulumi.CustomResourceOptions;
+}
+
+export function createIstioIpAllowPolicies(
+  args: IstioIpAllowPolicyArgs
+): pulumi.Output<k8s.apiextensions.CustomResource[]> {
+  const { namePrefix, namespace, selector, ipRanges, to, opts } = args;
+  return ipRanges.apply(ranges =>
+    chunkIpRanges(ranges).map(
+      (chunk, i) =>
+        new k8s.apiextensions.CustomResource(
+          `${namePrefix}-${i}`,
+          {
+            apiVersion: istioApiVersion,
+            kind: 'AuthorizationPolicy',
+            metadata: {
+              name: `${namePrefix}-${i}`,
+              namespace,
+            },
+            spec: {
+              selector,
+              action: 'ALLOW',
+              rules: [
+                {
+                  from: [{ source: { remoteIpBlocks: chunk } }],
+                  ...(to ? { to } : {}),
+                },
+              ],
+            },
+          },
+          opts
+        )
+    )
+  );
+}

--- a/cluster/pulumi/infra/src/whitelisting/publicInfo.ts
+++ b/cluster/pulumi/infra/src/whitelisting/publicInfo.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+import { getDnsNames } from '@canton-network/splice-pulumi-common';
+import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
+import { spliceConfig } from '@canton-network/splice-pulumi-common/src/config/config';
+
+import { istioApiVersion } from './policies';
+
+export function configurePublicInfo(
+  ingressNs: k8s.core.v1.Namespace
+): k8s.apiextensions.CustomResource[] {
+  return spliceConfig.pulumiProjectConfig.hasPublicInfo
+    ? [
+        new k8s.apiextensions.CustomResource('allow-sv-info', {
+          apiVersion: istioApiVersion,
+          kind: 'AuthorizationPolicy',
+          metadata: {
+            name: 'allow-sv-info',
+            namespace: ingressNs.metadata.name,
+          },
+          spec: {
+            selector: {
+              matchLabels: {
+                istio: 'ingress',
+              },
+            },
+            action: 'ALLOW',
+            rules: [
+              {
+                to: [
+                  {
+                    operation: {
+                      hosts: [
+                        // We could also have done `info.sv*.whatever` here but enumerating what we expect seems slightly more secure
+                        ...new Set(
+                          allSvsToDeployBasic
+                            .map(sv => [
+                              `info.${sv.ingressName}.${getDnsNames().cantonDnsName}`,
+                              `info.${sv.ingressName}.${getDnsNames().daDnsName}`,
+                            ])
+                            .flat()
+                        ),
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ]
+    : [];
+}

--- a/cluster/pulumi/infra/src/whitelisting/publicTokenRegistry.ts
+++ b/cluster/pulumi/infra/src/whitelisting/publicTokenRegistry.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+
+import { istioApiVersion } from './policies';
+
+export function configurePublicTokenRegistry(
+  ingressNs: k8s.core.v1.Namespace
+): k8s.apiextensions.CustomResource[] {
+  return [
+    new k8s.apiextensions.CustomResource('allow-public-token-registry', {
+      apiVersion: istioApiVersion,
+      kind: 'AuthorizationPolicy',
+      metadata: {
+        name: 'allow-public-token-registry',
+        namespace: ingressNs.metadata.name,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: 'istio-ingress',
+          },
+        },
+        action: 'ALLOW',
+        rules: [
+          {
+            to: [
+              {
+                operation: {
+                  paths: ['/registry/*'],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  ];
+}

--- a/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
+++ b/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
@@ -1,20 +1,23 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import { getDnsNames } from '@canton-network/splice-pulumi-common';
 import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 
 import { loadIPRanges } from './ipRanges';
-import { CLUSTER_INGRESS_NS, createIstioIpAllowPolicies, istioIngressSelector } from './policies';
+import { createIstioIpAllowPolicies, istioIngressSelector } from './policies';
 
-export function configureScanAndSvAppWhitelist(): pulumi.Output<pulumi.Resource[]> {
+export function configureScanAndSvAppWhitelist(
+  namespace: k8s.core.v1.Namespace
+): pulumi.Output<pulumi.Resource[]> {
   const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
   const hosts = allSvsToDeployBasic.flatMap(sv =>
     dnsNames.flatMap(dns => [`scan.${sv.ingressName}.${dns}`, `sv.${sv.ingressName}.${dns}`])
   );
   return createIstioIpAllowPolicies({
     namePrefix: 'scan-sv-app-ip-whitelist',
-    namespace: CLUSTER_INGRESS_NS,
+    namespace: namespace.metadata.name,
     selector: istioIngressSelector,
     ipRanges: loadIPRanges(),
     to: [{ operation: { hosts } }],

--- a/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
+++ b/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as pulumi from '@pulumi/pulumi';
+import { getDnsNames } from '@canton-network/splice-pulumi-common';
+import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
+
+import { loadIPRanges } from './ipRanges';
+import { CLUSTER_INGRESS_NS, createIstioIpAllowPolicies, istioIngressSelector } from './policies';
+
+export function configureScanAndSvAppWhitelist(): pulumi.Output<pulumi.Resource[]> {
+  const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
+  const hosts = allSvsToDeployBasic.flatMap(sv =>
+    dnsNames.flatMap(dns => [`scan.${sv.ingressName}.${dns}`, `sv.${sv.ingressName}.${dns}`])
+  );
+  return createIstioIpAllowPolicies({
+    namePrefix: 'scan-sv-app-ip-whitelist',
+    namespace: CLUSTER_INGRESS_NS,
+    selector: istioIngressSelector,
+    ipRanges: loadIPRanges(),
+    to: [{ operation: { hosts } }],
+  });
+}

--- a/cluster/pulumi/infra/src/whitelisting/sequencer.ts
+++ b/cluster/pulumi/infra/src/whitelisting/sequencer.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as pulumi from '@pulumi/pulumi';
+import {
+  DecentralizedSynchronizerUpgradeConfig,
+  getDnsNames,
+} from '@canton-network/splice-pulumi-common';
+import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
+
+import { loadIPRanges } from './ipRanges';
+import { CLUSTER_INGRESS_NS, createIstioIpAllowPolicies, istioIngressSelector } from './policies';
+
+export function configureSequencerWhitelist(): pulumi.Output<pulumi.Resource[]>[] {
+  const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
+  const migrations = DecentralizedSynchronizerUpgradeConfig.runningMigrations();
+
+  const publicApiHosts = allSvsToDeployBasic.flatMap(sv =>
+    migrations.flatMap(migration =>
+      dnsNames.map(dns => `sequencer-${migration.id}.${sv.ingressName}.${dns}`)
+    )
+  );
+  const p2pHosts = allSvsToDeployBasic.flatMap(sv =>
+    migrations
+      .filter(migration => migration.sequencer.enableBftSequencer)
+      .flatMap(migration =>
+        dnsNames.map(dns => `sequencer-p2p-${migration.id}.${sv.ingressName}.${dns}`)
+      )
+  );
+
+  const policies = [
+    createIstioIpAllowPolicies({
+      namePrefix: 'sequencer-pub-ip-whitelist',
+      namespace: CLUSTER_INGRESS_NS,
+      selector: istioIngressSelector,
+      ipRanges: loadIPRanges(),
+      to: [{ operation: { hosts: publicApiHosts } }],
+    }),
+  ];
+  if (p2pHosts.length > 0) {
+    policies.push(
+      createIstioIpAllowPolicies({
+        namePrefix: 'sequencer-p2p-ip-whitelist',
+        namespace: CLUSTER_INGRESS_NS,
+        selector: istioIngressSelector,
+        ipRanges: loadIPRanges(true),
+        to: [{ operation: { hosts: p2pHosts } }],
+      })
+    );
+  }
+  return policies;
+}

--- a/cluster/pulumi/infra/src/whitelisting/sequencer.ts
+++ b/cluster/pulumi/infra/src/whitelisting/sequencer.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import {
   DecentralizedSynchronizerUpgradeConfig,
@@ -8,29 +9,37 @@ import {
 import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 
 import { loadIPRanges } from './ipRanges';
-import { CLUSTER_INGRESS_NS, createIstioIpAllowPolicies, istioIngressSelector } from './policies';
+import { createIstioIpAllowPolicies, istioIngressSelector } from './policies';
 
-export function configureSequencerWhitelist(): pulumi.Output<pulumi.Resource[]>[] {
+export function configureSequencerWhitelist(
+  namespace: k8s.core.v1.Namespace
+): pulumi.Output<pulumi.Resource[]>[] {
   const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
   const migrations = DecentralizedSynchronizerUpgradeConfig.runningMigrations();
 
   const publicApiHosts = allSvsToDeployBasic.flatMap(sv =>
     migrations.flatMap(migration =>
-      dnsNames.map(dns => `sequencer-${migration.id}.${sv.ingressName}.${dns}`)
+      dnsNames.flatMap(dns => [
+        `sequencer-${migration.id}.${sv.ingressName}.${dns}`,
+        `sequencer-${migration.id}.${sv.ingressName}.${dns}:*`,
+      ])
     )
   );
   const p2pHosts = allSvsToDeployBasic.flatMap(sv =>
     migrations
       .filter(migration => migration.sequencer.enableBftSequencer)
       .flatMap(migration =>
-        dnsNames.map(dns => `sequencer-p2p-${migration.id}.${sv.ingressName}.${dns}`)
+        dnsNames.flatMap(dns => [
+          `sequencer-p2p-${migration.id}.${sv.ingressName}.${dns}`,
+          `sequencer-p2p-${migration.id}.${sv.ingressName}.${dns}:*`,
+        ])
       )
   );
 
   const policies = [
     createIstioIpAllowPolicies({
       namePrefix: 'sequencer-pub-ip-whitelist',
-      namespace: CLUSTER_INGRESS_NS,
+      namespace: namespace.metadata.name,
       selector: istioIngressSelector,
       ipRanges: loadIPRanges(),
       to: [{ operation: { hosts: publicApiHosts } }],
@@ -40,7 +49,7 @@ export function configureSequencerWhitelist(): pulumi.Output<pulumi.Resource[]>[
     policies.push(
       createIstioIpAllowPolicies({
         namePrefix: 'sequencer-p2p-ip-whitelist',
-        namespace: CLUSTER_INGRESS_NS,
+        namespace: namespace.metadata.name,
         selector: istioIngressSelector,
         ipRanges: loadIPRanges(true),
         to: [{ operation: { hosts: p2pHosts } }],


### PR DESCRIPTION
Instead of allowing access through the general whitelist we add specific scan/sv app/sequencer/cantonbft allow lists that target only the ip that are required and keep the general whitelisting only for internal ips.

cantonbft is exposed only to the svs

[static]

drafting this and will merge and enable by default when i come back from holiday 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
