### PR TITLE
Double scan rate limits for `/registry/transfer-instruction/v1/transfer-factory`

### DIFF
--- a/cluster/configs/shared/rate-limits/token-registry.yaml
+++ b/cluster/configs/shared/rate-limits/token-registry.yaml
@@ -52,12 +52,12 @@ rateLimits:
   /registry/transfer-instruction/v1/transfer-factory:
     name: registry-transfer-factory
     type: limited
-    maxTokens: 730
-    tokensPerFill: 730
+    maxTokens: 1440
+    tokensPerFill: 1440
     fillInterval: 60s
     perIpLimits:
-      maxTokens: 120
-      tokensPerFill: 120
+      maxTokens: 240
+      tokensPerFill: 240
       fillInterval: 60s
   /registry/allocation/v2/settlement-factory:
     name: registry-settlement-factory-v2

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -458,13 +458,13 @@ sv:
           type: 'limited'
         /registry/transfer-instruction/v1/transfer-factory:
           fillInterval: '60s'
-          maxTokens: 730
+          maxTokens: 1440
           name: 'registry-transfer-factory'
           perIpLimits:
             fillInterval: '60s'
-            maxTokens: 120
-            tokensPerFill: 120
-          tokensPerFill: 730
+            maxTokens: 240
+            tokensPerFill: 240
+          tokensPerFill: 1440
           type: 'limited'
         /registry/transfer-instruction/v2:
           fillInterval: '60s'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -458,13 +458,13 @@ sv:
           type: 'limited'
         /registry/transfer-instruction/v1/transfer-factory:
           fillInterval: '60s'
-          maxTokens: 730
+          maxTokens: 1440
           name: 'registry-transfer-factory'
           perIpLimits:
             fillInterval: '60s'
-            maxTokens: 120
-            tokensPerFill: 120
-          tokensPerFill: 730
+            maxTokens: 240
+            tokensPerFill: 240
+          tokensPerFill: 1440
           type: 'limited'
         /registry/transfer-instruction/v2:
           fillInterval: '60s'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -458,13 +458,13 @@ sv:
           type: 'limited'
         /registry/transfer-instruction/v1/transfer-factory:
           fillInterval: '60s'
-          maxTokens: 730
+          maxTokens: 1440
           name: 'registry-transfer-factory'
           perIpLimits:
             fillInterval: '60s'
-            maxTokens: 120
-            tokensPerFill: 120
-          tokensPerFill: 730
+            maxTokens: 240
+            tokensPerFill: 240
+          tokensPerFill: 1440
           type: 'limited'
         /registry/transfer-instruction/v2:
           fillInterval: '60s'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -458,13 +458,13 @@ sv:
           type: 'limited'
         /registry/transfer-instruction/v1/transfer-factory:
           fillInterval: '60s'
-          maxTokens: 730
+          maxTokens: 1440
           name: 'registry-transfer-factory'
           perIpLimits:
             fillInterval: '60s'
-            maxTokens: 120
-            tokensPerFill: 120
-          tokensPerFill: 730
+            maxTokens: 240
+            tokensPerFill: 240
+          tokensPerFill: 1440
           type: 'limited'
         /registry/transfer-instruction/v2:
           fillInterval: '60s'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -458,13 +458,13 @@ sv:
           type: 'limited'
         /registry/transfer-instruction/v1/transfer-factory:
           fillInterval: '60s'
-          maxTokens: 730
+          maxTokens: 1440
           name: 'registry-transfer-factory'
           perIpLimits:
             fillInterval: '60s'
-            maxTokens: 120
-            tokensPerFill: 120
-          tokensPerFill: 730
+            maxTokens: 240
+            tokensPerFill: 240
+          tokensPerFill: 1440
           type: 'limited'
         /registry/transfer-instruction/v2:
           fillInterval: '60s'

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1177,14 +1177,14 @@
         },
         "/registry/transfer-instruction/v1/transfer-factory": {
           "fillInterval": "60s",
-          "maxTokens": 730,
+          "maxTokens": 1440,
           "name": "registry-transfer-factory",
           "perIpLimits": {
             "fillInterval": "60s",
-            "maxTokens": 120,
-            "tokensPerFill": 120
+            "maxTokens": 240,
+            "tokensPerFill": 240
           },
-          "tokensPerFill": 730,
+          "tokensPerFill": 1440,
           "type": "limited"
         },
         "/registry/transfer-instruction/v2": {
@@ -2446,8 +2446,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 730,
-                          "tokens_per_fill": 730
+                          "max_tokens": 1440,
+                          "tokens_per_fill": 1440
                         }
                       },
                       {
@@ -2462,8 +2462,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 120,
-                          "tokens_per_fill": 120
+                          "max_tokens": 240,
+                          "tokens_per_fill": 240
                         }
                       },
                       {

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -1868,14 +1868,14 @@
         },
         "/registry/transfer-instruction/v1/transfer-factory": {
           "fillInterval": "60s",
-          "maxTokens": 730,
+          "maxTokens": 1440,
           "name": "registry-transfer-factory",
           "perIpLimits": {
             "fillInterval": "60s",
-            "maxTokens": 120,
-            "tokensPerFill": 120
+            "maxTokens": 240,
+            "tokensPerFill": 240
           },
-          "tokensPerFill": 730,
+          "tokensPerFill": 1440,
           "type": "limited"
         },
         "/registry/transfer-instruction/v2": {
@@ -2261,14 +2261,14 @@
         },
         "/registry/transfer-instruction/v1/transfer-factory": {
           "fillInterval": "60s",
-          "maxTokens": 730,
+          "maxTokens": 1440,
           "name": "registry-transfer-factory",
           "perIpLimits": {
             "fillInterval": "60s",
-            "maxTokens": 120,
-            "tokensPerFill": 120
+            "maxTokens": 240,
+            "tokensPerFill": 240
           },
-          "tokensPerFill": 730,
+          "tokensPerFill": 1440,
           "type": "limited"
         },
         "/registry/transfer-instruction/v2": {
@@ -3759,8 +3759,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 730,
-                          "tokens_per_fill": 730
+                          "max_tokens": 1440,
+                          "tokens_per_fill": 1440
                         }
                       },
                       {
@@ -3775,8 +3775,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 120,
-                          "tokens_per_fill": 120
+                          "max_tokens": 240,
+                          "tokens_per_fill": 240
                         }
                       },
                       {
@@ -6093,8 +6093,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 730,
-                          "tokens_per_fill": 730
+                          "max_tokens": 1440,
+                          "tokens_per_fill": 1440
                         }
                       },
                       {
@@ -6109,8 +6109,8 @@
                         ],
                         "token_bucket": {
                           "fill_interval": "60s",
-                          "max_tokens": 120,
-                          "tokens_per_fill": 120
+                          "max_tokens": 240,
+                          "tokens_per_fill": 240
                         }
                       },
                       {


### PR DESCRIPTION
Based on experience on MainNet, see DACH-NY/canton-network-internal#6543

This endpoint is cheap, some IP(s) are getting rate limited at 3-4 requests / second.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
