### PR TITLE
Pulumi: allow inlining SV sweep config in config.yaml instead of env var

### DIFF
--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -8,7 +8,10 @@ import {
   LogLevelSchema,
   K8sResourceSchema,
 } from '@canton-network/splice-pulumi-common';
-import { ValidatorAppConfigSchema } from '@canton-network/splice-pulumi-common-validator/src/config';
+import {
+  SweepConfigSchema,
+  ValidatorAppConfigSchema,
+} from '@canton-network/splice-pulumi-common-validator/src/config';
 import { clusterYamlConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { mergeConfigFragments } from '@canton-network/splice-pulumi-common/src/config/configLoader';
 import { CnChartVersionSchema } from '@canton-network/splice-pulumi-common/src/config/versionSchema';
@@ -126,12 +129,10 @@ const ScanAppConfigSchema = z
 const SvValidatorAppConfigSchema = z
   .object({
     walletUser: z.string().optional(),
-    // TODO(#2389) inline env var into config.yaml
-    sweep: z
-      .object({
-        fromEnv: z.string(),
-      })
-      .optional(),
+    // Inline values are preferred (#2389); the `fromEnv` variant is kept only for
+    // clusters whose config.yaml has not yet been migrated off of it and should be
+    // dropped once all prod configs inline their sweep values directly.
+    sweep: z.union([SweepConfigSchema, z.object({ fromEnv: z.string() })]).optional(),
     auth0: Auth0ConfigSchema.optional(),
     // Map of package name -> list of versions to explicitly unvet
     additionalPackagesToUnvet: z.record(z.string(), z.array(z.string())).optional(),

--- a/cluster/pulumi/common-sv/src/svConfigs.ts
+++ b/cluster/pulumi/common-sv/src/svConfigs.ts
@@ -8,8 +8,6 @@ import {
   SvCometBftKeys,
   svCometBftKeysFromSecret,
 } from '@canton-network/splice-pulumi-common';
-import { SweepConfig } from '@canton-network/splice-pulumi-common-validator';
-import { spliceEnvConfig } from '@canton-network/splice-pulumi-common/src/config/envConfig';
 
 import { StaticSvConfig } from './config';
 import { dsoSize, skipExtraSvs } from './dsoConfig';
@@ -364,11 +362,6 @@ export const svRunbookConfig: StaticSvConfig = {
     },
   },
 };
-
-export function sweepConfigFromEnv(nodeName: string): SweepConfig | undefined {
-  const asJson = spliceEnvConfig.optionalEnv(`${nodeName}_SWEEP`);
-  return asJson && JSON.parse(asJson);
-}
 
 // "core SVs" are deployed as part of the `canton-network` stack;
 // if config.yaml contains any SVs that don't match the standard sv-X pattern, we deploy them independently of DSO_SIZE

--- a/cluster/pulumi/common-sv/src/svConfigsBasic.ts
+++ b/cluster/pulumi/common-sv/src/svConfigsBasic.ts
@@ -15,13 +15,12 @@ function sweepConfigFromEnv(nodeName: string): SweepConfig | undefined {
 
 export function fromSingleSvConfigBasic(nodeName: string): StaticSvConfigBasic {
   const config = configForSv(nodeName);
+  const sweep = config.validatorApp?.sweep;
   return {
     nodeName,
     ingressName: config.subdomain!,
     onboardingName: config.publicName!,
-    ...(config.validatorApp?.sweep
-      ? { sweep: sweepConfigFromEnv(config.validatorApp.sweep.fromEnv) }
-      : {}),
+    ...(sweep ? { sweep: 'fromEnv' in sweep ? sweepConfigFromEnv(sweep.fromEnv) : sweep } : {}),
   };
 }
 

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -10,6 +10,15 @@ import {
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { z } from 'zod';
 
+// Matches the `SweepConfig` type in ./sweep.
+export const SweepConfigSchema = z.object({
+  fromParty: z.string(),
+  toParty: z.string(),
+  maxBalance: z.number(),
+  minBalance: z.number(),
+  useTransferPreapproval: z.boolean().optional(),
+});
+
 export const SynchronizerConfigSchema = z.union([
   z
     .object({


### PR DESCRIPTION
## Summary

- `SvValidatorAppConfigSchema.sweep` (`cluster/pulumi/common-sv/src/singleSvConfig.ts`) previously only accepted `{ fromEnv: string }`, a pointer to a `<NODE>_SWEEP` env var that gets JSON-parsed into the actual sweep values at deploy time.
- Added `SweepConfigSchema` (`cluster/pulumi/common-validator/src/config.ts`, matching the existing `SweepConfig` type in `./sweep`) and changed `sweep` to a union of the inline shape and the old `{ fromEnv }` pointer, so `config.yaml` can now carry the sweep values directly.
- `fromSingleSvConfigBasic` (`svConfigsBasic.ts`) resolves either shape: looks up the env var for `{ fromEnv }`, uses the value as-is otherwise.
- Along the way, removed a duplicate `sweepConfigFromEnv` in `svConfigs.ts` that was unused dead code (the real one lives in `svConfigsBasic.ts` and is what's actually called).

Kept this backward-compatible rather than a hard cutover: existing prod cluster configs (in the internal repo) still reference `{ fromEnv }` and I don't have access to migrate those or to the actual `SV1_SWEEP` secret values. Once those configs are migrated to inline values, the `{ fromEnv }` branch and `sweepConfigFromEnv` can be dropped as a follow-up.

Fixes #2389

## Test plan

- [x] `tsc --noEmit` clean on `common-sv` and `common-validator`
- [x] `eslint` clean on all 4 changed files
- [x] `prettier --check` clean on all 4 changed files
- [ ] Verify a `config.yaml` with an inline `sweep` object deploys correctly end-to-end (needs a live cluster to test against)