### PR TITLE
Add backup c3d machine type to scratchnet clusters

### DIFF
--- a/cluster/configs/shared/scratchnet.yaml
+++ b/cluster/configs/shared/scratchnet.yaml
@@ -11,6 +11,12 @@ cluster:
       maxNodes: 20
       nodeType: n4-standard-16
       zones: '*'
+    - minNodes: 0
+      maxNodes: 20
+      nodeType: c3d-standard-16
+      zones: '*'
+      labels:
+        node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
 infra:
   prometheus:
     retentionDuration: "30d"

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -21,6 +21,12 @@ cluster:
         minNodes: 0
         nodeType: 'n4-standard-16'
         zones: '*'
+      - labels:
+          node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
+        maxNodes: 20
+        minNodes: 0
+        nodeType: 'c3d-standard-16'
+        zones: '*'
     apps:
       maxNodes: 20
       minNodes: 0

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -21,6 +21,12 @@ cluster:
         minNodes: 0
         nodeType: 'n4-standard-16'
         zones: '*'
+      - labels:
+          node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
+        maxNodes: 20
+        minNodes: 0
+        nodeType: 'c3d-standard-16'
+        zones: '*'
     apps:
       maxNodes: 20
       minNodes: 0

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -21,6 +21,12 @@ cluster:
         minNodes: 0
         nodeType: 'n4-standard-16'
         zones: '*'
+      - labels:
+          node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
+        maxNodes: 20
+        minNodes: 0
+        nodeType: 'c3d-standard-16'
+        zones: '*'
     apps:
       maxNodes: 20
       minNodes: 0

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -21,6 +21,12 @@ cluster:
         minNodes: 0
         nodeType: 'n4-standard-16'
         zones: '*'
+      - labels:
+          node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
+        maxNodes: 20
+        minNodes: 0
+        nodeType: 'c3d-standard-16'
+        zones: '*'
     apps:
       maxNodes: 20
       minNodes: 0

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -21,6 +21,12 @@ cluster:
         minNodes: 0
         nodeType: 'n4-standard-16'
         zones: '*'
+      - labels:
+          node-restriction.kubernetes.io/gke-volume-attach-limit-override: '15'
+        maxNodes: 20
+        minNodes: 0
+        nodeType: 'c3d-standard-16'
+        zones: '*'
     apps:
       maxNodes: 20
       minNodes: 0


### PR DESCRIPTION


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
