### PR TITLE
Scan app: Activity meta row earliest_round fixes

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
@@ -256,7 +256,7 @@ class ScanVerdictIngestionService(
                   }
                   firstActiveRoundO <- recordTimes.minOption match {
                     case Some(minRecordTime) =>
-                      appActivityComputation.lookupActiveOpenMiningRound(minRecordTime)
+                      appActivityComputation.lookupEarliestIngestedRoundCandidate(minRecordTime)
                     case None => Future.successful(None)
                   }
                   lastArchivedRoundO <- recordTimes.maxOption match {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -49,13 +49,12 @@ class AppActivityComputation(
   )(implicit tc: TraceContext): Future[Option[Long]] =
     rewardsReferenceStore.lookupLatestArchivedOpenMiningRound(asOf)
 
-  /** The OpenMiningRound round number active at asOf, if the round data has been ingested. */
-  def lookupActiveOpenMiningRound(
+  /** See [[org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore.lookupEarliestIngestedRoundCandidate]].
+    */
+  def lookupEarliestIngestedRoundCandidate(
       asOf: CantonTimestamp
   )(implicit tc: TraceContext): Future[Option[Long]] =
-    rewardsReferenceStore
-      .lookupActiveOpenMiningRounds(Seq(asOf))
-      .map(_.get(asOf).map { case (roundNumber, _) => roundNumber })
+    rewardsReferenceStore.lookupEarliestIngestedRoundCandidate(asOf)
 
   /** Compute app activity records for a batch of verdicts.
     *

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -65,6 +65,11 @@ class CachingScanRewardsReferenceStore private[splice] (
   )(implicit tc: TraceContext): Future[Set[String]] =
     svParticipantIdsCache.get(asOf)
 
+  override def lookupEarliestIngestedRoundCandidate(
+      asOf: CantonTimestamp
+  )(implicit tc: TraceContext): Future[Option[Long]] =
+    store.lookupEarliestIngestedRoundCandidate(asOf)
+
   override def lookupOpenMiningRoundByNumber(
       roundNumber: Long
   )(implicit

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -70,6 +70,23 @@ trait ScanRewardsReferenceStore extends AppStore {
       asOf: CantonTimestamp
   )(implicit tc: TraceContext): Future[Set[String]]
 
+  /** Find the oldest round which was active asOf the given time.
+    * This is safe for use in `earliest_ingested_round` of the meta table.
+    *
+    * Unlike `lookupActiveOpenMiningRounds` here we do not gate on the store's ingestion start
+    * Because we just need to know whether the round was active at `asOf` time, and
+    * we don't require the ingestion to have started before the round opened.
+    *
+    * The reason for this is simply that `earliest_ingested_round` is by
+    * definition considered incomplete by the round completion logic.
+    *
+    * This would return `None` only when the first set of OpenMiningRounds ingested
+    * in the store has `opensAt` after the `asOf`.
+    */
+  def lookupEarliestIngestedRoundCandidate(
+      asOf: CantonTimestamp
+  )(implicit tc: TraceContext): Future[Option[Long]]
+
   /** Look up an OpenMiningRound contract by its round number.
     * Checks both the active ACS table and the archive table,
     * since the round may have already been closed by the time the trigger runs.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -321,7 +321,18 @@ class DbAppActivityRecordStore(
 
     // earliestRound: the oldest round open at the earliest record_time of this batch.
     // or (-1) on firstSV, as it is expected to have complete data for the first round.
-    val earliestRound = if (isFirstSv) Some(-1L) else firstActiveRoundO
+    //
+    // Its possible that we are processing a batch of verdicts where the
+    // earliest record_time is before the opensAt time of the earliest ingested
+    // rounds in the ScanRewardsReferenceStore. In this case firstActiveRoundO
+    // would be None, and it is always safe to consider the round info from
+    // items or the lastArchivedRoundO as a fallback.
+    val earliestRound =
+      if (isFirstSv) Some(-1L)
+      else
+        firstActiveRoundO
+          .orElse(items.map(_.roundNumber).minOption)
+          .orElse(lastArchivedRoundO)
 
     // lastArchived: the highest round archived as of this verdict batch.
     //   - From the caller when available

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -197,6 +197,16 @@ class DbScanRewardsReferenceStore(
   ): Future[Seq[ContractWithState[OpenMiningRound.ContractId, OpenMiningRound]]] =
     tcsStore.listAllContractsAsOf(OpenMiningRound.COMPANION, asOf)
 
+  override def lookupEarliestIngestedRoundCandidate(
+      asOf: CantonTimestamp
+  )(implicit tc: TraceContext): Future[Option[Long]] =
+    lookupOpenMiningRoundsAsOf(asOf).map { rounds =>
+      rounds
+        .filter(r => CantonTimestamp.assertFromInstant(r.contract.payload.opensAt) <= asOf)
+        .minByOption(_.contract.payload.round.number)
+        .map(_.contract.payload.round.number.toLong)
+    }
+
   override def lookupOpenMiningRoundByNumber(
       roundNumber: Long
   )(implicit


### PR DESCRIPTION
This does some fixes to the changes introduced in #6579, and partly fixes the issue described in #6690

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
