### PR TITLE
[ci] Keep the alias registered during an LSU status flip

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
@@ -275,7 +275,12 @@ trait ParticipantAdminSynchronizerConnection {
           // If nothing matches the given psid, fall back to an active synchronizer with the alias.
           if (matchingPsid.nonEmpty) matchingPsid else activeSynchronizers
         case None =>
-          activeSynchronizers
+          // A logical synchronizer upgrade flips the previous generation to LSU_SOURCE before its
+          // successor becomes ACTIVE, so there is a window in which the alias is registered but no
+          // generation is active. Reporting the alias as unregistered there makes callers such as
+          // ensureSynchronizerRegisteredWithManualConnect fail, so fall back to whatever
+          // generations are registered under the alias.
+          if (activeSynchronizers.nonEmpty) activeSynchronizers else withMatchingAlias
       }
     }
 


### PR DESCRIPTION
Between a generation going LSU_SOURCE and its successor going ACTIVE no generation is active, so a psid-less lookup reported the alias as unregistered and failed SV app init.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/9447

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
