### PR TITLE
improve failure message in packagesAreVetted test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BootstrapPackageConfigIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BootstrapPackageConfigIntegrationTest.scala
@@ -477,12 +477,12 @@ class BootstrapPackageConfigIntegrationTest
           )
         )
         .filter(_.metadata.version <= bootstrapPackage.metadata.version)
-      expectedToBeVettedVersions.foreach { expectedVettedVersion =>
+      forEvery(expectedToBeVettedVersions) { expectedVettedVersion =>
         val newVettedPackage = vettingState.packages
           .find(_.packageId == expectedVettedVersion.packageId)
-          .value
-        newVettedPackage.validFromInclusive should (
-          equal(scheduledTimeO) or equal(scheduledTime1) or equal(scheduledTime2)
+          .value withClue "newVettedPackage"
+        Seq(scheduledTimeO, scheduledTime1, scheduledTime2) should contain(
+          newVettedPackage.validFromInclusive
         )
       }
     }


### PR DESCRIPTION
Suggested by DACH-NY/cn-test-failures#9598.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
