### PR TITLE
helm: make the Postgres role and bootstrap database configurable for validators

### DIFF
--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -55,6 +55,10 @@ spec:
           value: {{ .Values.persistence.port | quote }}
         - name: CANTON_PARTICIPANT_POSTGRES_SCHEMA
           value: {{ .Values.persistence.schema }}
+        {{- with .Values.persistence.user }}
+        - name: CANTON_PARTICIPANT_POSTGRES_USER
+          value: {{ . | quote }}
+        {{- end }}
         - name: CANTON_PARTICIPANT_POSTGRES_PASSWORD
           {{- if ((.Values.persistence).secretOverrides).postgresPassword }}
           value: {{ .Values.persistence.secretOverrides.postgresPassword | quote }}
@@ -186,7 +190,7 @@ spec:
               {{- end }}
               DB_TO_CREATE='{{ .Values.persistence.databaseName }}'
 
-              until db_exists=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_TO_CREATE}'" 2>&1); do
+              until db_exists=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_TO_CREATE}'" 2>&1); do
                 echo "trying to connect to postgres, last error: ${db_exists}";
                 sleep 2;
               done
@@ -195,7 +199,7 @@ spec:
                 echo "Database ${DB_TO_CREATE} already exists. Done."
               else
                 {{- if $conflictCheck }}
-                existing=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'participant%'" | paste -sd ', ' -)
+                existing=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -tAc "SELECT datname FROM pg_database WHERE datname LIKE 'participant%'" | paste -sd ', ' -)
                 if [ -n "${existing}" ]; then
                   echo "ERROR: Refusing to create participant database '${DB_TO_CREATE}' because the following participant database(s) already exist: ${existing}." >&2
                   echo "       A participant database should only be created during a fresh deployment. Please double-check that this is intended and not a misconfiguration." >&2
@@ -203,7 +207,7 @@ spec:
                   exit 1
                 fi
                 {{- end }}
-                until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -c "create database ${DB_TO_CREATE}" 2>&1); do
+                until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -c "create database ${DB_TO_CREATE}" 2>&1); do
                   if [[ ${errmsg} == *"already exists"* ]]; then
                     echo "Database ${DB_TO_CREATE} already exists. Done."
                     break

--- a/cluster/helm/splice-participant/tests/postgres-identity_test.yaml
+++ b/cluster/helm/splice-participant/tests/postgres-identity_test.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: "postgres identity"
+templates:
+  - participant.yaml
+set:
+  # Things we need just to pass the schema
+  persistence:
+    host: mock-pg-host
+    schema: participant
+  auth:
+    jwksUrl: "https://mock.com/.well-known/jwks.json"
+    targetAudience: "mock_audience"
+tests:
+  - it: "defaults the pg-init role and bootstrap database to cnadmin/cantonnet"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=cnadmin --dbname=cantonnet"
+
+  - it: "uses persistence.user and persistence.bootstrapDatabaseName when set"
+    set:
+      persistence:
+        host: mock-pg-host
+        schema: participant
+        user: appuser
+        bootstrapDatabaseName: postgres
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=appuser --dbname=postgres"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=cnadmin|--dbname=cantonnet\\b"
+
+  - it: "passes persistence.user to the canton node itself, not just the init container"
+    set:
+      persistence:
+        host: mock-pg-host
+        schema: participant
+        user: appuser
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CANTON_PARTICIPANT_POSTGRES_USER
+            value: appuser
+
+  - it: "omits the canton node DB user when persistence.user is unset"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: CANTON_PARTICIPANT_POSTGRES_USER

--- a/cluster/helm/splice-participant/values-template.yaml
+++ b/cluster/helm/splice-participant/values-template.yaml
@@ -31,6 +31,10 @@ metrics:
 
 persistence:
   secretName: "postgres-secrets"
+  # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+  # user: cnadmin
+  # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+  # bootstrapDatabaseName: cantonnet
   port: 5432
   enablePgInitContainer: true
   initImageName: "postgres:14"

--- a/cluster/helm/splice-participant/values.schema.json
+++ b/cluster/helm/splice-participant/values.schema.json
@@ -95,6 +95,12 @@
           "minimum": 0,
           "maximum": 65535
         },
+        "bootstrapDatabaseName": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
         "initImageName": {
           "type": "string"
         },

--- a/cluster/helm/splice-util-lib/templates/_helpers.tpl
+++ b/cluster/helm/splice-util-lib/templates/_helpers.tpl
@@ -100,7 +100,7 @@ spec:
           - name: DATA_SOURCE_PASS_FILE
             value: /tmp/pwd
           - name: DATA_SOURCE_USER
-            value: cnadmin
+            value: {{ $persistence.user | default "cnadmin" }}
           - name: DATA_SOURCE_URI
             value: {{ $persistence.host  }}:{{ $persistence.port | default 5432 }}/{{ $.persistence.databaseName }}?sslmode=disable
         command:
@@ -124,7 +124,7 @@ spec:
           - 'bash'
           - '-c'
           - |
-            until errmsg=$(psql -h {{ $persistence.host }} -p {{ $persistence.port }} --username=cnadmin --dbname={{ $persistence.databaseName }} -p {{ $persistence.port | default 5432 }} -c 'select 1' 2>&1); do
+            until errmsg=$(psql -h {{ $persistence.host }} -p {{ $persistence.port }} --username={{ $persistence.user | default "cnadmin" }} --dbname={{ $persistence.databaseName }} -p {{ $persistence.port | default 5432 }} -c 'select 1' 2>&1); do
                 echo "Waiting for database {{ $persistence.databaseName }}, at hostname {{ $persistence.host }}, port {{ $persistence.port | default 5432 }} to be accessible. Last error: $errmsg"
                 sleep 2;
             done

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -443,7 +443,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-validator/tests/postgres-identity_test.yaml
+++ b/cluster/helm/splice-validator/tests/postgres-identity_test.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: "postgres identity"
+templates:
+  - validator.yaml
+set:
+  # Things we need just to pass the schema
+  nodeIdentifier: "helm-mock-1-validator"
+  validatorPartyHint: "helm-mock-1"
+  validatorWalletUser: "mock-wallet-user-id"
+  topup:
+    enabled: false
+  auth:
+    jwksUrl: "https://mock.com/.well-known/jwks.json"
+    audience: "mock_audience"
+  spliceInstanceNames:
+    networkName: MockNet
+    networkFaviconUrl: https://mock.net/favicon.ico
+    amuletName: Mocklet
+    amuletNameAcronym: MCK
+    nameServiceName: Mock Name Service
+    nameServiceNameAcronym: MNS
+tests:
+  - it: "defaults the pg-init role and bootstrap database to cnadmin/cantonnet"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=cnadmin --dbname=cantonnet"
+
+  - it: "uses persistence.user and persistence.bootstrapDatabaseName when set"
+    set:
+      persistence:
+        user: appuser
+        bootstrapDatabaseName: postgres
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=appuser --dbname=postgres"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--username=cnadmin|--dbname=cantonnet\\b"

--- a/cluster/helm/splice-validator/values-template.yaml
+++ b/cluster/helm/splice-validator/values-template.yaml
@@ -33,6 +33,10 @@ persistence:
   port: 5432
   user: cnadmin
   secretName: "postgres-secrets"
+  # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+  # user: cnadmin
+  # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+  # bootstrapDatabaseName: cantonnet
   enablePgInitContainer: true
   initImageName: "postgres:14"
   # Optional: Provide raw strings to override the default Kubernetes secret injection.

--- a/cluster/helm/splice-validator/values.schema.json
+++ b/cluster/helm/splice-validator/values.schema.json
@@ -365,6 +365,9 @@
             "secretName": {
               "type": "string"
             },
+            "bootstrapDatabaseName": {
+              "type": "string"
+            },
             "initImageName": {
               "type": "string"
             },

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -109,6 +109,16 @@ release-notes:: Upcoming
           protect a node from eviction under resource pressure. It is unset by default, which leaves
           scheduling behaviour unchanged.
 
+        - The Postgres role and bootstrap database used by the validator and participant charts are
+          no longer hardcoded. ``persistence.user`` and ``persistence.bootstrapDatabaseName`` are now
+          honoured by the ``pg-init`` and wait containers, by the Postgres exporter sidecar, and — for
+          the participant — by the Canton node itself, which previously always connected as
+          ``cnadmin`` regardless of the configured value. They default to ``cnadmin`` and
+          ``cantonnet``, so rendered output is unchanged unless you set them. This matters for
+          operators moving off ``splice-postgres`` to a self-provisioned or managed Postgres, where a
+          ``cnadmin`` superuser and a ``cantonnet`` database may not be available to create. The SV
+          charts are not covered yet and still use the hardcoded values.
+
     - SV UI
 
         - The ``AmuletRules_SetConfig`` proposal form can now set


### PR DESCRIPTION
Fixes #6802. **Scope reduced to validator and participant** per the discussion below — the SV charts and splitwell move to a follow-up.

## Why

`splice-postgres` is unsupported after 2026-11-12, so every operator on it has to move to a self-provisioned or managed Postgres. The charts assumed that migration target would offer a `cnadmin` superuser and a `cantonnet` database, which a managed offering may not permit creating at all — so the names blocked the very migration path upstream points at.

`persistence.user` and `persistence.bootstrapDatabaseName` are now read wherever those values were hardcoded, defaulting to `cnadmin` and `cantonnet` so **rendered output is byte-identical unless you set them**.

## The part that was not just the init container

The participant needed more than the pg-init fix. `canton-base`'s `storage.conf` reads `user = ${?CANTON_PARTICIPANT_POSTGRES_USER}`, and the chart never set it — so the node kept connecting as `cnadmin` even with `persistence.user` configured. That is a half-applied configuration: the init container uses the new role, the application does not, and nothing complains. Worse than not offering the value, since it looks configurable.

The image already supports the variable and the compose deployment already passes it (`CANTON_PARTICIPANT_POSTGRES_USER=${SPLICE_DB_USER}`); Helm was the only deployment path missing it. `splice-validator` was never affected — it writes `user` straight into its HOCON storage block.

## Testing

Helm deployment on a `kind` cluster, against a Postgres initialised with `POSTGRES_USER=appuser` / `POSTGRES_DB=bootstrapdb`, so `cnadmin` and `cantonnet` **do not exist**:

- participant `1/1 Running` — `participant_test owner=appuser`, `CANTON_PARTICIPANT_POSTGRES_USER=appuser`, 18 Flyway migrations, `Canton started`, and Postgres reports `appuser -> participant_test (32 conn)`
- validator app completes its DB work — `validator_test owner=appuser`, schema `validator owner=appuser` — then stops at the ledger-API wiring, which was deliberately not configured
- **negative control**: the unpatched charts with identical values loop on `FATAL: password authentication failed for user "cnadmin"` at `Init:0/1`, with no user env var rendered at all

Chart unit tests cover the defaults, an override, and that neither default survives in the rendered command; each was checked to fail without the change rather than assumed.

## Not in this PR

`splice-sv-node`, `splice-scan`, `splice-global-domain` (sequencer + mediator), `splice-domain` and `splice-splitwell-app` carry the same hardcoding and the same fix, but SV deployments have more moving parts and the cluster test coverage for them is not there yet. That work is preserved and will follow once it is.