### PR TITLE
Add `daml_value_encoding` parameters to `listBulkAcsSnapshotObjects` and `listBulkUpdateHistoryObjects`

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -868,11 +868,12 @@ abstract class ScanAppReference(
 
   @Help.Summary("List all objects in bulk storage for an ACS snapshot")
   def getBulkAcsSnapshot(
-      timestamp: CantonTimestamp
+      timestamp: CantonTimestamp,
+      damlValueEncoding: Option[definitions.DamlValueEncoding],
   ): definitions.ListBulkAcsSnapshotObjectsResponse =
     consoleEnvironment.run {
       httpCommand(
-        HttpScanAppClient.GetBulkAcsSnapshot(timestamp)
+        HttpScanAppClient.GetBulkAcsSnapshot(timestamp, damlValueEncoding)
       )
     }
 
@@ -882,6 +883,7 @@ abstract class ScanAppReference(
       endTimestamp: CantonTimestamp,
       nextPageToken: Option[String],
       limit: Int,
+      damlValueEncoding: Option[definitions.DamlValueEncoding],
   ): definitions.ListBulkUpdateHistoryObjectsResponse =
     consoleEnvironment.run {
       httpCommand(
@@ -890,6 +892,7 @@ abstract class ScanAppReference(
           endTimestamp,
           nextPageToken,
           limit,
+          damlValueEncoding,
         )
       )
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -18,10 +18,9 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   updateAutomationConfig,
 }
 import org.lfdecentralizedtrust.splice.http.v0.definitions
-import org.lfdecentralizedtrust.splice.http.v0.definitions.DamlValueEncoding.members.CompactJson
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
-import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
+import org.lfdecentralizedtrust.splice.scan.admin.http.ScanHttpEncodings
 import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
 import org.lfdecentralizedtrust.splice.scan.config.ScanStorageConfigs.scanStorageConfigV1
 import org.lfdecentralizedtrust.splice.store.{HasS3Mock, S3BucketConnectionForTests}
@@ -446,8 +445,6 @@ class ScanTimeBasedIntegrationTest
     val endTime = getLedgerTime
     val lastMidnight = endTime.toInstant.truncatedTo(ChronoUnit.DAYS);
     val nextMidnight = lastMidnight.plus(1, ChronoUnit.DAYS)
-    val expectedAcsSnapshotKey =
-      s"$lastMidnight~$nextMidnight/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", 0)}"
 
     val committedBucketConnection =
       new S3BucketConnectionForTests(s3ConfigMock("committed"), loggerFactory)
@@ -459,27 +456,52 @@ class ScanTimeBasedIntegrationTest
         .value
         .toInstant shouldBe >=(lastMidnight)
 
-      val getSnapshotResponse = eventuallySucceeds() {
-        val getSnapshotResponse = sv1ScanBackend
-          .getBulkAcsSnapshot(CantonTimestamp.assertFromInstant(lastMidnight))
-        getSnapshotResponse.recordTime should be(lastMidnight.atOffset(java.time.ZoneOffset.UTC))
-        getSnapshotResponse
-      }
       val committedS3Objs = committedBucketConnection.listObjects.futureValue.contents().asScala
 
-      // Wait for bulk storage objects to be created
-      committedS3Objs.map(_.key()) should contain(expectedAcsSnapshotKey)
-
-      // Depending on how the days are split exactly (based on the exact simtime when the test was started),
-      // the updates may be in one or two segments, so we only assert that there exists a segment that ends
-      // at last midnight
-      committedS3Objs
-        .map(_.key())
-        .filter(
-          _.endsWith(
-            s"~$lastMidnight/${ScanStorageConfig.Encoding.CompactJson.storageKey("updates", 0)}"
+      def checkAcsSnapshotEncoding(encoding: ScanStorageConfig.Encoding) = {
+        val expectedAcsSnapshotKey =
+          s"$lastMidnight~$nextMidnight/${encoding.storageKey("ACS", 0)}"
+        val getSnapshotResponse = eventuallySucceeds() {
+          val getSnapshotResponse = sv1ScanBackend.getBulkAcsSnapshot(
+            CantonTimestamp.assertFromInstant(lastMidnight),
+            Some(encoding.damlValueEncoding),
           )
-        ) should not be empty
+          getSnapshotResponse.recordTime should be(lastMidnight.atOffset(java.time.ZoneOffset.UTC))
+          getSnapshotResponse
+        }
+
+        // Wait for bulk storage objects to be created
+        committedS3Objs.map(_.key()) should contain(expectedAcsSnapshotKey)
+
+        // Depending on how the days are split exactly (based on the exact simtime when the test was started),
+        // the updates may be in one or two segments, so we only assert that there exists a segment that ends
+        // at last midnight
+        committedS3Objs
+          .map(_.key())
+          .filter(
+            _.endsWith(s"~$lastMidnight/${encoding.storageKey("updates", 0)}")
+          ) should not be empty
+
+        val acsObjUrl = getSnapshotResponse.objectRefs.head.url
+        acsObjUrl should startWith("http://foo.bar.com/api/scan/v0/history/bulk/download/")
+        val acsObjKey = URLDecoder.decode(
+          acsObjUrl.stripPrefix("http://foo.bar.com/api/scan/v0/history/bulk/download/"),
+          StandardCharsets.UTF_8,
+        )
+
+        val out = new ByteArrayOutputStream()
+        sv1ScanBackend.bulkStorageDownload(acsObjKey, out).futureValue
+        val acsAtMidnightFromS3 = uncompressAndDecode(
+          ByteString(out.toByteArray),
+          io.circe.parser.decode[definitions.ActiveContract],
+        )
+
+        (acsObjKey, acsAtMidnightFromS3)
+      }
+
+      val (acsObjKey, acsAtMidnightFromS3) =
+        checkAcsSnapshotEncoding(ScanStorageConfig.Encoding.CompactJson)
+      checkAcsSnapshotEncoding(ScanStorageConfig.Encoding.ProtobufJson)
 
       // Compare bulk storage data to hot storage data from scan
       // TODO(#4788): for now, bulk storage still uses v0, so we use that here as well
@@ -487,55 +509,50 @@ class ScanTimeBasedIntegrationTest
         .getAcsSnapshotAtV1(CantonTimestamp.assertFromInstant(lastMidnight), 0)
         .value
         .createdEvents
-      val acsObjUrl = getSnapshotResponse.objectRefs.head.url
-      acsObjUrl should startWith("http://foo.bar.com/api/scan/v0/history/bulk/download/")
-      val acsObjKey = URLDecoder.decode(
-        acsObjUrl.stripPrefix("http://foo.bar.com/api/scan/v0/history/bulk/download/"),
-        StandardCharsets.UTF_8,
-      )
-      val out = new ByteArrayOutputStream()
-      sv1ScanBackend.bulkStorageDownload(acsObjKey, out).futureValue
-      val acsAtMidnightFromS3 = uncompressAndDecode(
-        ByteString(out.toByteArray),
-        io.circe.parser.decode[definitions.ActiveContract],
-      )
       acsAtMidnightFromScan should contain theSameElementsInOrderAs acsAtMidnightFromS3
 
-      def isInTimeRange(u: definitions.UpdateHistoryItemV2) = {
-        val recordTime = CompactJsonScanHttpEncodings()
-          .httpToLapiUpdate(u)
-          .update
-          .update
-          .recordTime
-        recordTime <= CantonTimestamp.assertFromInstant(lastMidnight)
+      def checkUpdateEncoding(encoding: ScanStorageConfig.Encoding) = {
+        def isInTimeRange(u: definitions.UpdateHistoryItemV2) = {
+          val recordTime = ScanHttpEncodings
+            .fromDamlValueEncoding(encoding.damlValueEncoding)
+            .httpToLapiUpdate(u)
+            .update
+            .update
+            .recordTime
+          recordTime <= CantonTimestamp.assertFromInstant(lastMidnight)
+        }
+
+        val updateObjsResponse = sv1ScanBackend.getBulkUpdateHistory(
+          startTime,
+          CantonTimestamp.assertFromInstant(lastMidnight),
+          None,
+          100,
+          Some(encoding.damlValueEncoding),
+        )
+        val updateObjsUrls = updateObjsResponse.objectRefs.map(_.url)
+        val updateObjsKeys = updateObjsUrls.map(url =>
+          URLDecoder.decode(
+            url.stripPrefix("http://foo.bar.com/api/scan/v0/history/bulk/download/"),
+            StandardCharsets.UTF_8,
+          )
+        )
+        val updatesFromS3 = updateObjsKeys
+          .flatMap { key =>
+            val out = new ByteArrayOutputStream()
+            sv1ScanBackend.bulkStorageDownload(key, out).futureValue
+            uncompressAndDecode(
+              ByteString(out.toByteArray),
+              io.circe.parser.decode[definitions.UpdateHistoryItemV2],
+            )
+          }
+        val updatesFromScan = sv1ScanBackend
+          .getUpdateHistory(1000, None, encoding.damlValueEncoding)
+          .filter(isInTimeRange)
+        updatesFromScan should contain theSameElementsAs updatesFromS3
       }
 
-      val updateObjsResponse = sv1ScanBackend.getBulkUpdateHistory(
-        startTime,
-        CantonTimestamp.assertFromInstant(lastMidnight),
-        None,
-        100,
-      )
-      val updateObjsUrls = updateObjsResponse.objectRefs.map(_.url)
-      val updateObjsKeys = updateObjsUrls.map(url =>
-        URLDecoder.decode(
-          url.stripPrefix("http://foo.bar.com/api/scan/v0/history/bulk/download/"),
-          StandardCharsets.UTF_8,
-        )
-      )
-      val updatesFromS3 = updateObjsKeys
-        .flatMap { key =>
-          val out = new ByteArrayOutputStream()
-          sv1ScanBackend.bulkStorageDownload(key, out).futureValue
-          uncompressAndDecode(
-            ByteString(out.toByteArray),
-            io.circe.parser.decode[definitions.UpdateHistoryItemV2],
-          )
-        }
-      val updatesFromScan = sv1ScanBackend
-        .getUpdateHistory(1000, None, CompactJson)
-        .filter(isInTimeRange)
-      updatesFromScan should contain theSameElementsAs updatesFromS3
+      checkUpdateEncoding(ScanStorageConfig.Encoding.CompactJson)
+      checkUpdateEncoding(ScanStorageConfig.Encoding.ProtobufJson)
 
       // Compare acs v0 and v1 endpoints
       val acsV0AtMidnightFromScan = sv1ScanBackend

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1739,6 +1739,10 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: "daml_value_encoding"
+          in: "query"
+          schema:
+            $ref: "#/components/schemas/DamlValueEncoding"
       responses:
         "200":
           description: ok
@@ -4074,6 +4078,8 @@ components:
           format: int32
           minimum: 1
           maximum: 1000
+        daml_value_encoding:
+          $ref: "#/components/schemas/DamlValueEncoding"
 
     ListBulkUpdateHistoryObjectsResponse:
       type: object

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -3278,7 +3278,8 @@ object HttpScanAppClient {
   }
 
   case class GetBulkAcsSnapshot(
-      atOrBeforeTimestamp: CantonTimestamp
+      atOrBeforeTimestamp: CantonTimestamp,
+      damlValueEncoding: Option[definitions.DamlValueEncoding],
   ) extends InternalBaseCommand[
         http.ListBulkAcsSnapshotObjectsResponse,
         definitions.ListBulkAcsSnapshotObjectsResponse,
@@ -3289,6 +3290,7 @@ object HttpScanAppClient {
     ): EitherT[Future, Either[Throwable, HttpResponse], ListBulkAcsSnapshotObjectsResponse] =
       client.listBulkAcsSnapshotObjects(
         atOrBeforeTimestamp.toInstant.atOffset(java.time.ZoneOffset.UTC),
+        damlValueEncoding,
         headers,
       )
 
@@ -3313,6 +3315,7 @@ object HttpScanAppClient {
       endRecordTime: CantonTimestamp,
       nextPageToken: Option[String],
       limit: Int,
+      damlValueEncoding: Option[definitions.DamlValueEncoding],
   ) extends InternalBaseCommand[
         http.ListBulkUpdateHistoryObjectsResponse,
         definitions.ListBulkUpdateHistoryObjectsResponse,
@@ -3327,6 +3330,7 @@ object HttpScanAppClient {
           endRecordTime.toInstant.atOffset(java.time.ZoneOffset.UTC),
           nextPageToken,
           limit,
+          damlValueEncoding,
         ),
         headers,
       )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -3,7 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.admin.http
 
-import cats.data.{NonEmptyVector, OptionT}
+import cats.data.{NonEmptyList, NonEmptyVector, OptionT}
 import cats.implicits.catsSyntaxOptionId
 import cats.syntax.either.*
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
@@ -88,7 +88,11 @@ import org.lfdecentralizedtrust.splice.http.v0.definitions.{
 import org.lfdecentralizedtrust.splice.http.v0.scan.ScanResource
 import org.lfdecentralizedtrust.splice.scan.ScanSynchronizerNode
 import org.lfdecentralizedtrust.splice.scan.admin.http.ScanHttpEncodings.updateV1ToUpdateV2
-import org.lfdecentralizedtrust.splice.scan.config.{CantonBftPeerConfig, ScanRollForwardLsuConfig}
+import org.lfdecentralizedtrust.splice.scan.config.{
+  CantonBftPeerConfig,
+  ScanRollForwardLsuConfig,
+  ScanStorageConfig,
+}
 import org.lfdecentralizedtrust.splice.scan.dso.DsoAnsResolver
 import org.lfdecentralizedtrust.splice.scan.store.{
   AcsSnapshotStore,
@@ -2546,7 +2550,8 @@ class HttpScanHandler(
   override def listBulkAcsSnapshotObjects(
       respond: ScanResource.ListBulkAcsSnapshotObjectsResponse.type
   )(
-      atOrBeforeRecordTime: OffsetDateTime
+      atOrBeforeRecordTime: OffsetDateTime,
+      damlValueEncoding: Option[DamlValueEncoding],
   )(extracted: TraceContext): Future[ScanResource.ListBulkAcsSnapshotObjectsResponse] = {
     implicit val tc = extracted
     import cats.implicits.*
@@ -2559,15 +2564,22 @@ class HttpScanHandler(
         )
       ) { case (bulkStorage, publicUrl) =>
         val recordTimeTs = Codec.tryDecode(Codec.OffsetDateTime)(atOrBeforeRecordTime)
-        bulkStorage.getCommittedObjectsForAcsSnapshotAtOrBefore(recordTimeTs).map {
-          case AcsSnapshotObjects(ts, objects) =>
+        bulkStorage
+          .getCommittedObjectsForAcsSnapshotAtOrBefore(
+            recordTimeTs,
+            NonEmptyList.one(
+              ScanStorageConfig.Encoding
+                .fromDamlValueEncoding(damlValueEncoding.getOrElse(DamlValueEncoding.CompactJson))
+            ),
+          )
+          .map { case AcsSnapshotObjects(ts, objects) =>
             ScanResource.ListBulkAcsSnapshotObjectsResponse.OK(
               definitions.ListBulkAcsSnapshotObjectsResponse(
                 Codec.encode(ts),
                 encodeBulkStorageObjects(objects, publicUrl),
               )
             )
-        }
+          }
       }
 
     }
@@ -2596,6 +2608,11 @@ class HttpScanHandler(
             upToTs,
             PageLimit.tryCreate(body.pageSize),
             body.nextPageToken,
+            NonEmptyList.one(
+              ScanStorageConfig.Encoding.fromDamlValueEncoding(
+                body.damlValueEncoding.getOrElse(DamlValueEncoding.CompactJson)
+              )
+            ),
           )
           .map { case UpdateHistoryObjectsResponse(objects, nextPageToken) =>
             ScanResource.ListBulkUpdateHistoryObjectsResponse.OK(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -156,6 +156,12 @@ object ScanStorageConfig {
         extends Encoding("protobuf_json", definitions.DamlValueEncoding.ProtobufJson)
 
     lazy val all: NonEmptyList[Encoding] = NonEmptyList.of[Encoding](CompactJson, ProtobufJson)
+
+    def fromDamlValueEncoding(damlValueEncoding: definitions.DamlValueEncoding): Encoding =
+      damlValueEncoding match {
+        case definitions.DamlValueEncoding.members.CompactJson => CompactJson
+        case definitions.DamlValueEncoding.members.ProtobufJson => ProtobufJson
+      }
   }
 }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
@@ -30,8 +30,7 @@ class BulkStorageReader(
 
   def getCommittedObjectsForAcsSnapshotAtOrBefore(
       atOrBeforeTimestamp: CantonTimestamp,
-      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding] =
-        NonEmptyList.one(ScanStorageConfig.Encoding.CompactJson),
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[AcsSnapshotObjects] = {
     for {
       snapshotTs <-
@@ -125,8 +124,7 @@ class BulkStorageReader(
       atOrBeforeRecordTime: CantonTimestamp,
       limit: PageLimit,
       nextPageTokenO: Option[String],
-      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding] =
-        NonEmptyList.one(ScanStorageConfig.Encoding.CompactJson),
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[UpdateHistoryObjectsResponse] =
     getUpdatesBetweenDatesFromBucket(
       afterRecordTime,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDbTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDbTest.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.store.bulk
 
+import cats.data.NonEmptyList
 import com.daml.metrics.api.MetricsContext
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.api.testing.InMemoryMetricsFactory
@@ -253,14 +254,18 @@ class AcsSnapshotBulkStorageWriterFromDbTest
       def assertGetObjects(
           queryTs: CantonTimestamp,
           expectedTs: CantonTimestamp,
+          encoding: ScanStorageConfig.Encoding,
           expectedNumObjects: Int,
       ) = {
-        val getObjectsResult =
-          reader.getCommittedObjectsForAcsSnapshotAtOrBefore(queryTs).futureValue
+        val getObjectsResult = reader
+          .getCommittedObjectsForAcsSnapshotAtOrBefore(
+            queryTs,
+            NonEmptyList.one(encoding),
+          )
+          .futureValue
         getObjectsResult.objects.map(_.key) should contain theSameElementsInOrderAs
           (0 until expectedNumObjects).map(i =>
-            s"$expectedTs~${expectedTs
-                .add(1.days)}/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", i)}"
+            s"$expectedTs~${expectedTs.add(1.days)}/${encoding.storageKey("ACS", i)}"
           )
         getObjectsResult.objects.map(_.checksum).foreach {
           // We test elsewhere that computed and persisted checksums are correct, so here we just check that they are present and not empty
@@ -269,7 +274,13 @@ class AcsSnapshotBulkStorageWriterFromDbTest
         succeed
       }
 
-      val ex = reader.getCommittedObjectsForAcsSnapshotAtOrBefore(ts1).failed.futureValue
+      val ex = reader
+        .getCommittedObjectsForAcsSnapshotAtOrBefore(
+          ts1,
+          ScanStorageConfig.Encoding.all,
+        )
+        .failed
+        .futureValue
       ex shouldBe a[StatusRuntimeException]
       ex.asInstanceOf[StatusRuntimeException]
         .getStatus
@@ -289,7 +300,8 @@ class AcsSnapshotBulkStorageWriterFromDbTest
             persistedTs1 shouldBe Some(TimestampWithMigrationId(ts1, 0))
           }
           assertLatestSnapshotInMetrics(ts1)
-          assertGetObjects(ts1, ts1, 7)
+          assertGetObjects(ts1, ts1, ScanStorageConfig.Encoding.CompactJson, 7)
+          assertGetObjects(ts1, ts1, ScanStorageConfig.Encoding.ProtobufJson, 8)
         }
 
         clue(
@@ -307,7 +319,8 @@ class AcsSnapshotBulkStorageWriterFromDbTest
             },
           )
           assertLatestSnapshotInMetrics(ts1)
-          assertGetObjects(ts2, ts1, 7)
+          assertGetObjects(ts2, ts1, ScanStorageConfig.Encoding.CompactJson, 7)
+          assertGetObjects(ts2, ts1, ScanStorageConfig.Encoding.ProtobufJson, 8)
         }
 
         clue("Add one more snapshot to the store, at the end of the period") {
@@ -318,11 +331,15 @@ class AcsSnapshotBulkStorageWriterFromDbTest
             persistedTs3.value shouldBe TimestampWithMigrationId(ts3, 0)
           }
           assertLatestSnapshotInMetrics(ts3)
-          assertGetObjects(ts3, ts3, 7)
+          assertGetObjects(ts3, ts3, ScanStorageConfig.Encoding.CompactJson, 7)
+          assertGetObjects(ts3, ts3, ScanStorageConfig.Encoding.ProtobufJson, 8)
         }
 
         val ex1 = reader
-          .getCommittedObjectsForAcsSnapshotAtOrBefore(ts1.minus(java.time.Duration.ofDays(1)))
+          .getCommittedObjectsForAcsSnapshotAtOrBefore(
+            ts1.minus(java.time.Duration.ofDays(1)),
+            ScanStorageConfig.Encoding.all,
+          )
           .failed
           .futureValue
         ex1 shouldBe a[StatusRuntimeException]


### PR DESCRIPTION
Follow-up to #6602 per discussion with @isegall-da 

This adds an optional `daml_value_encoding` query parameter to `listBulkAcsSnapshotObjects` and field to `ListBulkUpdateHistoryObjectsRequest` (used in `listBulkUpdateHistoryObjects`) so users can list bulk storage objects with either encoding type (compact or protobuf-encoded JSON). If the parameter is not given, the current default behavior is preserved -- the endpoints will list objects with the compact encoding.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
