### PR TITLE
Default SVs to running without BFT sequencer connections

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -419,7 +419,11 @@ case class SvAppBackendConfig(
     delegatelessAutomationUnhideRewardCouponV2BatchSize: Int = 220,
     // configuration to periodically take topology snapshots
     topologySnapshotConfig: Option[PeriodicBackupDumpConfig] = None,
-    bftSequencerConnection: Boolean = true,
+    // Defaults to false to match prod, where BFT sequencer connections for SVs are
+    // not enabled: losing rewards when a node is down already provides the right
+    // incentive, so there isn't a case for SVs relying on BFT sequencer connections
+    // to stay up (#6336).
+    bftSequencerConnection: Boolean = false,
     // Skip synchronizer initialization and synchronizer config reconciliation.
     // Can be safely set to true for an SV that has completed onboarding unless you
     // 1. try to reset one of your sequencers or mediators


### PR DESCRIPTION
## Summary

Flips `SvAppBackendConfig.bftSequencerConnection`'s default from `true` to `false`, matching prod (BFT sequencer connections aren't enabled there) and keeping the right incentive -- an SV already loses rewards when its node is down.

Scoped to just the default flip, not the full removal of BFT sequencer connection support the issue floats as a possible follow-up.

Fixes #6336

Opened as draft, not locally verified -- see comment below for why.

## Test plan

- [ ] CI