### PR TITLE
Traffic-Based App Rewards: Clearly distinguish not-ingestable from not-yet-ingested

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2776,8 +2776,8 @@ class HttpScanHandler(
           }
         case None =>
           appActivityStore.ingestionStatusForRound(roundNumber).map {
-            case RoundIngestionStatus.AskElsewhere => cannotProvide
-            case RoundIngestionStatus.TryAgainLater => undetermined
+            case RoundIngestionStatus.CannotProvide => cannotProvide
+            case RoundIngestionStatus.Undetermined => undetermined
           }
       }
     }
@@ -2815,8 +2815,8 @@ class HttpScanHandler(
           )
         case None =>
           appActivityStore.ingestionStatusForRound(roundNumber).map {
-            case RoundIngestionStatus.AskElsewhere => cannotProvide
-            case RoundIngestionStatus.TryAgainLater => undetermined
+            case RoundIngestionStatus.CannotProvide => cannotProvide
+            case RoundIngestionStatus.Undetermined => undetermined
           }
       }
     }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -98,6 +98,7 @@ import org.lfdecentralizedtrust.splice.scan.store.{
   ScanStore,
   TxLogEntry,
 }
+import org.lfdecentralizedtrust.splice.scan.store.AppActivityStore.RoundIngestionStatus
 import org.lfdecentralizedtrust.splice.scan.store.bulk.BulkStorageReader
 import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.QueryAcsSnapshotResult
 import org.lfdecentralizedtrust.splice.scan.store.bulk.AcsSnapshotBulkStorage.AcsSnapshotObjects
@@ -2774,11 +2775,9 @@ class HttpScanHandler(
               undetermined
           }
         case None =>
-          appActivityStore.earliestIngestedRound().map {
-            case Some(earliestIngested) if roundNumber <= earliestIngested =>
-              cannotProvide
-            case _ =>
-              undetermined
+          appActivityStore.ingestionStatusForRound(roundNumber).map {
+            case RoundIngestionStatus.AskElsewhere => cannotProvide
+            case RoundIngestionStatus.TryAgainLater => undetermined
           }
       }
     }
@@ -2815,11 +2814,9 @@ class HttpScanHandler(
             )
           )
         case None =>
-          appActivityStore.earliestIngestedRound().map {
-            case Some(earliestIngested) if roundNumber <= earliestIngested =>
-              cannotProvide
-            case _ =>
-              undetermined
+          appActivityStore.ingestionStatusForRound(roundNumber).map {
+            case RoundIngestionStatus.AskElsewhere => cannotProvide
+            case RoundIngestionStatus.TryAgainLater => undetermined
           }
       }
     }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -97,6 +97,7 @@ import org.lfdecentralizedtrust.splice.scan.store.{
   ScanStore,
   TxLogEntry,
 }
+import org.lfdecentralizedtrust.splice.scan.store.AppActivityStore.RoundIngestionStatus
 import org.lfdecentralizedtrust.splice.scan.store.bulk.BulkStorageReader
 import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.QueryAcsSnapshotResult
 import org.lfdecentralizedtrust.splice.scan.store.bulk.AcsSnapshotBulkStorage.AcsSnapshotObjects
@@ -2774,11 +2775,9 @@ class HttpScanHandler(
                   undetermined
               }
             case None =>
-              appActivityStore.earliestIngestedRound().map {
-                case Some(earliestIngested) if roundNumber <= earliestIngested =>
-                  cannotProvide
-                case _ =>
-                  undetermined
+              appActivityStore.ingestionStatusForRound(roundNumber).map {
+                case RoundIngestionStatus.AskElsewhere => cannotProvide
+                case RoundIngestionStatus.TryAgainLater => undetermined
               }
           }
         case _ =>
@@ -2820,11 +2819,9 @@ class HttpScanHandler(
                 )
               )
             case None =>
-              appActivityStore.earliestIngestedRound().map {
-                case Some(earliestIngested) if roundNumber <= earliestIngested =>
-                  cannotProvide
-                case _ =>
-                  undetermined
+              appActivityStore.ingestionStatusForRound(roundNumber).map {
+                case RoundIngestionStatus.AskElsewhere => cannotProvide
+                case RoundIngestionStatus.TryAgainLater => undetermined
               }
           }
         case _ =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
@@ -47,11 +47,11 @@ object AppActivityStore {
     /** Cannot compute an answer for this round from local state.
       * Callers should delegate to BFT read.
       */
-    case object AskElsewhere extends RoundIngestionStatus
+    case object CannotProvide extends RoundIngestionStatus
 
     /** Do not yet have an answer but expect to have one after
       * ingesting up to this round. Callers should retry.
       */
-    case object TryAgainLater extends RoundIngestionStatus
+    case object Undetermined extends RoundIngestionStatus
   }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
@@ -12,21 +12,16 @@ import scala.concurrent.Future
   */
 trait AppActivityStore {
 
+  /** Ingestion status for a specific round, used by the Scan HTTP
+    * endpoints when no root hash or activity totals are yet stored.
+    */
+  def ingestionStatusForRound(roundNumber: Long)(implicit
+      tc: TraceContext
+  ): Future[AppActivityStore.RoundIngestionStatus]
+
   /** Find the earliest round for which all app activity records have been ingested.
     */
   def earliestRoundWithCompleteAppActivity()(implicit
-      tc: TraceContext
-  ): Future[Option[Long]]
-
-  /** The earliest round for which we have ingested app activity records.
-    * This round may not have all app activity records ingested.
-    *
-    * Returns None if no app activity records have been ingested.
-    *
-    * Return -1 for the first SV, if the ingestion started from beginning of round 0,
-    * indicating that this SV has complete data of round 0.
-    */
-  def earliestIngestedRound()(implicit
       tc: TraceContext
   ): Future[Option[Long]]
 
@@ -38,4 +33,25 @@ trait AppActivityStore {
 
   /** The record time of the first activity record in the store. */
   def startedIngestingAt(implicit tc: TraceContext): Future[Option[Long]]
+}
+
+object AppActivityStore {
+
+  /** Whether this Scan can ever be authoritative for a given round,
+    * or whether the answer will arrive as ingestion catches up.
+    */
+  sealed trait RoundIngestionStatus
+
+  object RoundIngestionStatus {
+
+    /** Cannot compute an answer for this round from local state.
+      * Callers should delegate to BFT read.
+      */
+    case object AskElsewhere extends RoundIngestionStatus
+
+    /** Do not yet have an answer but expect to have one after
+      * ingesting up to this round. Callers should retry.
+      */
+    case object TryAgainLater extends RoundIngestionStatus
+  }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -192,21 +192,26 @@ class DbAppActivityRecordStore(
       tc: TraceContext
   ): Future[RoundIngestionStatus] =
     earliestIngestedRound().map {
-      // Meta row is present and the requested round is within-or-before
-      // our ingestion boundary but no root hash was computed for it:
-      // delegate to peers.
       case Some(earliestIngested) if roundNumber <= earliestIngested =>
-        RoundIngestionStatus.AskElsewhere
+        // We should have data for this round but no root hash exists:
+        // a peer likely does, so delegate.
+        RoundIngestionStatus.CannotProvide
 
-      // Meta row absent on a non-firstSV Scan — during bootstrap we
-      // have no ingestion boundary yet:
-      // delegate to peers.
-      case None if !isFirstSv => RoundIngestionStatus.AskElsewhere
+      case Some(_) =>
+        // Meta row present but round is beyond our ingested boundary —
+        // ingestion is still catching up; retry.
+        RoundIngestionStatus.Undetermined
 
-      // Otherwise (meta row absent on firstSV during ms-scale warm-up,
-      // OR meta row present but roundNumber > earliestIngested):
-      // the caller should retry.
-      case _ => RoundIngestionStatus.TryAgainLater
+      case None if !isFirstSv =>
+        // Late-joining Scan with no ingestion boundary of its own —
+        // it might seem Undetermined is right, but peers do have one,
+        // so we delegate.
+        RoundIngestionStatus.CannotProvide
+
+      case None =>
+        // firstSV during initial ingestion (brief startup window before
+        // the meta row is inserted) — retry.
+        RoundIngestionStatus.Undetermined
     }
 
   /** Find the latest round with complete app activity.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.scan.store.db
 
 import org.lfdecentralizedtrust.splice.scan.store.AppActivityStore
+import org.lfdecentralizedtrust.splice.scan.store.AppActivityStore.RoundIngestionStatus
 import org.lfdecentralizedtrust.splice.store.UpdateHistory
 import org.lfdecentralizedtrust.splice.util.FutureUnlessShutdownUtil.futureUnlessShutdownToFuture
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
@@ -171,7 +172,7 @@ class DbAppActivityRecordStore(
     * This round may not have all app activity records ingested.
     * Returns None if no app activity records have been ingested, ie meta row does not exist.
     */
-  def earliestIngestedRound()(implicit
+  private[store] def earliestIngestedRound()(implicit
       tc: TraceContext
   ): Future[Option[Long]] = {
     val codeVersion = ingestionVersions.code
@@ -186,6 +187,27 @@ class DbAppActivityRecordStore(
       "appActivity.earliestIngestedRound",
     )
   }
+
+  override def ingestionStatusForRound(roundNumber: Long)(implicit
+      tc: TraceContext
+  ): Future[RoundIngestionStatus] =
+    earliestIngestedRound().map {
+      // Meta row is present and the requested round is within-or-before
+      // our ingestion boundary but no root hash was computed for it:
+      // delegate to peers.
+      case Some(earliestIngested) if roundNumber <= earliestIngested =>
+        RoundIngestionStatus.AskElsewhere
+
+      // Meta row absent on a non-firstSV Scan — during bootstrap we
+      // have no ingestion boundary yet:
+      // delegate to peers.
+      case None if !isFirstSv => RoundIngestionStatus.AskElsewhere
+
+      // Otherwise (meta row absent on firstSV during ms-scale warm-up,
+      // OR meta row present but roundNumber > earliestIngested):
+      // the caller should retry.
+      case _ => RoundIngestionStatus.TryAgainLater
+    }
 
   /** Find the latest round with complete app activity.
     * A round is complete once the verdict ingestion has moved passed its archival.

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -660,25 +660,25 @@ class DbAppActivityRecordStoreTest
 
   "ingestionStatusForRound" should {
 
-    "return AskElsewhere when meta row absent and isFirstSv=false" in {
+    "return CannotProvide when meta row absent and isFirstSv=false" in {
       for {
         (store, _) <- newStore(isFirstSv = false)
         result <- store.ingestionStatusForRound(5L)
       } yield {
-        result shouldBe RoundIngestionStatus.AskElsewhere
+        result shouldBe RoundIngestionStatus.CannotProvide
       }
     }
 
-    "return TryAgainLater when meta row absent and isFirstSv=true" in {
+    "return Undetermined when meta row absent and isFirstSv=true" in {
       for {
         (store, _) <- newStore(isFirstSv = true)
         result <- store.ingestionStatusForRound(5L)
       } yield {
-        result shouldBe RoundIngestionStatus.TryAgainLater
+        result shouldBe RoundIngestionStatus.Undetermined
       }
     }
 
-    "return AskElsewhere when meta row present and roundNumber <= earliestIngested" in {
+    "return CannotProvide when meta row present and roundNumber <= earliestIngested" in {
       for {
         (store, _) <- newStore()
         baseTs = CantonTimestamp.now()
@@ -686,19 +686,19 @@ class DbAppActivityRecordStoreTest
         atBoundary <- store.ingestionStatusForRound(10L)
         below <- store.ingestionStatusForRound(5L)
       } yield {
-        atBoundary shouldBe RoundIngestionStatus.AskElsewhere
-        below shouldBe RoundIngestionStatus.AskElsewhere
+        atBoundary shouldBe RoundIngestionStatus.CannotProvide
+        below shouldBe RoundIngestionStatus.CannotProvide
       }
     }
 
-    "return TryAgainLater when meta row present and roundNumber > earliestIngested" in {
+    "return Undetermined when meta row present and roundNumber > earliestIngested" in {
       for {
         (store, _) <- newStore()
         baseTs = CantonTimestamp.now()
         _ <- store.insertActivityRecordMetaForTesting(1, 0, baseTs.toMicros, 10L, Some(11L))
         result <- store.ingestionStatusForRound(15L)
       } yield {
-        result shouldBe RoundIngestionStatus.TryAgainLater
+        result shouldBe RoundIngestionStatus.Undetermined
       }
     }
   }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -7,6 +7,7 @@ import com.digitalasset.canton.topology.SynchronizerId
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import org.lfdecentralizedtrust.splice.scan.store.AppActivityStore.RoundIngestionStatus
 import org.lfdecentralizedtrust.splice.scan.store.db.DbAppActivityRecordStore
 import org.lfdecentralizedtrust.splice.scan.store.db.DbAppActivityRecordStore.*
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore
@@ -653,6 +654,51 @@ class DbAppActivityRecordStoreTest
         result <- store1.earliestIngestedRound()
       } yield {
         result shouldBe None
+      }
+    }
+  }
+
+  "ingestionStatusForRound" should {
+
+    "return AskElsewhere when meta row absent and isFirstSv=false" in {
+      for {
+        (store, _) <- newStore(isFirstSv = false)
+        result <- store.ingestionStatusForRound(5L)
+      } yield {
+        result shouldBe RoundIngestionStatus.AskElsewhere
+      }
+    }
+
+    "return TryAgainLater when meta row absent and isFirstSv=true" in {
+      for {
+        (store, _) <- newStore(isFirstSv = true)
+        result <- store.ingestionStatusForRound(5L)
+      } yield {
+        result shouldBe RoundIngestionStatus.TryAgainLater
+      }
+    }
+
+    "return AskElsewhere when meta row present and roundNumber <= earliestIngested" in {
+      for {
+        (store, _) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMetaForTesting(1, 0, baseTs.toMicros, 10L, Some(11L))
+        atBoundary <- store.ingestionStatusForRound(10L)
+        below <- store.ingestionStatusForRound(5L)
+      } yield {
+        atBoundary shouldBe RoundIngestionStatus.AskElsewhere
+        below shouldBe RoundIngestionStatus.AskElsewhere
+      }
+    }
+
+    "return TryAgainLater when meta row present and roundNumber > earliestIngested" in {
+      for {
+        (store, _) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMetaForTesting(1, 0, baseTs.toMicros, 10L, Some(11L))
+        result <- store.ingestionStatusForRound(15L)
+      } yield {
+        result shouldBe RoundIngestionStatus.TryAgainLater
       }
     }
   }


### PR DESCRIPTION
As discussed earlier this is

- a part of the solution for #6690
- discussed previously as a potential solution for #6065

The new method on `AppActivityStore` moves the logic for determining the result from the handler into the trait; it returns a case class of two values because that looks clearer;  alternatively, the result could be a simple boolean; let me know if that's preferable

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
