### PR TITLE
Improve client ip rate limits

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/RateLimitersConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/RateLimitersConfig.scala
@@ -22,6 +22,13 @@ case class RateLimitersConfig(
       * trusting a proxy header and only rely on `X-Forwarded-For`/`X-Real-Ip`/the remote address.
       */
     trustedClientIpHeader: String = RateLimitersConfig.DefaultTrustedClientIpHeader,
+    /** Whether to fall back to the client-controlled `X-Forwarded-For`/`X-Real-Ip` headers when the
+      * trusted proxy header (see `trustedClientIpHeader`) does not yield a client IP. Enabled by
+      * default. Set to `false` in deployments where a trusted proxy always sets
+      * `trustedClientIpHeader`, so that clients cannot influence the extracted IP - and thereby the
+      * per-client-IP rate limiting - by forging these spoofable headers.
+      */
+    enableClientProvidedIpHeaders: Boolean = true,
 ) {
   def forRateLimiter(name: String): SpliceRateLimitConfig.WithPerClientIp =
     rateLimiters.getOrElse(name, default)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/ClientIpDirectives.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/ClientIpDirectives.scala
@@ -15,19 +15,27 @@ object ClientIpDirectives {
     * The address is taken from the first of the following sources that yields an address:
     *   1. the `trustedClientIpHeader` (if configured and parseable as an IP literal), which is set
     *      by a trusted reverse proxy and hence cannot be spoofed by the client,
-    *   1. the client-controlled `X-Forwarded-For` header,
-    *   1. the client-controlled `X-Real-Ip` header,
+    *   1. the client-controlled `X-Forwarded-For` header (unless disabled),
+    *   1. the client-controlled `X-Real-Ip` header (unless disabled),
     *
     * @param trustedClientIpHeader
     *   name of the header set by a trusted reverse proxy, matched case-insensitively. An empty name
     *   disables trusting a proxy header.
+    * @param enableClientProvidedIpHeaders
+    *   whether to fall back to the client-controlled `X-Forwarded-For`/`X-Real-Ip` headers when the
+    *   trusted proxy header does not yield an address. Set to `false` to only rely on the trusted
+    *   proxy header, so that clients cannot influence the extracted address by forging these headers.
     */
-  def extractClientIp(trustedClientIpHeader: String): Directive1[Option[RemoteAddress]] =
-    firstDefined(
-      trustedClientIp(trustedClientIpHeader),
-      forwardedForClientIp,
-      realIpClientIp,
-    )
+  def extractClientIp(
+      trustedClientIpHeader: String,
+      enableClientProvidedIpHeaders: Boolean,
+  ): Directive1[Option[RemoteAddress]] = {
+    val clientProvidedSources: Seq[Directive1[Option[RemoteAddress]]] =
+      if (enableClientProvidedIpHeaders) Seq(forwardedForClientIp, realIpClientIp)
+      else Seq.empty
+    val sources = trustedClientIp(trustedClientIpHeader) +: clientProvidedSources
+    firstDefined(sources*)
+  }
 
   private def trustedClientIp(headerName: String): Directive1[Option[RemoteAddress]] = {
     val trimmedHeaderName = headerName.trim

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
@@ -96,29 +96,31 @@ class HttpRateLimiter(
 
     import org.apache.pekko.http.scaladsl.server.Directives.*
 
-    HttpRateLimiter.extractClientIpKey(trustedClientIpHeader).flatMap { clientIp =>
-      // The per client IP limiters are checked first (and `&&` short-circuits) so that a request
-      // rejected because of its own client IP does not consume budget from the shared overall
-      // limiters. Otherwise a single abusive client could exhaust the overall limits and thereby
-      // deny service to all other clients.
-      // Within each of those two groups the narrower per operation limiter is checked before the
-      // global one, so that a request rejected for its operation does not consume global budget.
-      val allowed =
-        operationClientIpLimiter.markRun(clientIp) &&
-          globalClientIpLimiter.markRun(clientIp) &&
-          operationLimiter.markRun() &&
-          globalLimiter.markRun()
-      if (allowed) {
-        pass
-      } else {
-        complete(
-          StatusCodes.TooManyRequests,
-          HttpEntity(
-            "Too Many Requests: Server is busy, please try again later."
-          ),
-        )
+    HttpRateLimiter
+      .extractClientIpKey(trustedClientIpHeader, config.enableClientProvidedIpHeaders)
+      .flatMap { clientIp =>
+        // The per client IP limiters are checked first (and `&&` short-circuits) so that a request
+        // rejected because of its own client IP does not consume budget from the shared overall
+        // limiters. Otherwise a single abusive client could exhaust the overall limits and thereby
+        // deny service to all other clients.
+        // Within each of those two groups the narrower per operation limiter is checked before the
+        // global one, so that a request rejected for its operation does not consume global budget.
+        val allowed =
+          operationClientIpLimiter.markRun(clientIp) &&
+            globalClientIpLimiter.markRun(clientIp) &&
+            operationLimiter.markRun() &&
+            globalLimiter.markRun()
+        if (allowed) {
+          pass
+        } else {
+          complete(
+            StatusCodes.TooManyRequests,
+            HttpEntity(
+              "Too Many Requests: Server is busy, please try again later."
+            ),
+          )
+        }
       }
-    }
   }
 
   def close(): Unit = metrics.view.values.foreach(_.close())
@@ -132,10 +134,11 @@ object HttpRateLimiter {
   private[splice] val GlobalService = "global"
 
   private[splice] def extractClientIpKey(
-      trustedClientIpHeader: String = RateLimitersConfig.DefaultTrustedClientIpHeader
+      trustedClientIpHeader: String = RateLimitersConfig.DefaultTrustedClientIpHeader,
+      enableClientProvidedIpHeaders: Boolean,
   ): Directive1[Option[String]] =
     ClientIpDirectives
-      .extractClientIp(trustedClientIpHeader)
+      .extractClientIp(trustedClientIpHeader, enableClientProvidedIpHeaders)
       .map(_.collect { case RemoteAddress.IP(ip, _) => rateLimitKey(ip) })
 
   /** Single clients are typically assigned a whole IPv6 /64 (or larger) network, so limiting per

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
@@ -41,6 +41,17 @@ case class SpliceRateLimitMetrics(
     )
   )
 
+  val unknownAttributeNotLimited: MetricHandle.Meter = otelFactory.meter(
+    MetricInfo(
+      SpliceMetrics.MetricsPrefix :+ "rate_limiting_unknown_attribute_not_limited",
+      "Number of requests not rate limited by a per-attribute limiter because the attribute value is unknown",
+      Saturation,
+    )
+  )
+
+  def recordUnknownAttributeNotLimited()(implicit extraMc: MetricsContext): Unit =
+    unknownAttributeNotLimited.mark()(mc.merge(extraMc))
+
   /*we need to pass the full context when we create it to avoid duplicate values warnings*/
   def recordMaxLimit(limit: Double)(implicit extraMc: MetricsContext): Unit = {
     val createdGauge = otelFactory.gauge[Double](
@@ -118,7 +129,6 @@ object SpliceRateLimiter {
 
   val GlobalLimiterType = "global"
   val PerAttributeLimiterType = "per-attribute"
-  val UnknownAttributeLimiterType = "unknown-attribute"
 
   val DefaultSustainedWindowSeconds: Long = 60
 
@@ -248,14 +258,6 @@ class PerAttributeRateLimiter(
     Some(new CacheMetrics(s"$name-$attribute-rate-limiter", metrics.otelFactory)),
   )
 
-  private lazy val defaultRateLimiter = new SpliceRateLimiter(
-    name,
-    perAttributeConfig,
-    metrics,
-    limiterType = SpliceRateLimiter.UnknownAttributeLimiterType,
-    extraLabels = attributeLabel,
-  )
-
   private lazy val reportedMaxLimit: Unit =
     metrics.recordMaxLimit(perAttributeConfig.ratePerSecond)(
       MetricsContext(
@@ -267,7 +269,19 @@ class PerAttributeRateLimiter(
     )
 
   def markRun(attributeValue: Option[String]): Boolean =
-    if (isEnabled) attributeValue.fold(defaultRateLimiter)(limiterFor).markRun()
+    if (isEnabled) attributeValue match {
+      case Some(value) => limiterFor(value).markRun()
+      case None =>
+        metrics.recordUnknownAttributeNotLimited()(
+          MetricsContext(
+            attributeLabel ++ Map(
+              "limiter" -> name,
+              "limiter_type" -> SpliceRateLimiter.PerAttributeLimiterType,
+            )
+          )
+        )
+        true
+    }
     else true
 
   private def limiterFor(attributeValue: String): SpliceRateLimiter = {

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
@@ -84,6 +84,27 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       ) should be(Some("1.1.1.1"))
     }
 
+    "not fall back to client-provided headers when they are disabled" in {
+      clientIp(
+        HttpRequest().withHeaders(
+          RawHeader("X-Envoy-External-Address", "4.4.4.4"),
+          `X-Forwarded-For`(RemoteAddress(InetAddress.getByName("1.1.1.1"))),
+          `X-Real-Ip`(RemoteAddress(InetAddress.getByName("2.2.2.2"))),
+        ),
+        enableClientProvidedIpHeaders = false,
+      ) should be(Some("4.4.4.4"))
+    }
+
+    "return None when client-provided headers are disabled and no trusted header is present" in {
+      clientIp(
+        HttpRequest().withHeaders(
+          `X-Forwarded-For`(RemoteAddress(InetAddress.getByName("1.1.1.1"))),
+          `X-Real-Ip`(RemoteAddress(InetAddress.getByName("2.2.2.2"))),
+        ),
+        enableClientProvidedIpHeaders = false,
+      ) should be(None)
+    }
+
     "prefer X-Forwarded-For" in {
       clientIp(
         HttpRequest()
@@ -234,17 +255,14 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       }
     }
 
-    "fall back to the default limiter if no client IP is known" in {
+    "not apply the per client IP limiter if no client IP is known" in {
       withRoutes(
         globalPerClientIp = perClientIp(1)
       )("testOperation") { routes =>
         val route = routes("testOperation")
-        call(route, ip = None) should be(StatusCodes.OK)
-        (1 to 20)
-          .map(_ => call(route, ip = None))
-          .count(_ == StatusCodes.TooManyRequests) should be > 0
-        // a request with a client IP uses a different limiter
+        (1 to 20).map(_ => call(route, ip = None)) should contain only StatusCodes.OK
         call(route, ip = Some("1.1.1.1")) should be(StatusCodes.OK)
+        call(route, ip = Some("1.1.1.1")) should be(StatusCodes.TooManyRequests)
       }
     }
 
@@ -438,10 +456,13 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
   private def clientIp(
       request: HttpRequest,
       trustedClientIpHeader: String = RateLimitersConfig.DefaultTrustedClientIpHeader,
+      enableClientProvidedIpHeaders: Boolean = true,
   ): Option[String] = {
-    val route = HttpRateLimiter.extractClientIpKey(trustedClientIpHeader) { extracted =>
-      complete(extracted.getOrElse[String](HttpRateLimiterTest.NoClientIp))
-    }
+    val route =
+      HttpRateLimiter.extractClientIpKey(trustedClientIpHeader, enableClientProvidedIpHeaders) {
+        extracted =>
+          complete(extracted.getOrElse[String](HttpRateLimiterTest.NoClientIp))
+      }
     request ~> route ~> check {
       status should be(StatusCodes.OK)
       Some(responseAs[String]).filterNot(_ == HttpRateLimiterTest.NoClientIp)

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
@@ -261,8 +261,9 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       )("testOperation") { routes =>
         val route = routes("testOperation")
         (1 to 20).map(_ => call(route, ip = None)) should contain only StatusCodes.OK
-        call(route, ip = Some("1.1.1.1")) should be(StatusCodes.OK)
-        call(route, ip = Some("1.1.1.1")) should be(StatusCodes.TooManyRequests)
+        val results = (1 to 20).map(_ => call(route, ip = Some("1.1.1.1")))
+        results.count(_ == StatusCodes.OK) should be(2)
+        results.count(_ == StatusCodes.TooManyRequests) should be(18)
       }
     }
 

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
@@ -138,22 +138,27 @@ class SpliceRateLimiterTest
       }
     }
 
-    "use a single default limiter if the attribute value is unknown" in {
+    "not limit requests with an unknown attribute value" in {
       withPerAttributeRateLimiter(
         SpliceRateLimitConfig(ratePerSecond = 10),
         PerAttributeRateLimitConfig(limit = SpliceRateLimitConfig(ratePerSecond = 1)),
       ) { case (metrics, perAttributeRateLimiter) =>
+        // requests without an attribute value are not rate limited here; the overall/global
+        // rate limiter is relied upon to bound them instead
         val results = Seq.fill(20)(perAttributeRateLimiter.markRun(None))
-        results.count(identity) should be(2)
+        results.count(identity) should be(20)
 
-        metrics.meter.valueFilteredOnLabels(
+        metrics.unknownAttributeNotLimited.valueFilteredOnLabels(
           LabelFilter("limiter", "test"),
           LabelFilter("limiter_attribute", "test_attribute"),
-          LabelFilter("limiter_type", SpliceRateLimiter.UnknownAttributeLimiterType),
-          LabelFilter("result", "rejected"),
-        ) should be(results.count(!_))
+          LabelFilter("limiter_type", SpliceRateLimiter.PerAttributeLimiterType),
+        ) should be(20)
 
-        // requests with a known attribute value are not affected by the default limiter
+        metrics.meter.valuesWithContext.keys
+          .flatMap(_.labels.get("limiter_attribute"))
+          .toSeq should be(empty)
+
+        // requests with a known attribute value are still limited
         perAttributeRateLimiter.markRun(Some("1.1.1.1")) should be(true)
       }
     }
@@ -177,7 +182,7 @@ class SpliceRateLimiterTest
           LabelFilter("limiter_type", SpliceRateLimiter.PerAttributeLimiterType),
           LabelFilter("result", "rejected"),
         ) should be(results.count(!_))
-        // no metrics are reported for the default limiter of unknown attribute values
+        // only per attribute limiters report metrics
         metrics.meter.valuesWithContext.keys
           .flatMap(_.labels.get("limiter_type"))
           .toSet should be(Set(SpliceRateLimiter.PerAttributeLimiterType))

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -42,6 +42,10 @@ release-notes:: Upcoming
              and cannot be spoofed by clients. Otherwise, clients may bypass per-client-IP limits or
              cause other clients to be throttled by forging these headers.
 
+          The fallback to the client-controlled ``X-Forwarded-For``/ ``X-Real-Ip`` headers can be
+          disabled by setting ``rate-limiting.enable-client-provided-ip-headers`` to ``false``.
+          If no IP can be extracted no per IP rate limit is enforced.
+
         - Default rate limits have been adjusted:
 
           - Scan app: the per-operation burst limit has been lowered from 200 to 100 requests per


### PR DESCRIPTION
Add ability to disable fallback for headers
Remove default rate limit when no ip is known and instead just count it through a metric (we count on the global rate limiter to avoid SVs that don't extract the ip correctly to just rate limit everyone more aggressivly)

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
