### PR TITLE
enable split-sv deployment for scratchnets by default

### DIFF
--- a/cluster/configs/shared/scratch-default-synchronizer-migration.yaml
+++ b/cluster/configs/shared/scratch-default-synchronizer-migration.yaml
@@ -1,4 +1,5 @@
 synchronizerMigration:
+  splitSvDeploymentEnabled: true
   frozenMigrationId: 0
   active:
     id: 0

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -1862,6 +1862,7 @@ synchronizerMigration:
       spliceRoot: 'splice'
     version: 'local'
   frozenMigrationId: 0
+  splitSvDeploymentEnabled: true
 validator1:
   deduplicationDuration: '30m'
   logging:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -1862,6 +1862,7 @@ synchronizerMigration:
       spliceRoot: 'splice'
     version: 'local'
   frozenMigrationId: 0
+  splitSvDeploymentEnabled: true
 validator1:
   deduplicationDuration: '30m'
   logging:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -1862,6 +1862,7 @@ synchronizerMigration:
       spliceRoot: 'splice'
     version: 'local'
   frozenMigrationId: 0
+  splitSvDeploymentEnabled: true
 validator1:
   deduplicationDuration: '30m'
   logging:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -1862,6 +1862,7 @@ synchronizerMigration:
       spliceRoot: 'splice'
     version: 'local'
   frozenMigrationId: 0
+  splitSvDeploymentEnabled: true
 validator1:
   deduplicationDuration: '30m'
   logging:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -1862,6 +1862,7 @@ synchronizerMigration:
       spliceRoot: 'splice'
     version: 'local'
   frozenMigrationId: 0
+  splitSvDeploymentEnabled: true
 validator1:
   deduplicationDuration: '30m'
   logging:


### PR DESCRIPTION
Fixes https://github.com/canton-network/splice/issues/6714

From the deployment point of view the migration of scratche looks fine. Still waiting for a confirmation from @kajalshah-da if I did not break BigQuery.

Backport to 0.7.3 is needed to prevent upgrade workflows from switching between deployment modes.