### PR TITLE
Re-enable `SplitwellUpgradeIntegrationTest`

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellTestUtil.scala
@@ -2,6 +2,7 @@ package org.lfdecentralizedtrust.splice.util
 
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.data.GrpcSequencerConnection
+import com.digitalasset.canton.integration.util.MultiSynchronizerFeatureFlag
 import com.digitalasset.canton.topology.PartyId
 import org.lfdecentralizedtrust.splice.codegen.java.splice.splitwell as splitwellCodegen
 import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.payment as walletCodegen
@@ -42,8 +43,13 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
     actAndCheck(
       timeUntilSuccess = 40.seconds
     )(
-      "Connect splitwell upgrade domain",
-      participant.synchronizers.connect(splitwellUpgradeAlias, url),
+      "Connect splitwell upgrade domain", {
+        participant.synchronizers.connect(splitwellUpgradeAlias, url)
+        participant.upload_dar_unless_exists(splitwellDarPath)
+        participant.synchronizers.list_connected().foreach { sync =>
+          MultiSynchronizerFeatureFlag.enable(Seq(participant), sync.synchronizerId)
+        }
+      },
     )(
       s"Wait for splitwell upgrade domain to be connected for party $ensurePartyIsOnNewDomain",
       _ => {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeFrontendIntegrationTest.scala
@@ -13,10 +13,7 @@ import org.lfdecentralizedtrust.splice.util.{
   WalletTestUtil,
 }
 import SplitwellUpgradeFrontendIntegrationTest.*
-import org.scalatest.Ignore
 
-// TODO(DACH-NY/canton-network-internal#1834) Reenable once we sorted out the reassignment issues
-@Ignore
 class SplitwellUpgradeFrontendIntegrationTest
     extends FrontendIntegrationTest(aliceSplitwellFE, bobSplitwellFE)
     with FrontendLoginUtil

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
@@ -11,13 +11,10 @@ import SpliceTests.BracketSynchronous.*
 import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
 import org.lfdecentralizedtrust.splice.util.{MultiDomainTestUtil, SplitwellTestUtil, WalletTestUtil}
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
-import org.scalatest.Ignore
 
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
-// TODO(#2703) Reenable or delete
-@Ignore
 class SplitwellUpgradeIntegrationTest
     extends IntegrationTest
     with MultiDomainTestUtil

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
@@ -8,7 +8,6 @@ import org.lfdecentralizedtrust.splice.console.SplitwellAppClientReference
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
 import SpliceTests.BracketSynchronous.*
-import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
 import org.lfdecentralizedtrust.splice.util.{MultiDomainTestUtil, SplitwellTestUtil, WalletTestUtil}
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 
@@ -58,27 +57,7 @@ class SplitwellUpgradeIntegrationTest
     def createInstalls(splitwells: SplitwellAppClientReference*) = for {
       splitwell <- splitwells
     } eventually() {
-      loggerFactory
-        .assertLogsUnorderedOptionalFromResult[Try[Unit]](
-          Try(splitwell.createInstallRequests()),
-          { r =>
-            if (r.isFailure) {
-              Seq(
-                (
-                  LogEntryOptionality.Required,
-                  log =>
-                    log.errorMessage should include(
-                      "Not all informee are on the specified domainID: splitwellUpgrade"
-                    ),
-                )
-              )
-            } else {
-              Seq.empty
-            }
-          },
-        )
-        .toEither
-        .valueOr(fail(_))
+      Try(splitwell.createInstallRequests()).toEither.valueOr(fail(_))
     }
 
     def twoInstalls(alice: PartyId, install: splitwellCodegen.SplitwellInstall.Contract)(implicit

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
@@ -128,8 +128,6 @@ class SplitwellUpgradeIntegrationTest
       val acceptedInvite = bobSplitwellClient.acceptInvite(invite)
       val splitwellSynchronizerId =
         aliceValidatorBackend.participantClient.synchronizers.id_of(splitwellAlias).logical
-      val splitwellUpgradeSynchronizerId =
-        aliceValidatorBackend.participantClient.synchronizers.id_of(splitwellUpgradeAlias).logical
 
       eventually() {
         val contractDomains =
@@ -151,6 +149,9 @@ class SplitwellUpgradeIntegrationTest
         connectSplitwellUpgradeDomain(aliceValidatorBackend.participantClient, alice),
         disconnectSplitwellUpgradeDomain(aliceValidatorBackend.participantClient),
       ) {
+        val splitwellUpgradeSynchronizerId =
+          aliceValidatorBackend.participantClient.synchronizers.id_of(splitwellUpgradeAlias).logical
+
         bracket(
           connectSplitwellUpgradeDomain(bobValidatorBackend.participantClient, bob),
           disconnectSplitwellUpgradeDomain(bobValidatorBackend.participantClient),


### PR DESCRIPTION
Fixes #2703

This re-enables `SplitwellUpgradeIntegrationTest` and `SplitwellUpgradeFrontendIntegrationTest`. The test failures in `SplitwellUpgradeIntegrationTest` are resolved by ensuring the the splitwell DAR is uploaded and that the multi-synchronizer feature flag is enabled.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
