### PR TITLE
Resolve tmux commands to absolute paths to avoid cross-shell PATH mismatch

### DIFF
--- a/start-canton.sh
+++ b/start-canton.sh
@@ -107,6 +107,12 @@ do
     shift
 done
 
+# Resolve to an absolute path now, in the environment that invoked this script.
+# Otherwise, if tmux's server was started from a different (nix) shell than this
+# invocation, the bare command name would resolve against that other shell's PATH
+# once sent into the tmux pane, silently running the wrong binary.
+CANTON="$(command -v "$CANTON")"
+
 tmux_session="canton"
 tmux_window=0
 
@@ -254,7 +260,7 @@ else
   echo "-D specified, not waiting for canton to start "
 fi
 
-tmux_cmd toxiproxy "toxiproxy-server 2>&1 | tee -a log/toxi.log"
+tmux_cmd toxiproxy "$(command -v toxiproxy-server) 2>&1 | tee -a log/toxi.log"
 
 if [ $daemon -eq 0 ]; then
   if [ -z "${TMUX-}" ]; then

--- a/start-frontends.sh
+++ b/start-frontends.sh
@@ -79,14 +79,14 @@ function start_frontend() {
   tmux_cmd "${app}-${user}" "${frontend_dir}" \
     "trap \"rm -f ${config_file}\" EXIT && \
     BROWSER=none PORT=$port JSON_API_URL=$JSON_API_URL VITE_SPLICE_CONFIG=\"\$(cat $config_file)\" \
-    npm start 2>&1 | tee -a $log_file"
+    $NPM start 2>&1 | tee -a $log_file"
 }
 
 function start_test() {
   local app=$1
   local frontend_dir="${SPLICE_ROOT}/apps/${app}/frontend"
 
-  tmux_cmd "${app}-test" "${frontend_dir}" "npm run test"
+  tmux_cmd "${app}-test" "${frontend_dir}" "$NPM run test"
 }
 
 function usage() {
@@ -138,6 +138,12 @@ done
 tmux_session="cn-frontends"
 tmux_window=0
 
+# Resolve to an absolute path now, in the environment that invoked this script.
+# Otherwise, if tmux's server was started from a different (nix) shell than this
+# invocation, the bare "npm" sent into the tmux pane would resolve against that
+# other shell's PATH once sent into the tmux pane, silently running the wrong binary.
+NPM="$(command -v npm)"
+
 LOG_DIR="${SPLICE_ROOT}/log"
 
 (cd "$SPLICE_ROOT" && sbt --batch apps-frontends/compile)
@@ -154,7 +160,7 @@ function wait_for_workspace_build() {
   local log_file="${LOG_DIR}/npm-${log_file_suffix}.out"
   echo "Logging to ${log_file}"
 
-  tmux_cmd "$workspace" "$SPLICE_ROOT/apps" "npm run start --workspace $workspace 2>&1 | tee -a $log_file"
+  tmux_cmd "$workspace" "$SPLICE_ROOT/apps" "$NPM run start --workspace $workspace 2>&1 | tee -a $log_file"
 
   local count=0
   while [ ! -f "$SPLICE_ROOT/apps/$index" ]; do


### PR DESCRIPTION
## Summary

If `tmux`'s server was started from one nix shell and `start-canton.sh` / `start-frontends.sh` is run from a different one, the bare command names sent into the tmux pane (`canton`, `toxiproxy-server`, `npm`) resolve against the *first* shell's `PATH` rather than the invoking shell's, which silently runs the wrong binary and can lead to confusing debugging sessions.

This resolves each of those commands to an absolute path via `command -v` in the invoking shell, before the string is ever sent into the tmux pane, per the first suggested fix in the issue.

- `start-canton.sh`: resolve `$CANTON` (after option parsing, so `-c <custom binary>` still works) and `toxiproxy-server`.
- `start-frontends.sh`: resolve `npm` once into `$NPM`, used in `start_frontend`, `start_test`, and `wait_for_workspace_build`.

`sbt` in `start-frontends.sh` is unaffected since it's invoked directly in the current shell, not inside a tmux pane.

Fixes #458

## Test plan

- [x] `bash -n start-canton.sh` / `bash -n start-frontends.sh` — syntax OK
- [ ] Start tmux from one nix shell, then run `start-canton.sh` from a different nix shell, and confirm the current shell's `canton` binary is used