### PR TITLE
helm: allow setting priorityClassName on node pods

### DIFF
--- a/cluster/helm/splice-cometbft/templates/deployment.yaml
+++ b/cluster/helm/splice-cometbft/templates/deployment.yaml
@@ -202,6 +202,9 @@ spec:
           emptyDir:
             sizeLimit: 1Mi
         {{- end }}
+      {{- with $.Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-cometbft/templates/deployment.yaml
+++ b/cluster/helm/splice-cometbft/templates/deployment.yaml
@@ -203,7 +203,7 @@ spec:
             sizeLimit: 1Mi
         {{- end }}
       {{- with $.Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -97,6 +97,9 @@ metrics:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 enableAntiAffinity: true
 
 logLevel: info

--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -171,6 +171,9 @@ spec:
                 echo "trying to create postgres database {{ .Values.mediator.persistence.databaseName }}, last error: $errmsg";
                 sleep 2;
               done
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -172,7 +172,7 @@ spec:
                 sleep 2;
               done
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-domain/values-template.yaml
+++ b/cluster/helm/splice-domain/values-template.yaml
@@ -44,6 +44,9 @@ sequencer:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
 

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -155,6 +155,9 @@ spec:
                 echo "trying to create postgres database {{ .Values.mediator.persistence.databaseName }}, last error: $errmsg";
                 sleep 2;
               done
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -227,5 +230,5 @@ data:
 {{ .Files.Get "files/logback.xml" | indent 4 }}
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.mediator.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.mediator.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end}}

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -156,7 +156,7 @@ spec:
                 sleep 2;
               done
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -275,7 +275,7 @@ spec:
               echo "Created empty database ${DB_NAME} on ${DB_HOST}.";
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -274,6 +274,9 @@ spec:
               psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -c "CREATE DATABASE \"${DB_NAME}\"";
               echo "Created empty database ${DB_NAME} on ${DB_HOST}.";
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -323,11 +326,11 @@ spec:
       protocol: TCP
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "name" (print "postgres-" (.Values.sequencer.persistence.databaseName | replace "_" "-" ) "-e") "namespace" .Release.Namespace "persistence" .Values.sequencer.persistence "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "name" (print "postgres-" (.Values.sequencer.persistence.databaseName | replace "_" "-" ) "-e") "namespace" .Release.Namespace "persistence" .Values.sequencer.persistence "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- if and (eq .Values.sequencer.driver.type "cantonbft") ((.Values.sequencer.driver).persistence) (((.Values.sequencer.driver).persistence).databaseName) (ne .Values.sequencer.driver.persistence.databaseName .Values.sequencer.persistence.databaseName) }}
 {{- $driverPersistence := dict "postgresName" (print .Values.sequencer.persistence.postgresName "-driver") "databaseName" .Values.sequencer.driver.persistence.databaseName "host" (.Values.sequencer.driver.persistence.host | default .Values.sequencer.persistence.host) "port" (.Values.sequencer.driver.persistence.port | default .Values.sequencer.persistence.port) "secretName" (.Values.sequencer.driver.persistence.secretName | default .Values.sequencer.persistence.secretName) }}
 ---
-{{- include "splice-util-lib.postgres-metrics" (dict "namespace" .Release.Namespace "persistence" $driverPersistence "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "namespace" .Release.Namespace "persistence" $driverPersistence "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end }}
 {{- end}}
 {{-  if .Values.pvc }}

--- a/cluster/helm/splice-global-domain/tests/mediator_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/mediator_test.yaml
@@ -297,3 +297,33 @@ tests:
             capabilities:
               drop:
                 - ALL
+
+  - it: "propagates priorityClassName to the postgres-metrics deployment"
+    set:
+      enablePostgresMetrics: true
+      priorityClassName: high-priority
+      mediator:
+        persistence:
+          postgresName: mediator-pg
+          databaseName: mediator_db
+    documentSelector:
+      path: spec.template.metadata.labels.app
+      value: pge-mediator-pg-mediator-db
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: "omits priorityClassName on the postgres-metrics deployment when unset"
+    set:
+      enablePostgresMetrics: true
+      mediator:
+        persistence:
+          postgresName: mediator-pg
+          databaseName: mediator_db
+    documentSelector:
+      path: spec.template.metadata.labels.app
+      value: pge-mediator-pg-mediator-db
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/cluster/helm/splice-global-domain/values-template.yaml
+++ b/cluster/helm/splice-global-domain/values-template.yaml
@@ -65,6 +65,9 @@ metrics:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 enableAntiAffinity: true
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)

--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -219,7 +219,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -218,6 +218,9 @@ spec:
         {{ .Values.extraInitContainers | toYaml | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -304,5 +307,5 @@ data:
 {{ .Files.Get "files/logback.xml" | indent 4 }}
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end}}

--- a/cluster/helm/splice-participant/tests/participant_test.yaml
+++ b/cluster/helm/splice-participant/tests/participant_test.yaml
@@ -464,3 +464,22 @@ tests:
               drop:
                 - ALL
 
+
+  - it: "sets priorityClassName when provided"
+    set:
+      priorityClassName: high-priority
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: "omits priorityClassName when not provided"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/cluster/helm/splice-participant/tests/participant_test.yaml
+++ b/cluster/helm/splice-participant/tests/participant_test.yaml
@@ -476,6 +476,17 @@ tests:
           path: spec.template.spec.priorityClassName
           value: high-priority
 
+  - it: "renders a numeric-looking priorityClassName as a string"
+    set:
+      priorityClassName: "42"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "42"
+
   - it: "omits priorityClassName when not provided"
     documentSelector:
       path: kind

--- a/cluster/helm/splice-participant/values-template.yaml
+++ b/cluster/helm/splice-participant/values-template.yaml
@@ -49,6 +49,9 @@ persistence:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 extraInitContainers: []
 
 # set to true to disable auth (this is highly insecure)

--- a/cluster/helm/splice-participant/values.schema.json
+++ b/cluster/helm/splice-participant/values.schema.json
@@ -215,6 +215,9 @@
     "tolerations": {
       "type": "array"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "nodeSelector": {
       "type": "object"
     },

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -336,7 +336,7 @@ spec:
                 sleep 2;
               done
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -470,7 +470,7 @@ spec:
           limits:
             memory: 1536Mi
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -335,6 +335,9 @@ spec:
                 echo "trying to create postgres database {{ .Values.persistence.databaseName }}, last error: $errmsg";
                 sleep 2;
               done
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -466,6 +469,9 @@ spec:
             memory: 240Mi
           limits:
             memory: 1536Mi
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -505,5 +511,5 @@ data:
 {{ .Files.Get "files/logback.xml" | indent 4 }}
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence  "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence  "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end}}

--- a/cluster/helm/splice-scan/values-template.yaml
+++ b/cluster/helm/splice-scan/values-template.yaml
@@ -62,6 +62,9 @@ spliceInstanceNames:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 # set the poll interval used by the UI in milliseconds (optional)
 # uiPollInterval:
 

--- a/cluster/helm/splice-scan/values.schema.json
+++ b/cluster/helm/splice-scan/values.schema.json
@@ -276,6 +276,9 @@
         "tolerations": {
           "type": "array"
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "enablePostgresMetrics": {
           "type": "boolean"
         },

--- a/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
@@ -95,7 +95,7 @@ spec:
             limits:
               memory: 1536Mi
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
@@ -94,6 +94,9 @@ spec:
               memory: 240Mi
             limits:
               memory: 1536Mi
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -647,6 +647,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-sv-app-pvc
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -724,5 +727,5 @@ data:
 {{ .Files.Get "files/logback.xml" | indent 4 }}
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end}}

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -648,7 +648,7 @@ spec:
             claimName: {{ .Release.Name }}-sv-app-pvc
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-sv-node/values-template.yaml
+++ b/cluster/helm/splice-sv-node/values-template.yaml
@@ -78,6 +78,9 @@ spliceInstanceNames:
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 # set the poll interval used by the UI in milliseconds (optional)
 # uiPollInterval:
 

--- a/cluster/helm/splice-sv-node/values.schema.json
+++ b/cluster/helm/splice-sv-node/values.schema.json
@@ -587,6 +587,9 @@
         "tolerations": {
           "type": "array"
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "livenessProbeInitialDelaySeconds": {
           "type": "integer",
           "minimum": 0

--- a/cluster/helm/splice-util-lib/templates/_helpers.tpl
+++ b/cluster/helm/splice-util-lib/templates/_helpers.tpl
@@ -67,6 +67,7 @@ valueFrom:
 {{- $nodeSelector := .nodeSelector }}
 {{- $affinity := .affinity }}
 {{- $tolerations := .tolerations }}
+{{- $priorityClassName := .priorityClassName }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -127,6 +128,9 @@ spec:
                 echo "Waiting for database {{ $persistence.databaseName }}, at hostname {{ $persistence.host }}, port {{ $persistence.port | default 5432 }} to be accessible. Last error: $errmsg"
                 sleep 2;
             done
+      {{- with $priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-util-lib/templates/_helpers.tpl
+++ b/cluster/helm/splice-util-lib/templates/_helpers.tpl
@@ -129,7 +129,7 @@ spec:
                 sleep 2;
             done
       {{- with $priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with $nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/ans-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/ans-web-ui.yaml
@@ -109,7 +109,7 @@ spec:
           limits:
             memory: 1536Mi
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/ans-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/ans-web-ui.yaml
@@ -108,6 +108,9 @@ spec:
             memory: 240Mi
           limits:
             memory: 1536Mi
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -457,6 +457,9 @@ spec:
         {{ .Values.extraInitContainers | toYaml | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -535,5 +538,5 @@ data:
 {{ .Files.Get "files/logback.xml" | indent 4 }}
 ---
 {{- if .Values.enablePostgresMetrics }}
-{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "serviceAccountName" .Values.serviceAccountName ) }}
+{{- include "splice-util-lib.postgres-metrics" (dict "persistence" .Values.persistence "namespace" .Release.Namespace "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "priorityClassName" .Values.priorityClassName "serviceAccountName" .Values.serviceAccountName ) }}
 {{- end}}

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -458,7 +458,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
@@ -109,7 +109,7 @@ spec:
           limits:
             memory: 1536Mi
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
@@ -108,6 +108,9 @@ spec:
             memory: 240Mi
           limits:
             memory: 1536Mi
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/cluster/helm/splice-validator/tests/validator_test.yaml
+++ b/cluster/helm/splice-validator/tests/validator_test.yaml
@@ -570,6 +570,17 @@ tests:
           path: spec.template.spec.priorityClassName
           value: high-priority
 
+  - it: "renders a numeric-looking priorityClassName as a string"
+    set:
+      priorityClassName: "42"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "42"
+
   - it: "omits priorityClassName when not provided"
     documentSelector:
       path: kind

--- a/cluster/helm/splice-validator/tests/validator_test.yaml
+++ b/cluster/helm/splice-validator/tests/validator_test.yaml
@@ -559,3 +559,21 @@ tests:
               drop:
                 - ALL
 
+  - it: "sets priorityClassName when provided"
+    set:
+      priorityClassName: high-priority
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: "omits priorityClassName when not provided"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/cluster/helm/splice-validator/values-template.yaml
+++ b/cluster/helm/splice-validator/values-template.yaml
@@ -62,6 +62,9 @@ enableWallet: true
 # k8s tolerations for all deployed pods (optional)
 # tolerations:
 
+# k8s priorityClassName for all deployed pods (optional)
+# priorityClassName:
+
 spliceInstanceNames:
   networkName: # Please provide a value as provided in the docs
   networkFaviconUrl: # Please provide a value as provided in the docs

--- a/cluster/helm/splice-validator/values.schema.json
+++ b/cluster/helm/splice-validator/values.schema.json
@@ -421,6 +421,9 @@
         "tolerations": {
           "type": "array"
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "auth": {
           "type": "object",
           "required": ["audience", "jwksUrl"],

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -73,3 +73,9 @@ release-notes:: Upcoming
           enabled by ``canton.validator-apps.validator_backend.enable-deprecated-transfer-command-support=true``
           has been fully removed. Migrate to token standard transfers
           and remove the flag.
+
+    - Helm
+
+        - The node pods of the operator charts now accept a ``priorityClassName``, so operators can
+          protect a node from eviction under resource pressure. It is unset by default, which leaves
+          scheduling behaviour unchanged.


### PR DESCRIPTION
Fixes #6800.

**Motivation:** running several Splice nodes on shared Kubernetes infrastructure is the normal operator topology — DevNet and TestNet alongside MainNet so a release can be validated before production, and node providers running nodes for several parties on shared capacity. Today every Splice pod sits at priority 0, so nothing expresses that MainNet outranks the rest: under node pressure the kubelet cannot tell a production validator from a DevNet one, and the scheduler has nothing to preempt with. A PriorityClass per tier is the standard Kubernetes answer, and the charts currently make it unreachable.

Adds an optional `priorityClassName`, rendered next to the existing `nodeSelector` / `affinity` / `tolerations`, and threaded through the shared `splice-util-lib.postgres-metrics` helper so the metrics deployment picks it up too. Nothing is rendered when the value is unset, so this is a no-op for anyone who does not set it.

It is declared in `values.schema.json` only for the charts that already declare `tolerations` there, so this does not start declaring placement values for charts that currently leave them undeclared.

Excluded: `splice-postgres` and `splice-istio-gateway` (both deprecated), and the dev/demo charts (`cn-docs`, `splice-info`, `splice-load-tester`, `splice-party-allocator`, `splice-splitwell-*`). Happy to extend to those if you would rather have the value everywhere.

Tested with `helm unittest` on all seven charts touched: existing tests still pass, plus new set/unset tests for `splice-participant` and `splice-validator`.