### PR TITLE
Bump deduplication cache size to 1000000

### DIFF
--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -104,7 +104,7 @@ mempool:
   # max number of transactions kept in the mempool
   size: 4000
   # number of transactions to keep to deduplicate new transactions
-  deduplicationCacheSize: 200000
+  deduplicationCacheSize: 1000000
   # max number of seconds that a transaction will be kept in the mempool without being included in a block before being discarded
   ttlSeconds: 60
 

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -62,3 +62,6 @@ release-notes:: Upcoming
           ``watchdog.sequencerMetricsUrl: http://global-domain-SERIAL_ID-sequencer:10013/metrics`` and
           ``watchdog.mediatorMetricsUrl: http://global-domain-SERIAL_ID-mediator:10013/metrics`` in the
           cometbft helm values. If needed, the watchdog can be disabled through ``watchdog.enabled: false``.
+
+
+        - Bump the default ``deduplicationCacheSize`` to ``1000000``.


### PR DESCRIPTION
[static]

We already asked everyone to apply that on mainnet so may as well make it the default.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
