### PR TITLE
Expose issuance caps in GetDsoInfoResponse

### DIFF
--- a/apps/common/src/main/openapi/common-internal.yaml
+++ b/apps/common/src/main/openapi/common-internal.yaml
@@ -266,6 +266,27 @@ components:
           description: |
             Initial round from which the network bootstraps
           type: string
+        validator_reward_cap:
+          description: |
+            Maximum per-validator issuance of validator reward coupons, in $,
+            from `latest_mining_round`'s `issuanceConfig`
+          type: string
+        featured_app_reward_cap:
+          description: |
+            Maximum per-featured-app issuance of app reward coupons, in $,
+            from `latest_mining_round`'s `issuanceConfig`
+          type: string
+        unfeatured_app_reward_cap:
+          description: |
+            Maximum per-unfeatured-app issuance of app reward coupons, in $,
+            from `latest_mining_round`'s `issuanceConfig`
+          type: string
+        validator_faucet_cap:
+          description: |
+            Maximum per-validator issuance of validator faucet coupons, in $,
+            from `latest_mining_round`'s `issuanceConfig`. Defaults to 2.85 if
+            not set on-ledger (see `Splice.Issuance.getValidatorFaucetCap`).
+          type: string
 
     BatchListVotesByVoteRequestsRequest:
       type: object

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
@@ -369,6 +369,7 @@ class HttpSvPublicHandler(
         amuletRules <- dsoStore.getAssignedAmuletRules()
         rulesAndStates <- dsoStore.getDsoRulesWithStateWithSvNodeStates()
         dsoRules = rulesAndStates.dsoRules
+        issuanceConfig = latestOpenMiningRound.payload.issuanceConfig
       } yield definitions.GetDsoInfoResponse(
         svUser = svUserName,
         svPartyId = svParty.toProtoPrimitive,
@@ -379,6 +380,15 @@ class HttpSvPublicHandler(
         dsoRules = dsoRules.toHttp,
         svNodeStates = rulesAndStates.svNodeStates.values.map(_.toHttp).toVector,
         initialRound = Some(initialRound),
+        validatorRewardCap = Some(Codec.encode(issuanceConfig.validatorRewardCap)),
+        featuredAppRewardCap = Some(Codec.encode(issuanceConfig.featuredAppRewardCap)),
+        unfeaturedAppRewardCap = Some(Codec.encode(issuanceConfig.unfeaturedAppRewardCap)),
+        validatorFaucetCap = Some(
+          Codec.encode(
+            issuanceConfig.optValidatorFaucetCap.toScala
+              .getOrElse(java.math.BigDecimal.valueOf(2.85))
+          )
+        ),
       )
     }
   }


### PR DESCRIPTION
## Summary

`getDsoInfo` (`HttpSvPublicHandler.scala`) already fetches the latest `OpenMiningRound` and `AmuletRules`, but the actual cap values (`validatorRewardCap`, `featuredAppRewardCap`, `unfeaturedAppRewardCap`, and the validator faucet cap from `Splice.Issuance.IssuanceConfig`) were only reachable by manually digging through the raw `amulet_rules` / `latest_mining_round` contract payloads returned by that endpoint.

This adds 4 fields to `GetDsoInfoResponse` (OpenAPI: `apps/common/src/main/openapi/common-internal.yaml`), populated from `latestOpenMiningRound.payload.issuanceConfig` (already fetched, no new store queries), following the same `Codec.encode(...)` pattern used elsewhere for Decimal fields (e.g. `amuletCreateFee` in `HttpScanHandler.scala`). The faucet cap falls back to `2.85` when unset on-ledger, matching `Splice.Issuance.getValidatorFaucetCap`'s default.

New fields are optional (not added to `required`), so this is backward compatible for existing clients.

Fixes #6230

Not locally compiled -- see comment below for why.

## Test plan

- [ ] CI compile
- [ ] Manual: hit `getDsoInfo` on a running SV and confirm the 4 new fields appear with sane values