### PR TITLE
Replace all `(Long, CantonTimestamp)` tuples with `TimestampWithMigrationId`

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/UpdateHistoryTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/UpdateHistoryTestUtil.scala
@@ -33,7 +33,12 @@ import org.lfdecentralizedtrust.splice.store.UpdateHistoryTestBase.{
   LostInScanApi,
   LostInStoreIngestion,
 }
-import org.lfdecentralizedtrust.splice.store.{PageLimit, UpdateHistory, UpdateHistoryTestBase}
+import org.lfdecentralizedtrust.splice.store.{
+  PageLimit,
+  TimestampWithMigrationId,
+  UpdateHistory,
+  UpdateHistoryTestBase,
+}
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.UpdateHistoryResponse
 import com.daml.ledger.api.v2.transaction_filter
 import com.digitalasset.canton.admin.api.client.commands.LedgerApiCommands.UpdateService.{
@@ -115,11 +120,11 @@ trait UpdateHistoryTestUtil extends TestCommon {
     val recordedUpdates = updateHistory
       .getAllUpdates(
         Some(
-          (
-            0L,
+          TimestampWithMigrationId(
             // The after0 argument to getUpdates() is exclusive, so we need to subtract a small value
             // to include the first element
             actualUpdates.head.update.recordTime.addMicros(-1L),
+            0L,
           )
         ),
         PageLimit.tryCreate(actualUpdates.size),
@@ -140,11 +145,11 @@ trait UpdateHistoryTestUtil extends TestCommon {
     val recordedUpdates = updateHistory
       .getAllUpdates(
         Some(
-          (
-            0L,
+          TimestampWithMigrationId(
             // The after0 argument to getUpdates() is exclusive, so we need to subtract a small value
             // to include the first element
             actualUpdates.head.update.recordTime.addMicros(-1L),
+            0L,
           )
         ),
         PageLimit.tryCreate(actualUpdates.size),

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
@@ -40,6 +40,8 @@ import com.digitalasset.canton.config.CantonRequireTypes.String256M
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.CloseContext
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.logging.pretty.Pretty
+import com.digitalasset.canton.logging.pretty.Pretty.{param, prettyOfClass}
 import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.topology.{ParticipantId, PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
@@ -906,14 +908,14 @@ class UpdateHistory(
   }
 
   private def afterFilters(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       includeImportUpdates: Boolean,
   ): NonEmptyList[SQLActionBuilder] = {
     val gtMin = if (includeImportUpdates) ">=" else ">"
     afterO match {
       case None =>
         NonEmptyList.of(sql"migration_id >= 0 and record_time #$gtMin ${CantonTimestamp.MinValue}")
-      case Some((afterMigrationId, afterRecordTime)) =>
+      case Some(TimestampWithMigrationId(afterRecordTime, afterMigrationId)) =>
         // This makes it so that the two queries use updt_hist_tran_hi_mi_rt_di,
         NonEmptyList.of(
           sql"migration_id = ${afterMigrationId} and record_time > ${afterRecordTime} ",
@@ -1101,7 +1103,7 @@ class UpdateHistory(
   }
 
   def getUpdatesWithoutImportUpdates(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       limit: Limit,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val filters = afterFilters(afterO, includeImportUpdates = false)
@@ -1132,7 +1134,7 @@ class UpdateHistory(
   }
 
   def getAllUpdates(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       limit: PageLimit,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val filters = afterFilters(afterO, includeImportUpdates = true)
@@ -2595,6 +2597,12 @@ final case class TimestampWithMigrationId(
 object TimestampWithMigrationId {
   implicit val ordering: Ordering[TimestampWithMigrationId] =
     Ordering.by(x => (x.migrationId, x.timestamp))
+
+  implicit val prettyTimestampWithMigrationId: Pretty[TimestampWithMigrationId] =
+    prettyOfClass(
+      param("timestamp", _.timestamp),
+      param("migrationId", _.migrationId),
+    )
 }
 
 final case class TreeUpdateWithMigrationId(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
@@ -424,7 +424,10 @@ class UpdateHistoryTest extends UpdateHistoryTestBase {
             store
               .getAllUpdates(
                 after.map { case (migrationId, recordTime) =>
-                  (migrationId, CantonTimestamp.assertFromInstant(recordTime))
+                  TimestampWithMigrationId(
+                    CantonTimestamp.assertFromInstant(recordTime),
+                    migrationId,
+                  )
                 },
                 PageLimit.tryCreate(1),
               )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -108,6 +108,7 @@ import org.lfdecentralizedtrust.splice.store.{
   AppStore,
   AppStoreWithIngestion,
   PageLimit,
+  TimestampWithMigrationId,
   VoteResultsFilters,
   VotesStore,
 }
@@ -704,9 +705,9 @@ class HttpScanHandler(
     implicit val tc: TraceContext = extracted
     val afterO = after.map { after =>
       val afterRecordTime = parseTimestamp(after.afterRecordTime)
-      (
-        after.afterMigrationId,
+      TimestampWithMigrationId(
         afterRecordTime,
+        after.afterMigrationId,
       )
     }
     confirmBackfillingIsCompleteThen(updateHistory) {
@@ -896,7 +897,7 @@ class HttpScanHandler(
     implicit val tc: TraceContext = extracted
     val afterO = after.map { a =>
       val afterRecordTime = parseTimestamp(a.afterRecordTime)
-      (a.afterMigrationId, afterRecordTime)
+      TimestampWithMigrationId(afterRecordTime, a.afterMigrationId)
     }
 
     confirmBackfillingIsCompleteThen(updateHistory) {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanHistoryBackfillingTrigger.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanHistoryBackfillingTrigger.scala
@@ -26,6 +26,7 @@ import org.lfdecentralizedtrust.splice.store.{
   HistoryMetrics,
   ImportUpdatesBackfilling,
   PageLimit,
+  TimestampWithMigrationId,
   TreeUpdateWithMigrationId,
   UpdateHistory,
 }
@@ -85,7 +86,7 @@ class ScanHistoryBackfillingTrigger(
     */
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   @volatile
-  private var findHistoryStartAfter: Option[(Long, CantonTimestamp)] = None
+  private var findHistoryStartAfter: Option[TimestampWithMigrationId] = None
 
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   @volatile
@@ -214,7 +215,8 @@ class ScanHistoryBackfillingTrigger(
           PageLimit.tryCreate(batchSize),
         )
         _ = updates.lastOption.foreach(u =>
-          findHistoryStartAfter = Some(u.migrationId -> u.update.update.recordTime)
+          findHistoryStartAfter =
+            Some(TimestampWithMigrationId(u.update.update.recordTime, u.migrationId))
         )
         result <-
           if (updates.isEmpty) {
@@ -311,7 +313,7 @@ class ScanHistoryBackfillingTrigger(
 object ScanHistoryBackfillingTrigger {
   sealed trait Task extends PrettyPrinting
   final case class InitializeBackfillingTask(
-      after: Option[(Long, CantonTimestamp)]
+      after: Option[TimestampWithMigrationId]
   ) extends Task {
     override def pretty: Pretty[this.type] =
       prettyOfClass(param("after", _.after))

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -11,6 +11,7 @@ import com.digitalasset.daml.lf.data.Numeric
 import com.digitalasset.daml.lf.data.{assertRight as damlRight}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
+import org.lfdecentralizedtrust.splice.store.TimestampWithMigrationId
 
 import java.math.RoundingMode
 import scala.collection.immutable.SortedMap
@@ -55,7 +56,7 @@ class AppActivityComputation(
   )(implicit tc: TraceContext): Future[Option[Long]] =
     rewardsReferenceStore
       .lookupActiveOpenMiningRounds(Seq(asOf))
-      .map(_.get(asOf).map { case (roundNumber, _) => roundNumber })
+      .map(_.get(asOf).map { case TimestampWithMigrationId(_, roundNumber) => roundNumber })
 
   /** Compute app activity records for a batch of verdicts.
     *
@@ -104,7 +105,7 @@ class AppActivityComputation(
             Future.successful((summary, verdict, None))
           case (summary, verdict, true) =>
             roundInfoByTime.get(summary.sequencingTime) match {
-              case Some((roundNumber, roundOpensAt)) =>
+              case Some(TimestampWithMigrationId(roundOpensAt, roundNumber)) =>
                 for {
                   featuredAppWeights <- rewardsReferenceStore.lookupFeaturedAppPartiesAsOf(
                     roundOpensAt

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -10,7 +10,12 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.github.blemale.scaffeine.Scaffeine
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.rewardaccountingv2.CalculateRewardsV2
 import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
-import org.lfdecentralizedtrust.splice.store.{Limit, MultiDomainAcsStore, SynchronizerStore}
+import org.lfdecentralizedtrust.splice.store.{
+  Limit,
+  MultiDomainAcsStore,
+  SynchronizerStore,
+  TimestampWithMigrationId,
+}
 import org.lfdecentralizedtrust.splice.util.Contract
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -52,7 +57,7 @@ class CachingScanRewardsReferenceStore private[splice] (
 
   override def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]] =
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]] =
     store.lookupActiveOpenMiningRounds(recordTimes)
 
   override def lookupFeaturedAppPartiesAsOf(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
@@ -10,7 +10,7 @@ import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, 
 import org.lfdecentralizedtrust.splice.store.TreeUpdateWithMigrationId
 import org.lfdecentralizedtrust.splice.store.UpdateHistory
 import com.digitalasset.canton.data.CantonTimestamp
-import org.lfdecentralizedtrust.splice.store.PageLimit
+import org.lfdecentralizedtrust.splice.store.{PageLimit, TimestampWithMigrationId}
 import scala.collection.immutable.SortedMap
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -60,7 +60,7 @@ class ScanEventStore(
   }
 
   def getEvents(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       currentMigrationId: Long,
       limit: PageLimit,
   )(implicit tc: TraceContext): Future[Seq[Event]] = {
@@ -88,9 +88,9 @@ class ScanEventStore(
         verdictStore.listTransactionViews(v.rowId).map(views => v -> views)
       )
     } yield {
-      val verdictEntries: Iterator[((Long, CantonTimestamp), Verdict)] =
+      val verdictEntries: Iterator[(TimestampWithMigrationId, Verdict)] =
         verdictsWithViews.iterator.map { case (v, views) =>
-          val k = (v.migrationId, v.recordTime)
+          val k = TimestampWithMigrationId(v.recordTime, v.migrationId)
           k -> (v -> views)
         }
 
@@ -100,11 +100,11 @@ class ScanEventStore(
       val mergedSorted = {
         val fromUpdates = filteredUpdates.iterator.foldLeft(
           SortedMap.empty[
-            (Long, CantonTimestamp),
+            TimestampWithMigrationId,
             (Option[Verdict], Option[TreeUpdateWithMigrationId]),
           ]
         ) { case (acc, u) =>
-          val k = (u.migrationId, u.update.update.recordTime)
+          val k = TimestampWithMigrationId(u.update.update.recordTime, u.migrationId)
           acc.updated(k, (None, Some(u)))
         }
         verdictEntries.foldLeft(fromUpdates) { case (acc, (k, v)) =>
@@ -151,12 +151,12 @@ class ScanEventStore(
 // Filtering logic extracted out for unit testing
 object ScanEventStore {
   def allowF(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       currentMigrationId: Long,
       currentMigrationCap: CantonTimestamp,
   )(mig: Long, rt: CantonTimestamp): Boolean = {
     afterO match {
-      case Some((afterMig, afterRt)) if mig == afterMig =>
+      case Some(TimestampWithMigrationId(afterRt, afterMig)) if mig == afterMig =>
         if (mig < currentMigrationId) rt > afterRt
         else rt > afterRt && rt <= currentMigrationCap
       case _ if mig < currentMigrationId =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -16,7 +16,12 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
 import org.lfdecentralizedtrust.splice.config.IngestionConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.scan.store.db.ScanRewardsReferenceTables.ScanRewardsReferenceStoreRowData
-import org.lfdecentralizedtrust.splice.store.{AppStore, Limit, MultiDomainAcsStore}
+import org.lfdecentralizedtrust.splice.store.{
+  AppStore,
+  Limit,
+  MultiDomainAcsStore,
+  TimestampWithMigrationId,
+}
 import org.lfdecentralizedtrust.splice.store.db.AcsInterfaceViewRowData
 import org.lfdecentralizedtrust.splice.util.{Contract, TemplateJsonDecoder}
 
@@ -57,7 +62,7 @@ trait ScanRewardsReferenceStore extends AppStore {
     */
   def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]]
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]]
 
   def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -63,7 +63,7 @@ class UpdateHistorySegmentBulkStorage(
   ): Future[Option[(TimestampWithMigrationId, Seq[TreeUpdateWithMigrationId])]] = {
     for {
       updates <- updateHistory.getUpdatesWithoutImportUpdates(
-        Some((afterTs.migrationId, afterTs.timestamp)),
+        Some(TimestampWithMigrationId(afterTs.timestamp, afterTs.migrationId)),
         PageLimit.tryCreate(storageConfig.bulkDbReadChunkSize),
       )
       updatesInSegment = updates.filter(update =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -17,7 +17,12 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
 import org.lfdecentralizedtrust.splice.config.IngestionConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.store.{Limit, LimitHelpers, TcsStore}
+import org.lfdecentralizedtrust.splice.store.{
+  Limit,
+  LimitHelpers,
+  TcsStore,
+  TimestampWithMigrationId,
+}
 import org.lfdecentralizedtrust.splice.store.db.{
   AcsArchiveConfig,
   AcsQueries,
@@ -103,7 +108,7 @@ class DbScanRewardsReferenceStore(
 
   override def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]] = {
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]] = {
     tcsStore.getEarliestArchivedAt().flatMap {
       case None =>
         Future.successful(Map.empty)
@@ -125,7 +130,10 @@ class DbScanRewardsReferenceStore(
                 .flatMap { r =>
                   val opensAt = CantonTimestamp.assertFromInstant(r.contract.payload.opensAt)
                   Option.when(opensAt >= ingestionStart) {
-                    recordTime -> (r.contract.payload.round.number.toLong, opensAt)
+                    recordTime -> TimestampWithMigrationId(
+                      opensAt,
+                      r.contract.payload.round.number.toLong,
+                    )
                   }
                 }
             }.toMap

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
@@ -25,7 +25,7 @@ import slick.dbio.DBIO
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, Future}
 import cats.data.NonEmptyList
-import org.lfdecentralizedtrust.splice.store.UpdateHistory
+import org.lfdecentralizedtrust.splice.store.{TimestampWithMigrationId, UpdateHistory}
 import org.lfdecentralizedtrust.splice.scan.store.db.DbAppActivityRecordStore.AppActivityRecordT
 
 object DbScanVerdictStore {
@@ -565,14 +565,14 @@ class DbScanVerdictStore(
     )
 
   private def afterFilters(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       includeImportUpdates: Boolean,
   ): NonEmptyList[SQLActionBuilder] = {
     val gt = if (includeImportUpdates) ">=" else ">"
     afterO match {
       case None =>
         NonEmptyList.of(sql"migration_id >= 0 and record_time #$gt ${CantonTimestamp.MinValue}")
-      case Some((afterMigrationId, afterRecordTime)) =>
+      case Some(TimestampWithMigrationId(afterRecordTime, afterMigrationId)) =>
         NonEmptyList.of(
           sql"migration_id = ${afterMigrationId} and record_time > ${afterRecordTime} ",
           sql"migration_id > ${afterMigrationId} and record_time #$gt ${CantonTimestamp.MinValue}",
@@ -615,7 +615,7 @@ class DbScanVerdictStore(
   }
 
   def listVerdicts(
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       includeImportUpdates: Boolean,
       limit: Int,
   )(implicit tc: TraceContext): Future[Seq[VerdictT]] = {

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
@@ -11,6 +11,7 @@ import com.google.protobuf.timestamp.Timestamp as ProtoTimestamp
 import com.google.protobuf.ByteString
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
+import org.lfdecentralizedtrust.splice.store.TimestampWithMigrationId
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Future
@@ -219,7 +220,7 @@ class AppActivityComputationTest extends AnyWordSpec with BaseTest {
     val store = mock[ScanRewardsReferenceStore]
     when(store.lookupActiveOpenMiningRounds(any[Seq[CantonTimestamp]])(any[TraceContext]))
       .thenAnswer { (times: Seq[CantonTimestamp]) =>
-        Future.successful(times.map(_ -> (0L, roundOpensAt)).toMap)
+        Future.successful(times.map(_ -> TimestampWithMigrationId(roundOpensAt, 0L)).toMap)
       }
     when(store.lookupFeaturedAppPartiesAsOf(any[CantonTimestamp])(any[TraceContext]))
       .thenReturn(Future.successful(featuredWeights))

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
@@ -9,6 +9,7 @@ import org.lfdecentralizedtrust.splice.store.{
   HistoryMetrics,
   PageLimit,
   StoreTestBase,
+  TimestampWithMigrationId,
   UpdateHistory,
 }
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
@@ -122,14 +123,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after recordTs1
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1)),
+          Some(TimestampWithMigrationId(recordTs1, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -169,14 +170,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after recordTs1
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1)),
+          Some(TimestampWithMigrationId(recordTs1, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -218,14 +219,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after recordTs1
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1)),
+          Some(TimestampWithMigrationId(recordTs1, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -267,12 +268,17 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         events <- fetchEvents(ctx1.eventStore, None, mig1, pageLimit)
         events2 <- fetchEvents(
           ctx1.eventStore,
-          Some((mig0, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), mig0)),
           mig1,
           pageLimit,
         )
         // after recordTs1
-        events3 <- fetchEvents(ctx1.eventStore, Some((mig0, recordTs1)), mig1, pageLimit)
+        events3 <- fetchEvents(
+          ctx1.eventStore,
+          Some(TimestampWithMigrationId(recordTs1, mig0)),
+          mig1,
+          pageLimit,
+        )
         // Fetch by id works across migrationIds
         e1 <- ctx1.eventStore.getEventByUpdateId(updateId1, domainMigrationId)
         e2 <- ctx1.eventStore.getEventByUpdateId(updateId2, domainMigrationId)
@@ -429,14 +435,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after latest verdict
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs2)),
+          Some(TimestampWithMigrationId(recordTs2, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -474,14 +480,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after latest assignment
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs2)),
+          Some(TimestampWithMigrationId(recordTs2, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -518,14 +524,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after latest verdict
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs2)),
+          Some(TimestampWithMigrationId(recordTs2, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -564,14 +570,14 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         // Fetch with cursor
         events2 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs1.minusSeconds(1))),
+          Some(TimestampWithMigrationId(recordTs1.minusSeconds(1), domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
         // Fetch after latest unassignment
         events3 <- fetchEvents(
           ctx.eventStore,
-          Some((domainMigrationId, recordTs2)),
+          Some(TimestampWithMigrationId(recordTs2, domainMigrationId)),
           domainMigrationId,
           pageLimit,
         )
@@ -813,7 +819,7 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
 
       {
         val allow = ScanEventStore.allowF(
-          afterO = Some((mig0, recordTs1)),
+          afterO = Some(TimestampWithMigrationId(recordTs1, mig0)),
           currentMigrationId = mig1,
           currentMigrationCap = capMin,
         )
@@ -824,7 +830,7 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
 
       {
         val allow = ScanEventStore.allowF(
-          afterO = Some((mig0, recordTs1)),
+          afterO = Some(TimestampWithMigrationId(recordTs1, mig0)),
           currentMigrationId = mig1,
           currentMigrationCap = cap3,
         )
@@ -838,7 +844,7 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
 
       {
         val allow = ScanEventStore.allowF(
-          afterO = Some((mig1, recordTs2)),
+          afterO = Some(TimestampWithMigrationId(recordTs2, mig1)),
           currentMigrationId = mig1,
           currentMigrationCap = cap3,
         )
@@ -849,7 +855,7 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
 
       {
         val allow = ScanEventStore.allowF(
-          afterO = Some((mig2, recordTs2)),
+          afterO = Some(TimestampWithMigrationId(recordTs2, mig2)),
           currentMigrationId = mig2,
           currentMigrationCap = cap2,
         )
@@ -1042,7 +1048,7 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
 
   private def fetchEvents(
       es: ScanEventStore,
-      afterO: Option[(Long, CantonTimestamp)],
+      afterO: Option[TimestampWithMigrationId],
       currentMigrationId: Long,
       limit: PageLimit,
   ): Future[Seq[ScanEventStore#Event]] = {

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -580,17 +580,15 @@ class UpdateHistoryBulkStorageTest
       val store = mock[UpdateHistory]
       when(
         store.getUpdatesWithoutImportUpdates(
-          any[Option[(Long, CantonTimestamp)]],
+          any[Option[TimestampWithMigrationId]],
           any[Limit],
         )(any[TraceContext])
       ).thenAnswer {
         (
-            afterO: Option[(Long, CantonTimestamp)],
+            afterO: Option[TimestampWithMigrationId],
             limit: Limit,
         ) =>
-          val after = afterO
-            .map(a => TimestampWithMigrationId(a._2, a._1))
-            .getOrElse(TimestampWithMigrationId(CantonTimestamp.MinValue, 0L))
+          val after = afterO.getOrElse(TimestampWithMigrationId(CantonTimestamp.MinValue, 0L))
           Future.successful(
             data
               .filter(update =>

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
@@ -24,7 +24,14 @@ import org.lfdecentralizedtrust.splice.environment.ledger.api.TreeUpdateOrOffset
 import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.store.{HardLimit, Limit, PageLimit, StoreTestBase, TcsStore}
+import org.lfdecentralizedtrust.splice.store.{
+  HardLimit,
+  Limit,
+  PageLimit,
+  StoreTestBase,
+  TcsStore,
+  TimestampWithMigrationId,
+}
 import org.lfdecentralizedtrust.splice.util.{ResourceTemplateDecoder, TemplateJsonDecoder}
 import slick.jdbc.JdbcProfile
 
@@ -479,10 +486,16 @@ class DbScanRewardsReferenceStoreTest
         result.get(ts(275)) shouldBe None // round4.opensAt before earliest archived_at
         result.get(ts(350)) shouldBe None // round4.opensAt before earliest archived_at
         result.get(ts(375)) shouldBe None // gap: round4 archived, round5 not yet open
-        result(ts(400)) shouldBe (5L, ts(400))
+        result(ts(400)) shouldBe TimestampWithMigrationId(ts(400), 5L)
         result.get(ts(401)) shouldBe None // 401 was not present in request
-        result(ts(450)) shouldBe (5L, ts(400)) // round5 open, round6 not yet open
-        result(ts(550)) shouldBe (5L, ts(400)) // both open, lowest round selected
+        result(ts(450)) shouldBe TimestampWithMigrationId(
+          ts(400),
+          5L,
+        ) // round5 open, round6 not yet open
+        result(ts(550)) shouldBe TimestampWithMigrationId(
+          ts(400),
+          5L,
+        ) // both open, lowest round selected
       }
     }
   }

--- a/project/ignore-patterns/sbt-output.ignore.txt
+++ b/project/ignore-patterns/sbt-output.ignore.txt
@@ -43,7 +43,7 @@ protoc-jar: caught exception, retrying: java\.io\.IOException: Cannot run progra
 .*no longer exists at.*
 
 # sbt 1.4 onwards logs GC warnings
-.*\[.*warn.*\].* of the last .* were spent in GC\.
+.*\[.*warn.*\].* In the last .* were spent in GC\.
 
 # During release bundling, the copy of the Canton OS repo emits a bunch of warnings
 .*\[.*warn.*\].*Negative time


### PR DESCRIPTION
Fixes #3795

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
