### PR TITLE
Start splice rate limiters with the configured no of permits available

### DIFF
--- a/apps/common/src/main/java/com/google/common/util/concurrent/BurstyRateLimiterFactory.java
+++ b/apps/common/src/main/java/com/google/common/util/concurrent/BurstyRateLimiterFactory.java
@@ -6,22 +6,46 @@ package com.google.common.util.concurrent;
 /**
  * Shim that constructs a Guava {@link RateLimiter} backed by {@code SmoothBursty} with a custom
  * maximum burst duration. It lives in this package because the relevant {@code
- * SmoothRateLimiter.SmoothBursty} constructor is package-private.
+ * SmoothRateLimiter.SmoothBursty} constructor and its permit bookkeeping fields are package-private.
+ *
+ * <p>In contrast to {@link RateLimiter#create(double)}, the limiters created here already hold
+ * {@code permitsPerSecond} permits (capped by the maximum burst budget) at creation time, instead of
+ * starting with an empty bucket that only fills up over time. That matters for limiters that are
+ * created lazily (e.g. one per client IP), which would otherwise reject an initial burst that an
+ * already running limiter would have accepted.
  */
 public final class BurstyRateLimiterFactory {
+
+    /**
+     * Guava's default burst window for {@code RateLimiter.create(double)}.
+     */
+    private static final double DEFAULT_MAX_BURST_SECONDS = 1.0;
 
     private BurstyRateLimiterFactory() {
     }
 
     /**
+     * Creates a {@link RateLimiter} allowing {@code permitsPerSecond} permits per second, starting
+     * with {@code permitsPerSecond} permits already available.
+     */
+    public static RateLimiter create(double permitsPerSecond) {
+        return create(permitsPerSecond, DEFAULT_MAX_BURST_SECONDS);
+    }
+
+    /**
      * Creates a bursty {@link RateLimiter} that sustains {@code permitsPerSecond} on average while
      * allowing bursts of up to {@code permitsPerSecond * maxBurstSeconds} permits after idle periods.
+     * The limiter starts with one second worth of permits, i.e. {@code permitsPerSecond} permits
+     * (capped by the maximum burst budget), already available.
      */
     public static RateLimiter create(double permitsPerSecond, double maxBurstSeconds) {
-        RateLimiter rateLimiter =
+        SmoothRateLimiter.SmoothBursty rateLimiter =
                 new SmoothRateLimiter.SmoothBursty(
                         RateLimiter.SleepingStopwatch.createFromSystemTimer(), maxBurstSeconds);
         rateLimiter.setRate(permitsPerSecond);
+        synchronized (rateLimiter) {
+            rateLimiter.storedPermits = Math.min(permitsPerSecond, rateLimiter.maxPermits);
+        }
         return rateLimiter;
     }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
@@ -16,7 +16,6 @@ import org.lfdecentralizedtrust.splice.util.{
 }
 
 import java.net.{Inet6Address, InetAddress}
-import java.time.Instant
 
 class HttpRateLimiter(
     config: RateLimitersConfig,
@@ -46,10 +45,6 @@ class HttpRateLimiter(
       ),
     )
 
-  // the rate limiter has a cold start, to avoid the first request being rejected
-  // we enforce the rate limit only after 1 second
-  private def enforceAfter = Instant.now().plusSeconds(1)
-
   private val globalRateLimiter: (SpliceRateLimiter, PerAttributeRateLimiter) = {
     val globalMetrics = metricsFor(HttpRateLimiter.GlobalService)
     (
@@ -57,7 +52,6 @@ class HttpRateLimiter(
         HttpRateLimiter.GlobalLimiter,
         config.global,
         globalMetrics,
-        enforceAfter,
       ),
       new PerAttributeRateLimiter(
         HttpRateLimiter.GlobalLimiter,
@@ -65,7 +59,6 @@ class HttpRateLimiter(
         config.global,
         config.global.perClientIp,
         globalMetrics,
-        enforceAfter,
         logger,
       ),
     )
@@ -84,7 +77,6 @@ class HttpRateLimiter(
             operation,
             operationConfig,
             rateLimiterMetrics,
-            enforceAfter,
           ),
           new PerAttributeRateLimiter(
             operation,
@@ -92,7 +84,6 @@ class HttpRateLimiter(
             operationConfig,
             operationConfig.perClientIp,
             rateLimiterMetrics,
-            enforceAfter,
             logger,
           ),
         )

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
@@ -16,7 +16,7 @@ import com.github.benmanes.caffeine.cache.{Caffeine, RemovalCause, RemovalListen
 import com.google.common.util.concurrent.{BurstyRateLimiterFactory, RateLimiter}
 import org.lfdecentralizedtrust.splice.environment.SpliceMetrics
 
-import java.time.{Duration, Instant}
+import java.time.Duration
 import java.util
 import java.util.Collections
 import java.util.concurrent.TimeUnit
@@ -131,7 +131,6 @@ class SpliceRateLimiter(
     name: String,
     config: SpliceRateLimitConfig,
     metrics: SpliceRateLimitMetrics,
-    enforceAfter: Instant = Instant.now(),
     limiterType: String = SpliceRateLimiter.GlobalLimiterType,
     extraLabels: Map[String, String] = Map.empty,
     // must be disabled for the per-attribute limiters as they'd all report the same value
@@ -143,13 +142,9 @@ class SpliceRateLimiter(
     extraLabels ++ Map("limiter" -> name, "limiter_type" -> limiterType)
   )
 
-  // The limiters are created eagerly so that they are already "warm" (i.e. have accumulated their
-  // burst budget) by the time the limit starts being enforced. They are only created for enabled
-  // limiters: a disabled limiter is never consulted and its configured rate might not even be a
-  // valid guava rate (e.g. 0).
-  // enforces the per-second burst limit (checked over a 1s window)
+  // The limiters are created with one second worth of permits already available
   private val limiter: Option[RateLimiter] =
-    Option.when(config.enabled)(RateLimiter.create(config.ratePerSecond))
+    Option.when(config.enabled)(BurstyRateLimiterFactory.create(config.ratePerSecond))
   // enforces the sustained limit over the sustained window, while still allowing bursts within its budget.
   private val sustainedLimiter: Option[RateLimiter] =
     Option
@@ -169,7 +164,7 @@ class SpliceRateLimiter(
   }
 
   def markRun(): Boolean = {
-    if (config.enabled && Instant.now().isAfter(enforceAfter)) {
+    if (config.enabled) {
       val canRun = rateLimiter.forall(_.tryAcquire()) && sustainedLimiter.forall(_.tryAcquire())
       if (canRun) {
         metrics.meter.mark()(
@@ -204,7 +199,6 @@ class PerAttributeRateLimiter(
     config: SpliceRateLimitConfig,
     attributeConfig: PerAttributeRateLimitConfig,
     metrics: SpliceRateLimitMetrics,
-    enforceAfter: Instant = Instant.now(),
     logger: TracedLogger,
 ) {
 
@@ -258,7 +252,6 @@ class PerAttributeRateLimiter(
     name,
     perAttributeConfig,
     metrics,
-    enforceAfter,
     limiterType = SpliceRateLimiter.UnknownAttributeLimiterType,
     extraLabels = attributeLabel,
   )
@@ -286,7 +279,6 @@ class PerAttributeRateLimiter(
           name,
           perAttributeConfig,
           metrics,
-          enforceAfter,
           limiterType = SpliceRateLimiter.PerAttributeLimiterType,
           extraLabels = attributeLabel,
           reportMaxLimit = false,

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
@@ -5,7 +5,6 @@ package org.lfdecentralizedtrust.splice.http
 
 import com.daml.metrics.api.testing.InMemoryMetricsFactory
 import com.digitalasset.canton.BaseTest
-import com.digitalasset.canton.concurrent.Threading
 import org.apache.pekko.http.scaladsl.model.headers.{RawHeader, `X-Forwarded-For`, `X-Real-Ip`}
 import org.apache.pekko.http.scaladsl.model.{
   AttributeKeys,
@@ -198,9 +197,10 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       )("testOperation") { routes =>
         val route = routes("testOperation")
         val results = (1 to 20).map(_ => call(route, ip = Some("1.1.1.1")))
-        // 1 request per second per client IP => the burst gets rejected
-        results.count(_ == StatusCodes.OK) should be(1)
-        results.count(_ == StatusCodes.TooManyRequests) should be(19)
+        // 1 request per second per client IP, with 1 permit available from the creation of the
+        // limiter plus guava's deferred payment for the next one => the rest of the burst is rejected
+        results.count(_ == StatusCodes.OK) should be(2)
+        results.count(_ == StatusCodes.TooManyRequests) should be(18)
       }
     }
 
@@ -221,7 +221,10 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
         globalPerClientIp = perClientIp(1)
       )("testOperation") { routes =>
         val route = routes("testOperation")
-        call(route, ip = Some("2001:db8:0:1:1:2:3:4")) should be(StatusCodes.OK)
+        // drain the budget of the /64 network
+        (1 to 20)
+          .map(_ => call(route, ip = Some("2001:db8:0:1:1:2:3:4")))
+          .count(_ == StatusCodes.OK) should be > 0
         // a different address of the same /64 shares the limiter, so it is rejected
         call(route, ip = Some("2001:db8:0:1:ffff:ffff:ffff:ffff")) should be(
           StatusCodes.TooManyRequests
@@ -250,7 +253,9 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       withRoutes(
         globalPerClientIp = perClientIp(1)
       )("operationA", "operationB") { routes =>
-        call(routes("operationA"), ip = Some("1.1.1.1")) should be(StatusCodes.OK)
+        (1 to 20)
+          .map(_ => call(routes("operationA"), ip = Some("1.1.1.1")))
+          .count(_ == StatusCodes.OK) should be > 0
         call(routes("operationB"), ip = Some("1.1.1.1")) should be(StatusCodes.TooManyRequests)
       }
     }
@@ -282,7 +287,7 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       )("limitedOperation", "otherOperation") { routes =>
         val results =
           (1 to 20).map(_ => call(routes("limitedOperation"), ip = Some("1.1.1.1")))
-        results.count(_ == StatusCodes.OK) should be(1)
+        results.count(_ == StatusCodes.OK) should be(2)
         // a different operation is not affected by the per operation client IP limiter
         call(routes("otherOperation"), ip = Some("1.1.1.1")) should be(StatusCodes.OK)
       }
@@ -320,8 +325,6 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
           rateLimiter.withRateLimit("serviceV1")("sharedOperation")(complete(StatusCodes.OK))
         val routeV2 =
           rateLimiter.withRateLimit("serviceV2")("sharedOperation")(complete(StatusCodes.OK))
-        // the rate limiter only starts enforcing 1 second after it got created
-        Threading.sleep(1100)
         (1 to 20)
           .map(_ => call(routeV1, ip = Some("1.1.1.1")))
           .count(_ == StatusCodes.TooManyRequests) should be > 0
@@ -495,8 +498,6 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
           complete(StatusCodes.OK)
         }
       }.toMap
-      // the rate limiter only starts enforcing 1 second after it got created
-      Threading.sleep(1100)
       f(HttpRateLimiterTest.Fixture(routes, metricsFactory))
     } finally {
       rateLimiter.close()

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
@@ -15,7 +15,6 @@ import org.lfdecentralizedtrust.splice.admin.api.client.commands.HttpCommandExce
 import org.lfdecentralizedtrust.splice.util.SpliceRateLimiterTest.runRateLimited
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import java.time.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
@@ -80,6 +79,16 @@ class SpliceRateLimiterTest
 
     }
 
+    "start with the configured rate per second worth of permits" in {
+      withRateLimiter(SpliceRateLimitConfig(ratePerSecond = 10)) { case (_, rateLimiter) =>
+        // the limiter must not have to warm up first: it holds its configured rate worth of permits
+        // (10) right from its creation, plus guava's deferred payment for the next one
+        val results = Seq.fill(50)(rateLimiter.markRun())
+        results.take(11) should contain only true
+        results.count(!_) should be > 35
+      }
+    }
+
     "not create any limiter if disabled" in {
       // a disabled limiter must not fail even for a rate that guava would reject
       withRateLimiter(SpliceRateLimitConfig(enabled = false, ratePerSecond = 0)) {
@@ -118,12 +127,12 @@ class SpliceRateLimiterTest
         SpliceRateLimitConfig(ratePerSecond = 10),
         PerAttributeRateLimitConfig(limit = SpliceRateLimitConfig(ratePerSecond = 1)),
       ) { case (_, perAttributeRateLimiter) =>
-        // 1 per second per attribute value, so a burst is rejected after the first request
         val ip1 = Seq.fill(20)(perAttributeRateLimiter.markRun(Some("1.1.1.1")))
-        ip1.count(identity) should be(1)
-        ip1.count(!_) should be(19)
+        ip1.count(identity) should be(2)
+        ip1.count(!_) should be(18)
 
         // a different attribute value is not affected by the limiter of the first one
+        perAttributeRateLimiter.markRun(Some("2.2.2.2")) should be(true)
         perAttributeRateLimiter.markRun(Some("2.2.2.2")) should be(true)
         perAttributeRateLimiter.markRun(Some("2.2.2.2")) should be(false)
       }
@@ -135,7 +144,7 @@ class SpliceRateLimiterTest
         PerAttributeRateLimitConfig(limit = SpliceRateLimitConfig(ratePerSecond = 1)),
       ) { case (metrics, perAttributeRateLimiter) =>
         val results = Seq.fill(20)(perAttributeRateLimiter.markRun(None))
-        results.count(identity) should be(1)
+        results.count(identity) should be(2)
 
         metrics.meter.valueFilteredOnLabels(
           LabelFilter("limiter", "test"),
@@ -214,10 +223,6 @@ class SpliceRateLimiterTest
       withRateLimiter(
         SpliceRateLimitConfig(ratePerSecond = 1000, sustainedRatePerSecond = Some(10))
       ) { case (_, rateLimiter) =>
-        // The per-second limit is high enough to never reject the throttled input, so the sustained
-        // limiter (10/s) is the binding constraint over the run. The sustained limiter starts with
-        // an empty burst budget (Guava SmoothBursty semantics), so throughput tracks the sustained
-        // rate plus a small initial allowance.
         val results = runRateLimited(40, 120) {
           rateLimiter.runWithLimit(Future.successful(true))
         }.futureValue
@@ -271,8 +276,6 @@ class SpliceRateLimiterTest
       config,
       attributeConfig,
       rateLimitMetrics,
-      // no cold start delay in tests
-      Instant.now().minusSeconds(1),
       logger,
     )
     try {


### PR DESCRIPTION
If not the per IP rate limiters come in to force too aggressive.

[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/9717

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
