### PR TITLE
Verify TTL-based batching of reward coupons v2 works as expected

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -825,12 +825,12 @@ class WalletMintingDelegationTimeBasedIntegrationTest
 
         setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
           actAndCheck(
-            "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",
+            "Create only unassigned V2 coupons, ttl (8m) > minTtl (6m)",
             createRewardCouponsV2(
               Seq((providerParty.party, amount1, None), (providerParty.party, amount2, None)),
               ttl = Duration.ofMinutes(8),
             ),
-          )("Both coupons visible an unassigned", _ => unassignedCount() shouldBe 2)
+          )("Both coupons visible and unassigned", _ => unassignedCount() shouldBe 2)
 
           clue("Gate is false while above threshold: one explicit poll does no work") {
             trigger.runOnce().futureValue shouldBe false

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -766,6 +766,12 @@ class WalletMintingDelegationTimeBasedIntegrationTest
       }
     }
 
+    // Hold-back then assign+mint: coupons start above the sharing threshold and are shared only
+    // once near expiry. ttl 8m > minTtl 6m -> held (Phase 1); advanceTime(4m) leaves remaining
+    // ttl 4m <= 6m -> gate opens (Phase 2). Keep the advance under one mining-round tick (10m)
+    // or the coupons' round ages out and the mint can't collect them. Amounts 1000/500 stay
+    // under the amulet-merge limit (2x=20) so a pending merge can't force sharing. Recipient
+    // gets 40%; provider keeps 60% (added as a beneficiary of its own coupon).
     "hold back unassigned V2 coupons until the TTL threshold, then assign and mint" in {
       implicit env =>
         val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
@@ -817,7 +823,6 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         val amount1 = BigDecimal(1000.0)
         val amount2 = BigDecimal(500.0)
 
-        advanceRoundsToNextRoundOpening
         setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
           actAndCheck(
             "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -52,6 +52,8 @@ class WalletMintingDelegationTimeBasedIntegrationTest
   private val sharingAppProvider = preGenerateExternalParty("sharing_app_provider")
   private val sharingRecipient = preGenerateExternalParty("sharing_recipient")
   private val externalSharingProvider = preGenerateExternalParty("external_sharing_provider")
+  private val ttlSharingProvider = preGenerateExternalParty("ttl_sharing_provider")
+  private val ttlSharingRecipient = preGenerateExternalParty("ttl_sharing_recipient")
 
   // We create many coupons directly, so avoid running sanity checks
   override protected def runUpdateHistorySanityCheck: Boolean = false
@@ -75,6 +77,11 @@ class WalletMintingDelegationTimeBasedIntegrationTest
                   ),
                 ),
                 externalSharingProvider.partyId.toProtoPrimitive -> RewardSharingConfig.External(),
+                ttlSharingProvider.partyId.toProtoPrimitive -> RewardSharingConfig.BuiltIn(
+                  minTtlAfterSharing = NonNegativeFiniteDuration.ofMinutes(6),
+                  beneficiaries =
+                    Seq(AppRewardBeneficiaryConfig(ttlSharingRecipient.partyId, BigDecimal(0.4))),
+                ),
               )
             )
           } else c
@@ -758,6 +765,97 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         }
       }
     }
+
+    "hold back unassigned V2 coupons until the TTL threshold, then assign and mint" in {
+      implicit env =>
+        val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
+        aliceWalletClient.tap(100.0)
+        aliceValidatorWalletClient.tap(100.0)
+
+        val providerParty = onboardExternalParty(aliceValidatorBackend, ttlSharingProvider)
+        createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, providerParty)
+
+        val recipientParty = onboardExternalParty(aliceValidatorBackend, ttlSharingRecipient)
+        createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, recipientParty)
+
+        val expiresAt = env.environment.clock.now.plus(Duration.ofDays(30)).toInstant
+        val (_, proposalContractId) = actAndCheck(
+          "Create minting delegation proposal",
+          createMintingDelegationProposal(providerParty, aliceParty, expiresAt),
+        )(
+          "Proposal is visible",
+          _ => {
+            val proposals = aliceWalletClient.listMintingDelegationProposals()
+            proposals.proposals should have size 1 withClue "proposals"
+            proposals.proposals.head.contract.contractId
+          },
+        )
+        actAndCheck(
+          "Alice accepts the proposal",
+          aliceWalletClient.acceptMintingDelegationProposal(proposalContractId),
+        )(
+          "Delegation is created",
+          _ =>
+            aliceWalletClient
+              .listMintingDelegations()
+              .delegations should have size 1 withClue "delegations",
+        )
+
+        val trigger = mintingDelegationTriggerTyped(aliceValidatorBackend, providerParty.party)
+        val wallet = aliceValidatorBackend.appState.walletManager
+          .valueOrFail("Wallet manager is expected to be defined")
+          .externalPartyWalletManager
+          .lookupExternalPartyWallet(providerParty.party)
+          .valueOrFail(s"Expected ${providerParty.party} to have an external party wallet")
+
+        def unassignedCount(): Int =
+          wallet.store.multiDomainAcsStore
+            .listContracts(RewardCouponV2.COMPANION)
+            .futureValue
+            .count(_.payload.beneficiary.isEmpty)
+
+        val amount1 = BigDecimal(1000.0)
+        val amount2 = BigDecimal(500.0)
+
+        advanceRoundsToNextRoundOpening
+        setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
+          actAndCheck(
+            "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",
+            createRewardCouponsV2(
+              Seq((providerParty.party, amount1, None), (providerParty.party, amount2, None)),
+              ttl = Duration.ofMinutes(8),
+            ),
+          )("Both coupons visible an unassigned", _ => unassignedCount() shouldBe 2)
+
+          clue("Gate is false while above threshold: one explicit poll does no work") {
+            trigger.runOnce().futureValue shouldBe false
+          }
+          unassignedCount() shouldBe 2
+
+          BigDecimal(
+            aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
+          ) shouldBe BigDecimal(0)
+
+          advanceTime(Duration.ofMinutes(4))
+
+          clue("Gate is true once within minTtl: poll assigns + mints") {
+            eventually() { trigger.runOnce().futureValue shouldBe true }
+          }
+        }
+
+        clue("Unassigned coupons consumed by assign-and-mint") {
+          eventually() { unassignedCount() shouldBe 0 }
+        }
+
+        clue("Balance reflects provider's 60% split") {
+          eventually() {
+            BigDecimal(
+              aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
+            ) shouldBe (amount1 + amount2) * BigDecimal(0.6)
+          }
+        }
+    }
+
     "mint already-assigned V2 coupons but hold back unassigned ones in external sharing mode" in {
       implicit env =>
         val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
@@ -916,4 +1014,16 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         commands = proposal.create.commands.asScala.toSeq,
       )
   }
+
+  private def mintingDelegationTriggerTyped(
+      validatorBackend: ValidatorAppBackendReference,
+      externalPartyId: PartyId,
+  ): MintingDelegationCollectRewardsTrigger =
+    validatorBackend.appState.walletManager
+      .valueOrFail("Wallet manager is expected to be defined")
+      .externalPartyWalletManager
+      .lookupExternalPartyWallet(externalPartyId)
+      .valueOrFail(s"Expected $externalPartyId to have an external party wallet")
+      .automation
+      .trigger[MintingDelegationCollectRewardsTrigger]
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -801,6 +801,12 @@ class WalletMintingDelegationTimeBasedIntegrationTest
       }
     }
 
+    // Hold-back then assign+mint: coupons start above the sharing threshold and are shared only
+    // once near expiry. ttl 8m > minTtl 6m -> held (Phase 1); advanceTime(4m) leaves remaining
+    // ttl 4m <= 6m -> gate opens (Phase 2). Keep the advance under one mining-round tick (10m)
+    // or the coupons' round ages out and the mint can't collect them. Amounts 1000/500 stay
+    // under the amulet-merge limit (2x=20) so a pending merge can't force sharing. Recipient
+    // gets 40%; provider keeps 60% (added as a beneficiary of its own coupon).
     "hold back unassigned V2 coupons until the TTL threshold, then assign and mint" in {
       implicit env =>
         val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
@@ -852,7 +858,6 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         val amount1 = BigDecimal(1000.0)
         val amount2 = BigDecimal(500.0)
 
-        advanceRoundsToNextRoundOpening
         setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
           actAndCheck(
             "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -860,12 +860,12 @@ class WalletMintingDelegationTimeBasedIntegrationTest
 
         setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
           actAndCheck(
-            "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",
+            "Create only unassigned V2 coupons, ttl (8m) > minTtl (6m)",
             createRewardCouponsV2(
               Seq((providerParty.party, amount1, None), (providerParty.party, amount2, None)),
               ttl = Duration.ofMinutes(8),
             ),
-          )("Both coupons visible an unassigned", _ => unassignedCount() shouldBe 2)
+          )("Both coupons visible and unassigned", _ => unassignedCount() shouldBe 2)
 
           clue("Gate is false while above threshold: one explicit poll does no work") {
             trigger.runOnce().futureValue shouldBe false

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -842,12 +842,16 @@ class WalletMintingDelegationTimeBasedIntegrationTest
               .delegations should have size 1 withClue "delegations",
         )
 
-        val trigger = mintingDelegationTriggerTyped(aliceValidatorBackend, providerParty.party)
-        val wallet = aliceValidatorBackend.appState.walletManager
-          .valueOrFail("Wallet manager is expected to be defined")
-          .externalPartyWalletManager
-          .lookupExternalPartyWallet(providerParty.party)
-          .valueOrFail(s"Expected ${providerParty.party} to have an external party wallet")
+        val wallet = eventually() {
+          aliceValidatorBackend.appState.walletManager
+            .valueOrFail("Wallet manager is expected to be defined")
+            .externalPartyWalletManager
+            .lookupExternalPartyWallet(providerParty.party)
+            .valueOrFail(s"Expected ${providerParty.party} to have an external party wallet")
+        }
+
+        val trigger = wallet.automation
+          .trigger[MintingDelegationCollectRewardsTrigger]
 
         def unassignedCount(): Int =
           wallet.store.multiDomainAcsStore
@@ -1054,16 +1058,4 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         commands = proposal.create.commands.asScala.toSeq,
       )
   }
-
-  private def mintingDelegationTriggerTyped(
-      validatorBackend: ValidatorAppBackendReference,
-      externalPartyId: PartyId,
-  ): MintingDelegationCollectRewardsTrigger =
-    validatorBackend.appState.walletManager
-      .valueOrFail("Wallet manager is expected to be defined")
-      .externalPartyWalletManager
-      .lookupExternalPartyWallet(externalPartyId)
-      .valueOrFail(s"Expected $externalPartyId to have an external party wallet")
-      .automation
-      .trigger[MintingDelegationCollectRewardsTrigger]
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -52,6 +52,8 @@ class WalletMintingDelegationTimeBasedIntegrationTest
   private val sharingAppProvider = preGenerateExternalParty("sharing_app_provider")
   private val sharingRecipient = preGenerateExternalParty("sharing_recipient")
   private val externalSharingProvider = preGenerateExternalParty("external_sharing_provider")
+  private val ttlSharingProvider = preGenerateExternalParty("ttl_sharing_provider")
+  private val ttlSharingRecipient = preGenerateExternalParty("ttl_sharing_recipient")
 
   // We create many coupons directly, so avoid running sanity checks
   override protected def runUpdateHistorySanityCheck: Boolean = false
@@ -75,6 +77,11 @@ class WalletMintingDelegationTimeBasedIntegrationTest
                   ),
                 ),
                 externalSharingProvider.partyId.toProtoPrimitive -> RewardSharingConfig.External(),
+                ttlSharingProvider.partyId.toProtoPrimitive -> RewardSharingConfig.BuiltIn(
+                  minTtlAfterSharing = NonNegativeFiniteDuration.ofMinutes(6),
+                  beneficiaries =
+                    Seq(AppRewardBeneficiaryConfig(ttlSharingRecipient.partyId, BigDecimal(0.4))),
+                ),
               )
             )
           } else c
@@ -793,6 +800,97 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         }
       }
     }
+
+    "hold back unassigned V2 coupons until the TTL threshold, then assign and mint" in {
+      implicit env =>
+        val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
+        aliceWalletClient.tap(100.0)
+        aliceValidatorWalletClient.tap(100.0)
+
+        val providerParty = onboardExternalParty(aliceValidatorBackend, ttlSharingProvider)
+        createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, providerParty)
+
+        val recipientParty = onboardExternalParty(aliceValidatorBackend, ttlSharingRecipient)
+        createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, recipientParty)
+
+        val expiresAt = env.environment.clock.now.plus(Duration.ofDays(30)).toInstant
+        val (_, proposalContractId) = actAndCheck(
+          "Create minting delegation proposal",
+          createMintingDelegationProposal(providerParty, aliceParty, expiresAt),
+        )(
+          "Proposal is visible",
+          _ => {
+            val proposals = aliceWalletClient.listMintingDelegationProposals()
+            proposals.proposals should have size 1 withClue "proposals"
+            proposals.proposals.head.contract.contractId
+          },
+        )
+        actAndCheck(
+          "Alice accepts the proposal",
+          aliceWalletClient.acceptMintingDelegationProposal(proposalContractId),
+        )(
+          "Delegation is created",
+          _ =>
+            aliceWalletClient
+              .listMintingDelegations()
+              .delegations should have size 1 withClue "delegations",
+        )
+
+        val trigger = mintingDelegationTriggerTyped(aliceValidatorBackend, providerParty.party)
+        val wallet = aliceValidatorBackend.appState.walletManager
+          .valueOrFail("Wallet manager is expected to be defined")
+          .externalPartyWalletManager
+          .lookupExternalPartyWallet(providerParty.party)
+          .valueOrFail(s"Expected ${providerParty.party} to have an external party wallet")
+
+        def unassignedCount(): Int =
+          wallet.store.multiDomainAcsStore
+            .listContracts(RewardCouponV2.COMPANION)
+            .futureValue
+            .count(_.payload.beneficiary.isEmpty)
+
+        val amount1 = BigDecimal(1000.0)
+        val amount2 = BigDecimal(500.0)
+
+        advanceRoundsToNextRoundOpening
+        setTriggersWithin(triggersToPauseAtStart = Seq(trigger)) {
+          actAndCheck(
+            "Create only unassigned V2 coupons, ttl (2h) > minTtl (1h)",
+            createRewardCouponsV2(
+              Seq((providerParty.party, amount1, None), (providerParty.party, amount2, None)),
+              ttl = Duration.ofMinutes(8),
+            ),
+          )("Both coupons visible an unassigned", _ => unassignedCount() shouldBe 2)
+
+          clue("Gate is false while above threshold: one explicit poll does no work") {
+            trigger.runOnce().futureValue shouldBe false
+          }
+          unassignedCount() shouldBe 2
+
+          BigDecimal(
+            aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
+          ) shouldBe BigDecimal(0)
+
+          advanceTime(Duration.ofMinutes(4))
+
+          clue("Gate is true once within minTtl: poll assigns + mints") {
+            eventually() { trigger.runOnce().futureValue shouldBe true }
+          }
+        }
+
+        clue("Unassigned coupons consumed by assign-and-mint") {
+          eventually() { unassignedCount() shouldBe 0 }
+        }
+
+        clue("Balance reflects provider's 60% split") {
+          eventually() {
+            BigDecimal(
+              aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
+            ) shouldBe (amount1 + amount2) * BigDecimal(0.6)
+          }
+        }
+    }
+
     "mint already-assigned V2 coupons but hold back unassigned ones in external sharing mode" in {
       implicit env =>
         val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
@@ -951,4 +1049,16 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         commands = proposal.create.commands.asScala.toSeq,
       )
   }
+
+  private def mintingDelegationTriggerTyped(
+      validatorBackend: ValidatorAppBackendReference,
+      externalPartyId: PartyId,
+  ): MintingDelegationCollectRewardsTrigger =
+    validatorBackend.appState.walletManager
+      .valueOrFail("Wallet manager is expected to be defined")
+      .externalPartyWalletManager
+      .lookupExternalPartyWallet(externalPartyId)
+      .valueOrFail(s"Expected $externalPartyId to have an external party wallet")
+      .automation
+      .trigger[MintingDelegationCollectRewardsTrigger]
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -804,14 +804,21 @@ class WalletMintingDelegationTimeBasedIntegrationTest
     // Hold-back then assign+mint: coupons start above the sharing threshold and are shared only
     // once near expiry. ttl 8m > minTtl 6m -> held (Phase 1); advanceTime(4m) leaves remaining
     // ttl 4m <= 6m -> gate opens (Phase 2). Keep the advance under one mining-round tick (10m)
-    // or the coupons' round ages out and the mint can't collect them. Amounts 1000/500 stay
-    // under the amulet-merge limit (2x=20) so a pending merge can't force sharing. Recipient
-    // gets 40%; provider keeps 60% (added as a beneficiary of its own coupon).
+    // or the coupons' round ages out and the mint can't collect them. Only 2 coupons/amulets
+    // exist here, far below the merge threshold of 2 x amuletMergeLimit (DefaultAmuletMergeLimit
+    // = 10 -> 20; see MintingDelegationCollectRewardsTrigger.selectAmuletsToMerge), so no forced
+    // merge can trigger sharing before the TTL gate opens. Recipient gets 40%; provider keeps
+    // 60% (added as a beneficiary of its own coupon).
     "hold back unassigned V2 coupons until the TTL threshold, then assign and mint" in {
       implicit env =>
         val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
         aliceWalletClient.tap(100.0)
         aliceValidatorWalletClient.tap(100.0)
+
+        val delegationValidity = Duration.ofDays(30)
+        val couponTtl = Duration.ofMinutes(8) // > minTtl (6m) -> held in Phase 1
+        val advanceIntoGate =
+          Duration.ofMinutes(4) // leaves 4m remaining <= 6m -> gate opens in Phase 2
 
         val providerParty = onboardExternalParty(aliceValidatorBackend, ttlSharingProvider)
         createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, providerParty)
@@ -819,7 +826,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         val recipientParty = onboardExternalParty(aliceValidatorBackend, ttlSharingRecipient)
         createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, recipientParty)
 
-        val expiresAt = env.environment.clock.now.plus(Duration.ofDays(30)).toInstant
+        val expiresAt = env.environment.clock.now.plus(delegationValidity).toInstant
         val (_, proposalContractId) = actAndCheck(
           "Create minting delegation proposal",
           createMintingDelegationProposal(providerParty, aliceParty, expiresAt),
@@ -859,6 +866,21 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             .futureValue
             .count(_.payload.beneficiary.isEmpty)
 
+        // Provider is an observer of every coupon (providerIsObserver = true), so its store also
+        // sees the coupons assigned to the recipient. After assign+mint the provider's own 60%
+        // coupons are consumed by the transfer, leaving the recipient's 40% coupons unminted
+        // (the recipient has no delegation to collect them).
+        def assignedToRecipientTotal(): BigDecimal =
+          wallet.store.multiDomainAcsStore
+            .listContracts(RewardCouponV2.COMPANION)
+            .futureValue
+            .filter(c =>
+              c.payload.beneficiary.isPresent &&
+                c.payload.beneficiary.get == recipientParty.party.toProtoPrimitive
+            )
+            .map(c => BigDecimal(c.payload.amount))
+            .sum
+
         val amount1 = BigDecimal(1000.0)
         val amount2 = BigDecimal(500.0)
 
@@ -867,20 +889,22 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Create only unassigned V2 coupons, ttl (8m) > minTtl (6m)",
             createRewardCouponsV2(
               Seq((providerParty.party, amount1, None), (providerParty.party, amount2, None)),
-              ttl = Duration.ofMinutes(8),
+              ttl = couponTtl,
             ),
           )("Both coupons visible and unassigned", _ => unassignedCount() shouldBe 2)
 
           clue("Gate is false while above threshold: one explicit poll does no work") {
             trigger.runOnce().futureValue shouldBe false
           }
-          unassignedCount() shouldBe 2
 
-          BigDecimal(
-            aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
-          ) shouldBe BigDecimal(0)
+          clue("Above threshold: coupons stay unassigned and nothing is minted yet") {
+            unassignedCount() shouldBe 2
+            BigDecimal(
+              aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
+            ) shouldBe BigDecimal(0)
+          }
 
-          advanceTime(Duration.ofMinutes(4))
+          advanceTime(advanceIntoGate)
 
           clue("Gate is true once within minTtl: poll assigns + mints") {
             eventually() { trigger.runOnce().futureValue shouldBe true }
@@ -891,11 +915,19 @@ class WalletMintingDelegationTimeBasedIntegrationTest
           eventually() { unassignedCount() shouldBe 0 }
         }
 
-        clue("Balance reflects provider's 60% split") {
+        // Provider mints only its own 60%; the recipient's 40% is carved out into separate
+        // coupons that the recipient would mint via its own delegation (absent here).
+        clue("Provider mints exactly its 60% share") {
           eventually() {
             BigDecimal(
               aliceValidatorBackend.getExternalPartyBalance(providerParty.party).totalUnlockedCoin
             ) shouldBe (amount1 + amount2) * BigDecimal(0.6)
+          }
+        }
+
+        clue("Recipient's 40% is assigned as unminted coupons") {
+          eventually() {
+            assignedToRecipientTotal() shouldBe (amount1 + amount2) * BigDecimal(0.4)
           }
         }
     }


### PR DESCRIPTION
fixes: https://github.com/canton-network/splice/issues/5873