### PR TITLE
[ci] Ignore INTERNAL from GetConnectedSynchronizers mid-reconnect

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -211,3 +211,11 @@ LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*Rejected transaction due to a fail
 
 # TODO(DACH-NY/cn-test-failures#9136) remove once Canton fixes this race condition from not storing packages in dependency order
 INTERNAL/Missing package-id.*in package metadata view
+
+# TODO(DACH-NY/cn-test-failures#9445) remove once Canton stops failing the whole
+# GetConnectedSynchronizers call when one synchronizer is mid-reconnect.
+# SynchronizerRegistryHelpers calls cryptoApiProvider.removeAndClose(psid) and then
+# ips.add(topologyClient); in between, the synchronizer is still in readySynchronizers but has no
+# topology client, and CantonSyncService.getConnectedSynchronizers turns that into a thrown exception
+# for the entire request rather than omitting the one synchronizer.
+INTERNAL/Failed retrieving SynchronizerTopologyClient for synchronizer

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -211,3 +211,7 @@ LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*Rejected transaction due to a fail
 
 # TODO(DACH-NY/cn-test-failures#9136) remove once Canton fixes this race condition from not storing packages in dependency order
 INTERNAL/Missing package-id.*in package metadata view
+
+# TODO(DACH-NY/cn-test-failures#9445) remove once Canton stops failing the whole
+# GetConnectedSynchronizers call for one synchronizer that is mid-reconnect.
+INTERNAL/Failed retrieving SynchronizerTopologyClient for synchronizer


### PR DESCRIPTION
Canton fails the whole call when one synchronizer has no topology client during the remove/add window in SynchronizerRegistryHelpers. See https://github.com/DACH-NY/cn-test-failures/issues/9445

(this is just the ignore, I'll try a fix in canton for the actual issue)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
