### PR TITLE
Introduce optional use of ComputeClasses

### DIFF
--- a/cluster/pulumi/canton-network/src/chaosMesh.ts
+++ b/cluster/pulumi/canton-network/src/chaosMesh.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   clusterYamlConfig,
   DecentralizedSynchronizerUpgradeConfig,
   GCP_PROJECT,
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraAndAppsKubernetesSchedulingForDaemonSets,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 import { Resource } from '@pulumi/pulumi';
 import { z } from 'zod';
@@ -211,35 +212,18 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
       },
       values: {
         controllerManager: {
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         chaosDaemon: {
-          ...infraAffinityAndTolerations,
-          // the chaos-daemon needs to run on the apps nodes to be able to inject latency
-          tolerations: [
-            ...infraAffinityAndTolerations.tolerations,
-            ...appsAffinityAndTolerations.tolerations,
-          ],
-          affinity: {
-            nodeAffinity: {
-              requiredDuringSchedulingIgnoredDuringExecution: {
-                nodeSelectorTerms: [
-                  ...infraAffinityAndTolerations.affinity.nodeAffinity
-                    .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
-                  ...appsAffinityAndTolerations.affinity.nodeAffinity
-                    .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
-                ],
-              },
-            },
-          },
+          ...infraAndAppsKubernetesSchedulingForDaemonSets,
           runtime: 'containerd',
           socketPath: '/run/containerd/containerd.sock',
         },
         dashboard: {
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         dnsServer: {
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         maxHistory: HELM_MAX_HISTORY_SIZE,
       },

--- a/cluster/pulumi/circleci/src/index.ts
+++ b/cluster/pulumi/circleci/src/index.ts
@@ -4,10 +4,10 @@ import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import {
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   ChartValues,
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 import { spliceEnvConfig } from '@canton-network/splice-pulumi-common/src/config/envConfig';
 import { Namespace } from '@pulumi/kubernetes/core/v1';
@@ -166,7 +166,7 @@ function resourceClass(
           },
         },
       ],
-      ...appsAffinityAndTolerations,
+      ...appsKubernetesScheduling,
     },
   };
 }
@@ -221,7 +221,7 @@ new k8s.helm.v3.Release('container-agent', {
           memory: '512Mi',
         },
       },
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
       maxHistory: HELM_MAX_HISTORY_SIZE,
     },
   },

--- a/cluster/pulumi/cluster/src/config.ts
+++ b/cluster/pulumi/cluster/src/config.ts
@@ -10,7 +10,9 @@ const GkeNodePoolConfigSchema = z.object({
   bootDiskSizeGb: z.number().optional(),
   zones: z.literal('*').or(z.array(z.string())).optional(),
   labels: z.record(z.string(), z.string()).optional(),
+  priority: z.number().optional(),
 });
+
 const GkeClusterConfigSchema = z.object({
   nodePools: z.object({
     infra: GkeNodePoolConfigSchema,

--- a/cluster/pulumi/cluster/src/fluentBit.ts
+++ b/cluster/pulumi/cluster/src/fluentBit.ts
@@ -6,6 +6,7 @@ import {
   CLUSTER_NAME,
   exactNamespace,
   GCP_REGION,
+  infraAndAppsKubernetesSchedulingForDaemonSets,
   infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 
@@ -14,7 +15,7 @@ export function installFluentBit(): void {
   const fluentBit = exactNamespace('fluent-bit');
 
   const values = {
-    tolerations: infraKubernetesScheduling.tolerations.concat(appsKubernetesScheduling.tolerations),
+    ...infraAndAppsKubernetesSchedulingForDaemonSets,
     config: {
       inputs: [
         // Input config is roughly copied from the default GCP config available from `kubectl get configmap -n kube-system fluentbit-gke-config-v1.4.0 -o yaml`

--- a/cluster/pulumi/cluster/src/fluentBit.ts
+++ b/cluster/pulumi/cluster/src/fluentBit.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   CLUSTER_NAME,
   exactNamespace,
   GCP_REGION,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 
 export function installFluentBit(): void {
@@ -14,9 +14,7 @@ export function installFluentBit(): void {
   const fluentBit = exactNamespace('fluent-bit');
 
   const values = {
-    tolerations: infraAffinityAndTolerations.tolerations.concat(
-      appsAffinityAndTolerations.tolerations
-    ),
+    tolerations: infraKubernetesScheduling.tolerations.concat(appsKubernetesScheduling.tolerations),
     config: {
       inputs: [
         // Input config is roughly copied from the default GCP config available from `kubectl get configmap -n kube-system fluentbit-gke-config-v1.4.0 -o yaml`

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
 import {
   config,
   GCP_PROJECT,
@@ -69,11 +70,16 @@ type NodeConfigLabelsAndTaints = Pick<
   'labels' | 'taints'
 >;
 
+interface NodePoolWithConfig {
+  pool: gcp.container.NodePool;
+  config: GkeNodePoolConfig;
+}
+
 function installAppsNodePools(
   cluster: string,
   allZones: string[],
   configs: Array<GkeNodePoolConfig>
-): Array<gcp.container.NodePool> {
+): Array<NodePoolWithConfig> {
   const defaultZone = config.optionalEnv('CLOUDSDK_HYPERDISK_NODEPOOL_COMPUTE_ZONE');
   return configs.map((config, index) => {
     const name =
@@ -110,7 +116,7 @@ function installAppsNodePools(
             ...config.labels,
           },
         };
-    return new gcp.container.NodePool(
+    const pool = new gcp.container.NodePool(
       name,
       {
         cluster,
@@ -134,6 +140,7 @@ function installAppsNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
+    return { pool, config };
   });
 }
 
@@ -142,7 +149,7 @@ function installInfraNodePools(
   allZones: string[],
   defaultZone: string | undefined,
   configs: Array<GkeNodePoolConfig>
-): Array<gcp.container.NodePool> {
+): Array<NodePoolWithConfig> {
   return configs.map((config, index) => {
     const name =
       index === 0
@@ -179,7 +186,7 @@ function installInfraNodePools(
           },
         };
 
-    return new gcp.container.NodePool(
+    const pool = new gcp.container.NodePool(
       name,
       {
         cluster,
@@ -199,13 +206,30 @@ function installInfraNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
+    return { pool, config };
   });
 }
 
 function installComputeClass(
   name: string,
-  pools: gcp.container.NodePool[]
+  pools: NodePoolWithConfig[]
 ): k8s.apiextensions.CustomResource {
+  // Group node pools by their configured priority.
+  // Priority defaults to -index (so that the first pool is highest priority, second is next, etc),
+  // and any explicitly set positive priority will be sorted above the defaulted ones.
+  const byPriority = new Map<number, pulumi.Input<string>[]>();
+  pools.forEach(({ pool, config: poolConfig }, index) => {
+    const priority = poolConfig.priority ?? -index;
+    const group = byPriority.get(priority) ?? [];
+    group.push(pool.name);
+    byPriority.set(priority, group);
+  });
+
+  // Sort by descending priority (highest first) and emit one entry per group.
+  const priorities = [...byPriority.entries()]
+    .sort(([a], [b]) => b - a)
+    .map(([, nodepools]) => ({ nodepools }));
+
   return new k8s.apiextensions.CustomResource(
     `compute-class-${name}`,
     {
@@ -213,14 +237,12 @@ function installComputeClass(
       kind: 'ComputeClass',
       metadata: { name },
       spec: {
-        // Reference the existing, manually-managed node pools rather than
-        // letting GKE auto-provision. Priorities are evaluated in order.
-        priorities: pools.map(p => ({ nodepools: [p.name] })),
+        priorities,
         nodePoolAutoCreation: { enabled: false },
       },
     },
     {
-      dependsOn: pools,
+      dependsOn: pools.map(({ pool }) => pool),
     }
   );
 }

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -12,11 +12,6 @@ import {
 
 import { gkeClusterConfig, GkeNodePoolConfig } from './config';
 
-interface NamedNodePool {
-  name: string;
-  pool: gcp.container.NodePool;
-}
-
 export async function installNodePools(): Promise<void> {
   const clusterName = `cn-${config.requireEnv('GCP_CLUSTER_BASENAME')}net`;
   const cluster = config.optionalEnv('CLOUDSDK_COMPUTE_ZONE')
@@ -69,27 +64,40 @@ export async function installNodePools(): Promise<void> {
   }
 }
 
+type NodeConfigLabelsAndTaints = Pick<
+  gcp.types.input.container.NodePoolNodeConfig,
+  'labels' | 'taints'
+>;
+
 function installAppsNodePools(
   cluster: string,
   allZones: string[],
   configs: Array<GkeNodePoolConfig>
-): Array<NamedNodePool> {
+): Array<gcp.container.NodePool> {
   const defaultZone = config.optionalEnv('CLOUDSDK_HYPERDISK_NODEPOOL_COMPUTE_ZONE');
   return configs.map((config, index) => {
     const name =
       index === 0
         ? 'cn-apps-node-pool-hd' // for backwards compat
         : `cn-apps-node-pool-${index}-hd`;
-    const pool = new gcp.container.NodePool(
-      name,
-      {
-        cluster,
-        nodeConfig: {
-          machineType: config.nodeType,
-          bootDisk: {
-            diskType: 'hyperdisk-balanced',
-            sizeGb: config.bootDiskSizeGb || 100,
+    // With ComputeClasses, we rely on the `cloud.google.com/compute-class` label only.
+    // That label *must* be present for the ComputeClass use the node pool, even
+    // if it's explicitly mentioned in the ComputeClass priorities.
+    const labelsAndTaints: NodeConfigLabelsAndTaints = useComputeClasses
+      ? {
+          taints: [
+            {
+              effect: 'NO_SCHEDULE',
+              key: 'cloud.google.com/compute-class',
+              value: appsComputeClassName,
+            },
+          ],
+          labels: {
+            'cloud.google.com/compute-class': appsComputeClassName,
+            ...config.labels,
           },
+        }
+      : {
           taints: [
             {
               effect: 'NO_SCHEDULE',
@@ -101,6 +109,18 @@ function installAppsNodePools(
             cn_apps: 'hyperdisk',
             ...config.labels,
           },
+        };
+    return new gcp.container.NodePool(
+      name,
+      {
+        cluster,
+        nodeConfig: {
+          machineType: config.nodeType,
+          bootDisk: {
+            diskType: 'hyperdisk-balanced',
+            sizeGb: config.bootDiskSizeGb || 100,
+          },
+          ...labelsAndTaints,
           loggingVariant: 'DEFAULT',
         },
         nodeLocations:
@@ -114,7 +134,6 @@ function installAppsNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
-    return { name, pool };
   });
 }
 
@@ -123,18 +142,31 @@ function installInfraNodePools(
   allZones: string[],
   defaultZone: string | undefined,
   configs: Array<GkeNodePoolConfig>
-): Array<NamedNodePool> {
+): Array<gcp.container.NodePool> {
   return configs.map((config, index) => {
     const name =
       index === 0
         ? 'cn-infra-node-pool' // for backwards compat
         : `cn-infra-node-pool-${index}`;
-    const pool = new gcp.container.NodePool(
-      name,
-      {
-        cluster,
-        nodeConfig: {
-          machineType: config.nodeType,
+
+    // With ComputeClasses, we rely on the `cloud.google.com/compute-class` label only.
+    // That label *must* be present for the ComputeClass use the node pool, even
+    // if it's explicitly mentioned in the ComputeClass priorities.
+    const labelsAndTaints: NodeConfigLabelsAndTaints = useComputeClasses
+      ? {
+          taints: [
+            {
+              effect: 'NO_SCHEDULE',
+              key: 'cloud.google.com/compute-class',
+              value: infraComputeClassName,
+            },
+          ],
+          labels: {
+            'cloud.google.com/compute-class': infraComputeClassName,
+            ...config.labels,
+          },
+        }
+      : {
           taints: [
             {
               effect: 'NO_SCHEDULE',
@@ -145,6 +177,15 @@ function installInfraNodePools(
           labels: {
             cn_infra: 'true',
           },
+        };
+
+    return new gcp.container.NodePool(
+      name,
+      {
+        cluster,
+        nodeConfig: {
+          machineType: config.nodeType,
+          ...labelsAndTaints,
           loggingVariant: 'DEFAULT',
         },
         nodeLocations:
@@ -158,13 +199,12 @@ function installInfraNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
-    return { name, pool };
   });
 }
 
 function installComputeClass(
   name: string,
-  pools: NamedNodePool[]
+  pools: gcp.container.NodePool[]
 ): k8s.apiextensions.CustomResource {
   return new k8s.apiextensions.CustomResource(
     `compute-class-${name}`,
@@ -180,7 +220,7 @@ function installComputeClass(
       },
     },
     {
-      dependsOn: pools.map(p => p.pool),
+      dependsOn: pools,
     }
   );
 }

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -1,9 +1,21 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as gcp from '@pulumi/gcp';
-import { config, GCP_PROJECT } from '@canton-network/splice-pulumi-common';
+import * as k8s from '@pulumi/kubernetes';
+import {
+  config,
+  GCP_PROJECT,
+  appsComputeClassName,
+  infraComputeClassName,
+  useComputeClasses,
+} from '@canton-network/splice-pulumi-common';
 
 import { gkeClusterConfig, GkeNodePoolConfig } from './config';
+
+interface NamedNodePool {
+  name: string;
+  pool: gcp.container.NodePool;
+}
 
 export async function installNodePools(): Promise<void> {
   const clusterName = `cn-${config.requireEnv('GCP_CLUSTER_BASENAME')}net`;
@@ -15,11 +27,11 @@ export async function installNodePools(): Promise<void> {
   });
   const nodePoolComputeZone = config.optionalEnv('CLOUDSDK_NODEPOOL_COMPUTE_ZONE');
 
-  installAppsNodePools(cluster, zones.names, [
+  const appPools = installAppsNodePools(cluster, zones.names, [
     gkeClusterConfig.nodePools.apps,
     ...gkeClusterConfig.nodePools.additionalApps,
   ]);
-  installInfraNodePools(cluster, zones.names, nodePoolComputeZone, [
+  const infraPools = installInfraNodePools(cluster, zones.names, nodePoolComputeZone, [
     gkeClusterConfig.nodePools.infra,
     ...gkeClusterConfig.nodePools.additionalInfra,
   ]);
@@ -50,20 +62,25 @@ export async function installNodePools(): Promise<void> {
       replaceOnChanges: ['nodeConfig.machineType'],
     }
   );
+
+  if (useComputeClasses) {
+    installComputeClass(appsComputeClassName, appPools);
+    installComputeClass(infraComputeClassName, infraPools);
+  }
 }
 
 function installAppsNodePools(
   cluster: string,
   allZones: string[],
   configs: Array<GkeNodePoolConfig>
-): Array<gcp.container.NodePool> {
+): Array<NamedNodePool> {
   const defaultZone = config.optionalEnv('CLOUDSDK_HYPERDISK_NODEPOOL_COMPUTE_ZONE');
   return configs.map((config, index) => {
     const name =
       index === 0
         ? 'cn-apps-node-pool-hd' // for backwards compat
         : `cn-apps-node-pool-${index}-hd`;
-    return new gcp.container.NodePool(
+    const pool = new gcp.container.NodePool(
       name,
       {
         cluster,
@@ -97,6 +114,7 @@ function installAppsNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
+    return { name, pool };
   });
 }
 
@@ -105,13 +123,13 @@ function installInfraNodePools(
   allZones: string[],
   defaultZone: string | undefined,
   configs: Array<GkeNodePoolConfig>
-): Array<gcp.container.NodePool> {
+): Array<NamedNodePool> {
   return configs.map((config, index) => {
     const name =
       index === 0
         ? 'cn-infra-node-pool' // for backwards compat
         : `cn-infra-node-pool-${index}`;
-    return new gcp.container.NodePool(
+    const pool = new gcp.container.NodePool(
       name,
       {
         cluster,
@@ -140,7 +158,31 @@ function installInfraNodePools(
         replaceOnChanges: ['nodeConfig.machineType'],
       }
     );
+    return { name, pool };
   });
+}
+
+function installComputeClass(
+  name: string,
+  pools: NamedNodePool[]
+): k8s.apiextensions.CustomResource {
+  return new k8s.apiextensions.CustomResource(
+    `compute-class-${name}`,
+    {
+      apiVersion: 'cloud.google.com/v1',
+      kind: 'ComputeClass',
+      metadata: { name },
+      spec: {
+        // Reference the existing, manually-managed node pools rather than
+        // letting GKE auto-provision. Priorities are evaluated in order.
+        priorities: pools.map(p => ({ nodepools: [p.name] })),
+        nodePoolAutoCreation: { enabled: false },
+      },
+    },
+    {
+      dependsOn: pools.map(p => p.pool),
+    }
+  );
 }
 
 function autoscalingConfigOf(config: GkeNodePoolConfig): gcp.container.NodePoolArgs['autoscaling'] {

--- a/cluster/pulumi/common-sv/src/sv.ts
+++ b/cluster/pulumi/common-sv/src/sv.ts
@@ -6,7 +6,7 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   activeVersion,
   ansDomainPrefix,
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   Auth0Client,
   btoa,
   ChartValues,
@@ -697,7 +697,7 @@ function installSvApp(
       dependsOn: dependsOn.concat([postgres]).concat(allSynchronizerDependencies),
     },
     undefined,
-    appsAffinityAndTolerations
+    appsKubernetesScheduling
   );
 }
 

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 import * as _ from 'lodash';
 import {
   activeVersion,
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   ChartValues,
   CLUSTER_BASENAME,
   CLUSTER_HOSTNAME,
@@ -164,7 +164,7 @@ export function installCometBftNode(
       protect: disableProtection ? false : protectCometBft,
     },
     true,
-    appsAffinityAndTolerations
+    appsKubernetesScheduling
   );
   return { rpcServiceName: `${nodeConfig.identifier}-cometbft-rpc`, release };
 }

--- a/cluster/pulumi/common/src/config/configSchema.ts
+++ b/cluster/pulumi/common/src/config/configSchema.ts
@@ -37,6 +37,14 @@ export const ConfigSchema = z.object({
         PulumiProjectConfigSchema.extend({ cloudSql: CloudSqlConfigSchema.partial() }).partial()
       )
     ),
+  // Settings that affect both how node pools are created and how pods are deployed
+  // (e.g, how we set labels/taints). Since these are implemented in different pulumi projects,
+  // we need to have a common config schema for them.
+  kubernetesScheduling: z.object({
+    computeClasses: z.object({
+      enabled: z.boolean().default(false),
+    }),
+  }),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/cluster/pulumi/common/src/config/configSchema.ts
+++ b/cluster/pulumi/common/src/config/configSchema.ts
@@ -40,11 +40,15 @@ export const ConfigSchema = z.object({
   // Settings that affect both how node pools are created and how pods are deployed
   // (e.g, how we set labels/taints). Since these are implemented in different pulumi projects,
   // we need to have a common config schema for them.
-  kubernetesScheduling: z.object({
-    computeClasses: z.object({
-      enabled: z.boolean().default(false),
-    }),
-  }),
+  kubernetesScheduling: z
+    .object({
+      computeClasses: z
+        .object({
+          enabled: z.boolean().default(false),
+        })
+        .prefault({}),
+    })
+    .prefault({}),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/cluster/pulumi/common/src/helm.ts
+++ b/cluster/pulumi/common/src/helm.ts
@@ -228,29 +228,7 @@ export const appsComputeClassName = 'cn-apps';
 export const infraComputeClassName = 'cn-infra';
 
 const appsKubernetesSchedulingComputeClass = {
-  // A nodeSelector is a simpler way to select a single ComputeClass.
-  // We still use nodeAffinity for better compatibility with other parts of the code.
-  // As long as the node affinity is a single term, it *should* trigger the ComputeClass
-  // mechanism for scaling up nodes.
-  // nodeSelector: {'cloud.google.com/compute-class': appsComputeClassName},
-  affinity: {
-    nodeAffinity: {
-      requiredDuringSchedulingIgnoredDuringExecution: {
-        nodeSelectorTerms: [
-          {
-            matchExpressions: [
-              {
-                key: 'cloud.google.com/compute-class',
-                operator: 'In',
-                values: [appsComputeClassName],
-              },
-            ],
-          },
-        ],
-      },
-    },
-  },
-  tolerations: [{ key: 'cn_apps', operator: 'Exists', effect: 'NoSchedule' }],
+  nodeSelector: { 'cloud.google.com/compute-class': appsComputeClassName },
 };
 
 const appsKubernetesSchedulingAffinityTolerations = {
@@ -293,11 +271,13 @@ export const appsKubernetesScheduling = useComputeClasses
   : appsKubernetesSchedulingAffinityTolerations;
 
 export const infraKubernetesSchedulingComputeClass = {
-  // A nodeSelector is a simpler way to select a single ComputeClass.
-  // We still use nodeAffinity for better compatibility with other parts of the code.
-  // As long as the node affinity is a single term, it *should* trigger the ComputeClass
-  // mechanism for scaling up nodes.
-  // nodeSelector: {'cloud.google.com/compute-class': infraComputeClassName},
+  nodeSelector: { 'cloud.google.com/compute-class': infraComputeClassName },
+};
+
+// This should have the same effect as infraKubernetesSchedulingComputeClass,
+// but uses affinity instead of nodeSelector. It's not the documented way to use
+// compute classes, but can be used for helm charts that do not support node selectors.
+export const infraKubernetesSchedulingComputeClassViaAffinity = {
   affinity: {
     nodeAffinity: {
       requiredDuringSchedulingIgnoredDuringExecution: {
@@ -315,7 +295,6 @@ export const infraKubernetesSchedulingComputeClass = {
       },
     },
   },
-  tolerations: [{ key: 'cn_infra', operator: 'Exists', effect: 'NoSchedule' }],
 };
 
 export const infraKubernetesSchedulingAffinityTolerations = {
@@ -352,30 +331,21 @@ export const infraKubernetesScheduling = useComputeClasses
 // Values that determine how daemons are scheduled that need to run on BOTH apps and infra nodes.
 export const infraAndAppsKubernetesSchedulingForDaemonSets = useComputeClasses
   ? {
-      // A pod can only pick a single ComputeClass via a nodeSelector,
-      // so we use nodeAffinity that allows OR-expressions.
-      // This is fine because DaemonSets do not trigger autoscaling and are instead scheduled once
+      // DaemonSets do not trigger autoscaling and are instead scheduled once
       // per existing, eligible node.
-      affinity: {
-        nodeAffinity: {
-          requiredDuringSchedulingIgnoredDuringExecution: {
-            nodeSelectorTerms: [
-              {
-                matchExpressions: [
-                  {
-                    key: 'cloud.google.com/compute-class',
-                    operator: 'In',
-                    values: [appsComputeClassName, infraComputeClassName],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-      },
       tolerations: [
-        ...appsKubernetesSchedulingComputeClass.tolerations,
-        ...infraKubernetesSchedulingComputeClass.tolerations,
+        {
+          key: 'cloud.google.com/compute-class',
+          operator: 'Equal',
+          value: infraComputeClassName,
+          effect: 'NoSchedule',
+        },
+        {
+          key: 'cloud.google.com/compute-class',
+          operator: 'Equal',
+          value: appsComputeClassName,
+          effect: 'NoSchedule',
+        },
       ],
     }
   : {

--- a/cluster/pulumi/common/src/helm.ts
+++ b/cluster/pulumi/common/src/helm.ts
@@ -73,7 +73,7 @@ function installSpliceHelmChartByNamespaceName(
   version: CnChartVersion = activeVersion,
   opts?: SpliceCustomResourceOptions,
   includeNamespaceInName = true,
-  affinityAndTolerations: object = appsAffinityAndTolerations,
+  affinityAndTolerations: object = appsKubernetesScheduling,
   timeout: number = HELM_CHART_TIMEOUT_SEC
 ): InstalledHelmChart {
   if (spliceConfig.pulumiProjectConfig.installDataOnly) {
@@ -107,7 +107,7 @@ export function installSpliceHelmChart(
   version: CnChartVersion = activeVersion,
   opts?: SpliceCustomResourceOptions,
   includeNamespaceInName = true,
-  affinityAndTolerations: object = appsAffinityAndTolerations,
+  affinityAndTolerations: object = appsKubernetesScheduling,
   timeout: number = HELM_CHART_TIMEOUT_SEC
 ): InstalledHelmChart {
   return installSpliceHelmChartByNamespaceName(
@@ -171,7 +171,7 @@ export function installSpliceRunbookHelmChartByNamespaceName(
         chart: chartPath(chartName, version),
         version: versionStringWithPossibleOverride(version, nsLogicalName, chartName),
         values: {
-          ...appsAffinityAndTolerations,
+          ...appsKubernetesScheduling,
           ...values,
           imageRepo: DOCKER_REPO,
           ...imagePullPolicy,
@@ -224,7 +224,36 @@ function versionStringWithPossibleOverride(
   }
 }
 
-export const appsAffinityAndTolerations = {
+export const appsComputeClassName = 'cn-apps';
+export const infraComputeClassName = 'cn-infra';
+
+const appsKubernetesSchedulingComputeClass = {
+  // A nodeSelector is a simpler way to select a single ComputeClass.
+  // We still use nodeAffinity for better compatibility with other parts of the code.
+  // As long as the node affinity is a single term, it *should* trigger the ComputeClass
+  // mechanism for scaling up nodes.
+  // nodeSelector: {'cloud.google.com/compute-class': appsComputeClassName},
+  affinity: {
+    nodeAffinity: {
+      requiredDuringSchedulingIgnoredDuringExecution: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'cloud.google.com/compute-class',
+                operator: 'In',
+                values: [appsComputeClassName],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+  tolerations: [{ key: 'cn_apps', operator: 'Exists', effect: 'NoSchedule' }],
+};
+
+const appsKubernetesSchedulingAffinityTolerations = {
   affinity: {
     nodeAffinity: {
       requiredDuringSchedulingIgnoredDuringExecution: {
@@ -255,7 +284,41 @@ export const appsAffinityAndTolerations = {
   ],
 };
 
-export const infraAffinityAndTolerations = {
+export const useComputeClasses =
+  spliceConfig.configuration.kubernetesScheduling.computeClasses.enabled;
+
+// Values that determine how apps pods are scheduled.
+export const appsKubernetesScheduling = useComputeClasses
+  ? appsKubernetesSchedulingComputeClass
+  : appsKubernetesSchedulingAffinityTolerations;
+
+export const infraKubernetesSchedulingComputeClass = {
+  // A nodeSelector is a simpler way to select a single ComputeClass.
+  // We still use nodeAffinity for better compatibility with other parts of the code.
+  // As long as the node affinity is a single term, it *should* trigger the ComputeClass
+  // mechanism for scaling up nodes.
+  // nodeSelector: {'cloud.google.com/compute-class': infraComputeClassName},
+  affinity: {
+    nodeAffinity: {
+      requiredDuringSchedulingIgnoredDuringExecution: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'cloud.google.com/compute-class',
+                operator: 'In',
+                values: [infraComputeClassName],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+  tolerations: [{ key: 'cn_infra', operator: 'Exists', effect: 'NoSchedule' }],
+};
+
+export const infraKubernetesSchedulingAffinityTolerations = {
   affinity: {
     nodeAffinity: {
       requiredDuringSchedulingIgnoredDuringExecution: {
@@ -280,3 +343,56 @@ export const infraAffinityAndTolerations = {
     },
   ],
 };
+
+// Values that determine how infra pods are scheduled.
+export const infraKubernetesScheduling = useComputeClasses
+  ? infraKubernetesSchedulingComputeClass
+  : infraKubernetesSchedulingAffinityTolerations;
+
+// Values that determine how daemons are scheduled that need to run on BOTH apps and infra nodes.
+export const infraAndAppsKubernetesSchedulingForDaemonSets = useComputeClasses
+  ? {
+      // A pod can only pick a single ComputeClass via a nodeSelector,
+      // so we use nodeAffinity that allows OR-expressions.
+      // This is fine because DaemonSets do not trigger autoscaling and are instead scheduled once
+      // per existing, eligible node.
+      affinity: {
+        nodeAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: [
+              {
+                matchExpressions: [
+                  {
+                    key: 'cloud.google.com/compute-class',
+                    operator: 'In',
+                    values: [appsComputeClassName, infraComputeClassName],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+      tolerations: [
+        ...appsKubernetesSchedulingComputeClass.tolerations,
+        ...infraKubernetesSchedulingComputeClass.tolerations,
+      ],
+    }
+  : {
+      affinity: {
+        nodeAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: [
+              ...appsKubernetesSchedulingAffinityTolerations.affinity.nodeAffinity
+                .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
+              ...infraKubernetesSchedulingAffinityTolerations.affinity.nodeAffinity
+                .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
+            ],
+          },
+        },
+      },
+      tolerations: [
+        ...appsKubernetesSchedulingAffinityTolerations.tolerations,
+        ...infraKubernetesSchedulingAffinityTolerations.tolerations,
+      ],
+    };

--- a/cluster/pulumi/common/src/operator/stack.ts
+++ b/cluster/pulumi/common/src/operator/stack.ts
@@ -5,7 +5,7 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   CLUSTER_BASENAME,
   config,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
   isMainNet,
 } from '@canton-network/splice-pulumi-common';
 import { CustomResource } from '@pulumi/kubernetes/apiextensions';
@@ -265,7 +265,7 @@ export function createStackCR(
               resources: stackConfig.resources,
               podTemplate: {
                 spec: {
-                  ...infraAffinityAndTolerations,
+                  ...infraKubernetesScheduling,
                   terminationGracePeriodSeconds: PulumiOperatorGracePeriod,
                   volumes: [
                     {

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -19,8 +19,8 @@ import {
 import { spliceConfig } from './config/config';
 import { GcpProject } from './config/gcpConfig';
 import {
-  appsAffinityAndTolerations,
-  infraAffinityAndTolerations,
+  appsKubernetesScheduling,
+  infraKubernetesScheduling,
   installSpliceHelmChart,
   SpliceCustomResourceOptions,
 } from './helm';
@@ -395,7 +395,7 @@ export class LegacyHelmSplicePostgres extends pulumi.ComponentResource implement
     overrideDbSizeFromValues?: boolean,
     disableProtection?: boolean,
     version?: CnChartVersion,
-    useInfraAffinityAndTolerations: boolean = false,
+    useinfraKubernetesScheduling: boolean = false,
     resourceOpts?: SpliceCustomResourceOptions
   ) {
     const logicalName = xns.logicalName + '-' + instanceName;
@@ -445,7 +445,7 @@ export class LegacyHelmSplicePostgres extends pulumi.ComponentResource implement
           : {}),
       },
       true,
-      useInfraAffinityAndTolerations ? infraAffinityAndTolerations : appsAffinityAndTolerations
+      useinfraKubernetesScheduling ? infraKubernetesScheduling : appsKubernetesScheduling
     );
     this.pg = pg;
     this.database = pg;
@@ -514,7 +514,7 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
     overrideDbSizeFromValues?: boolean,
     disableProtection?: boolean,
     version?: CnChartVersion,
-    useInfraAffinityAndTolerations: boolean = false,
+    useinfraKubernetesScheduling: boolean = false,
     resourceOpts?: SpliceCustomResourceOptions
   ) {
     // Avoiding collisions with the name in LegacyHelmSplicePostgres
@@ -539,7 +539,7 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
         overrideDbSizeFromValues,
         disableProtection,
         version,
-        useInfraAffinityAndTolerations
+        useinfraKubernetesScheduling
       );
 
       migrationSource = {
@@ -574,9 +574,9 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
       { limits: { memory: '12Gi' }, requests: { cpu: '0.5', memory: '1Gi' } },
       values?.resources || {}
     );
-    const affinityAndTolerations = useInfraAffinityAndTolerations
-      ? infraAffinityAndTolerations
-      : appsAffinityAndTolerations;
+    const kubernetesScheduling = useinfraKubernetesScheduling
+      ? infraKubernetesScheduling
+      : appsKubernetesScheduling;
 
     // Optional init container that migrates data from a pre-existing postgres instance.
     // It runs pg_dumpall against the source and writes migration.dump into a dedicated
@@ -772,8 +772,7 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
                 },
               ],
               restartPolicy: 'Always',
-              affinity: affinityAndTolerations.affinity,
-              tolerations: affinityAndTolerations.tolerations,
+              ...kubernetesScheduling,
               ...(migrationVolumes.length > 0 ? { volumes: migrationVolumes } : {}),
             },
           },
@@ -903,7 +902,7 @@ export function installSplicePostgres(
   opts: SplicePostgresInstallOptions = {},
   chartValues?: LegacyChartValues,
   overrideDbSizeFromValues?: boolean,
-  useInfraAffinityAndTolerations: boolean = false,
+  useinfraKubernetesScheduling: boolean = false,
   resourceOpts?: SpliceCustomResourceOptions
 ): Postgres {
   if (splicePostgresHelmMigrationConfig.deployment == 'legacy-helm-chart') {
@@ -915,7 +914,7 @@ export function installSplicePostgres(
       overrideDbSizeFromValues,
       opts.disableProtection,
       version,
-      useInfraAffinityAndTolerations,
+      useinfraKubernetesScheduling,
       resourceOpts
     );
   } else {
@@ -930,7 +929,7 @@ export function installSplicePostgres(
       overrideDbSizeFromValues,
       opts.disableProtection,
       version,
-      useInfraAffinityAndTolerations,
+      useinfraKubernetesScheduling,
       resourceOpts
     );
   }

--- a/cluster/pulumi/gha/src/controller.ts
+++ b/cluster/pulumi/gha/src/controller.ts
@@ -3,7 +3,7 @@
 import * as k8s from '@pulumi/kubernetes';
 import {
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 import { Namespace } from '@pulumi/kubernetes/core/v1';
 
@@ -22,7 +22,7 @@ export function installController(repo: string, runnersNamespaceName: string): k
     version: ghaConfig.runnerScaleSetVersion,
     namespace: controllerNamespace.metadata.name,
     values: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
       maxHistory: HELM_MAX_HISTORY_SIZE,
       flags: {
         logFormat: 'json',

--- a/cluster/pulumi/gha/src/dockerMirror.ts
+++ b/cluster/pulumi/gha/src/dockerMirror.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
   standardStorageClassName,
 } from '@canton-network/splice-pulumi-common';
 import { Namespace } from '@pulumi/kubernetes/core/v1';
@@ -56,7 +56,7 @@ export function installDockerRegistryMirror(): k8s.helm.v3.Release {
             },
           },
         },
-        ...infraAffinityAndTolerations,
+        ...infraKubernetesScheduling,
       },
     },
     {

--- a/cluster/pulumi/gha/src/runners.test.ts
+++ b/cluster/pulumi/gha/src/runners.test.ts
@@ -43,7 +43,7 @@ jest.mock('@canton-network/splice-pulumi-common', () => ({
   GCP_REGION: 'us-central123',
   GCP_ZONE: 'some-wonderful-place',
   imagePullSecretByNamespaceNameForServiceAccount: () => [],
-  infraAffinityAndTolerations: {},
+  infraKubernetesScheduling: {},
   CloudSqlConfigSchema: z.object({ flags: z.record(z.string(), z.string()).default({}) }),
   installPostgresPasswordSecret: () => {
     return { metadata: { name: 'secret' } };

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -3,12 +3,12 @@
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import {
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   DOCKER_REPO,
   ExactNamespace,
   HELM_MAX_HISTORY_SIZE,
   imagePullSecretByNamespaceNameForServiceAccount,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
   K8sResourceSchema,
   SingleK8sResourceSchema,
 } from '@canton-network/splice-pulumi-common';
@@ -86,7 +86,7 @@ function installDockerRunnerScaleSet(
         listenerTemplate: {
           spec: {
             containers: [{ name: 'listener' }],
-            ...infraAffinityAndTolerations,
+            ...infraKubernetesScheduling,
           },
         },
         template: {
@@ -231,7 +231,7 @@ function installDockerRunnerScaleSet(
               },
             ],
             serviceAccountName: serviceAccountName,
-            ...appsAffinityAndTolerations,
+            ...appsKubernetesScheduling,
           },
           metadata: {
             // prevent eviction by the gke autoscaler
@@ -244,7 +244,7 @@ function installDockerRunnerScaleSet(
             },
           },
         },
-        ...infraAffinityAndTolerations,
+        ...infraKubernetesScheduling,
         maxHistory: HELM_MAX_HISTORY_SIZE,
       },
     },
@@ -407,7 +407,7 @@ function installK8sRunnerScaleSet(
                   },
                 ],
                 serviceAccountName: serviceAccountName,
-                ...appsAffinityAndTolerations,
+                ...appsKubernetesScheduling,
               },
               metadata: {
                 // prevent eviction by the gke autoscaler
@@ -439,7 +439,7 @@ function installK8sRunnerScaleSet(
         listenerTemplate: {
           spec: {
             containers: [{ name: 'listener' }],
-            ...infraAffinityAndTolerations,
+            ...infraKubernetesScheduling,
           },
         },
         template: {
@@ -524,7 +524,7 @@ function installK8sRunnerScaleSet(
               // Mount the volumes as owned by the runner user
               fsGroup: 1001,
             },
-            ...appsAffinityAndTolerations,
+            ...appsKubernetesScheduling,
             volumes: [
               {
                 name: 'work',
@@ -559,7 +559,7 @@ function installK8sRunnerScaleSet(
             },
           },
         },
-        ...infraAffinityAndTolerations,
+        ...infraKubernetesScheduling,
         maxHistory: HELM_MAX_HISTORY_SIZE,
       },
     },

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -20,7 +20,7 @@ import {
   GCP_ZONE,
   getDnsNames,
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
   isDevNet,
   isMainNet,
 } from '../../common';
@@ -83,7 +83,7 @@ function configureIstiod(
   const defaultValues = {
     autoscaleMin: 2,
     autoscaleMax: 30,
-    ...infraAffinityAndTolerations,
+    ...infraKubernetesScheduling,
     global: {
       istioNamespace: ingressNs.metadata.name,
       logAsJson: true,
@@ -421,7 +421,7 @@ function configureGatewayService(
             ingressPort('https', 443),
           ].concat(ingressPorts),
         },
-        ...infraAffinityAndTolerations,
+        ...infraKubernetesScheduling,
         // The httpLoadBalancing addon needs to be enabled to use backend service-based network load balancers.
         annotations: {
           'cloud.google.com/l4-rbs': 'enabled',

--- a/cluster/pulumi/infra/src/maintenance.ts
+++ b/cluster/pulumi/infra/src/maintenance.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import { versionFromDefault } from '@canton-network/splice-pulumi-common/src/version';
 
-import { DOCKER_REPO, infraAffinityAndTolerations } from '../../common';
+import { DOCKER_REPO, infraKubernetesScheduling } from '../../common';
 
 const cronJobName = 'gc-pod-reaper-job';
 const reaperNamespace = 'gc-pod-reaper';
@@ -154,7 +154,7 @@ export function deployGCPodReaper(
               spec: {
                 serviceAccountName: serviceAccountName,
                 restartPolicy: 'OnFailure',
-                ...infraAffinityAndTolerations,
+                ...infraKubernetesScheduling,
                 containers: [
                   {
                     name: cronJobName,

--- a/cluster/pulumi/infra/src/network.ts
+++ b/cluster/pulumi/infra/src/network.ts
@@ -11,9 +11,13 @@ import {
   ExactNamespace,
   GCP_PROJECT,
   getDnsNames,
+  infraComputeClassName,
+  infraKubernetesSchedulingAffinityTolerations,
+  infraKubernetesSchedulingComputeClass,
   isDevNet,
+  useComputeClasses,
 } from '@canton-network/splice-pulumi-common';
-import { infraAffinityAndTolerations } from '@canton-network/splice-pulumi-common';
+import { infraKubernetesScheduling } from '@canton-network/splice-pulumi-common';
 import { svConfigsBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 
 import { gcpDnsProject } from './config';
@@ -84,15 +88,15 @@ function certManager(certManagerNamespaceName: string): certmanager.CertManager 
       namespace: ns.metadata.name,
       version: '1.18.2',
     },
-    ...infraAffinityAndTolerations,
+    ...infraKubernetesScheduling,
     webhook: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
     cainjector: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
     startupapicheck: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
   });
 }

--- a/cluster/pulumi/infra/src/network.ts
+++ b/cluster/pulumi/infra/src/network.ts
@@ -11,9 +11,8 @@ import {
   ExactNamespace,
   GCP_PROJECT,
   getDnsNames,
-  infraComputeClassName,
   infraKubernetesSchedulingAffinityTolerations,
-  infraKubernetesSchedulingComputeClass,
+  infraKubernetesSchedulingComputeClassViaAffinity,
   isDevNet,
   useComputeClasses,
 } from '@canton-network/splice-pulumi-common';
@@ -88,7 +87,13 @@ function certManager(certManagerNamespaceName: string): certmanager.CertManager 
       namespace: ns.metadata.name,
       version: '1.18.2',
     },
-    ...infraKubernetesScheduling,
+    // Ideally, we would just use `...infraKubernetesScheduling` here.
+    // Unfortunately, the cert-manager helm chart does not support the `nodeSelector` field.
+    // It uses the wrong typing for it and then enforces it in Go,
+    // so no amount of TypeScript hacking will help.
+    ...(useComputeClasses
+      ? infraKubernetesSchedulingComputeClassViaAffinity
+      : infraKubernetesSchedulingAffinityTolerations),
     webhook: {
       ...infraKubernetesScheduling,
     },

--- a/cluster/pulumi/infra/src/reloader.ts
+++ b/cluster/pulumi/infra/src/reloader.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 import {
   HELM_MAX_HISTORY_SIZE,
   exactNamespace,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 
 export function configureReloader(): k8s.helm.v3.Release {
@@ -29,7 +29,7 @@ export function configureReloader(): k8s.helm.v3.Release {
           readOnlyRootFileSystem: true,
           enableMetricsByNamespace: true,
           deployment: {
-            ...infraAffinityAndTolerations,
+            ...infraKubernetesScheduling,
           },
           containerSecurityContext: {
             capabilities: {

--- a/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
+++ b/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
@@ -3,7 +3,7 @@
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import {
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   DOCKER_REPO,
   imagePullPolicy,
   jmxOptions,
@@ -178,7 +178,7 @@ export class MultiNodeDeployment extends pulumi.ComponentResource {
                   ],
                 },
               ],
-              ...appsAffinityAndTolerations,
+              ...appsKubernetesScheduling,
             },
           },
         },

--- a/cluster/pulumi/multi-validator/src/postgres.ts
+++ b/cluster/pulumi/multi-validator/src/postgres.ts
@@ -3,7 +3,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import {
   activeVersion,
-  appsAffinityAndTolerations,
+  appsKubernetesScheduling,
   CnInput,
   ExactNamespace,
   spliceConfig,
@@ -40,10 +40,10 @@ export function installPostgres(
         pvcTemplateName: 'pg-data-hd',
       },
       resources: config.resources?.postgres,
-      appsAffinityAndTolerations,
+      appsAffinityAndTolerations: appsKubernetesScheduling,
     },
     true, // overrideDbSizeFromValues
-    false, // useInfraAffinityAndTolerations
+    false, // useinfraKubernetesScheduling
     {
       dependsOn,
       ...(spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges

--- a/cluster/pulumi/observability/src/observability.ts
+++ b/cluster/pulumi/observability/src/observability.ts
@@ -16,7 +16,7 @@ import {
   GCP_PROJECT,
   GrafanaKeys,
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
   infraPremiumStorageClassName,
   infraStandardStorageClassName,
   loadTesterConfig,
@@ -205,7 +205,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
                 },
               },
             },
-            ...infraAffinityAndTolerations,
+            ...infraKubernetesScheduling,
           },
           templateFiles: {
             'template.tmpl': substituteSlackNotificationTemplate(
@@ -224,7 +224,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
           tls: {
             enabled: false, // because `admissionWebhooks` are disabled, see: https://github.com/prometheus-community/helm-charts/issues/418
           },
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         prometheus: {
           prometheusSpec: {
@@ -265,7 +265,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
               },
             },
             externalUrl: prometheusExternalUrl,
-            ...infraAffinityAndTolerations,
+            ...infraKubernetesScheduling,
           },
         },
         grafana: {
@@ -394,7 +394,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
           },
           adminUser: 'cn-admin',
           adminPassword: adminPassword,
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         'kube-state-metrics': {
           fullnameOverride: 'ksm',
@@ -499,7 +499,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
               },
             ],
           },
-          ...infraAffinityAndTolerations,
+          ...infraKubernetesScheduling,
         },
         'prometheus-node-exporter': {
           fullnameOverride: 'node-exporter',
@@ -566,7 +566,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
           namespace: namespaceName,
           additionalLabels: { release: 'prometheus-grafana-monitoring' },
         },
-        ...infraAffinityAndTolerations,
+        ...infraKubernetesScheduling,
       },
       maxHistory: HELM_MAX_HISTORY_SIZE,
     });
@@ -1218,6 +1218,6 @@ function installPostgres(namespace: ExactNamespace): Postgres {
     { disableProtection: true },
     { db: { volumeSize: '20Gi' } }, // A tiny pvc should be enough for grafana
     true, // overrideDbSizeFromValues
-    true // useInfraAffinityAndTolerations
+    true // useinfraKubernetesScheduling
   );
 }

--- a/cluster/pulumi/operator/src/flux/flux.ts
+++ b/cluster/pulumi/operator/src/flux/flux.ts
@@ -3,7 +3,7 @@
 import * as k8s from '@pulumi/kubernetes';
 import {
   HELM_MAX_HISTORY_SIZE,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 
 import { namespace } from '../namespace';
@@ -21,13 +21,13 @@ export const flux = new k8s.helm.v3.Release('flux', {
   },
   values: {
     cli: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
     notificationController: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
     sourceController: {
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
     },
     helmController: {
       create: false,

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -7,7 +7,7 @@ import {
   config,
   HELM_MAX_HISTORY_SIZE,
   imagePullSecret,
-  infraAffinityAndTolerations,
+  infraKubernetesScheduling,
 } from '@canton-network/splice-pulumi-common';
 import { local } from '@pulumi/command';
 
@@ -56,7 +56,7 @@ export const operator = new k8s.helm.v3.Release(
       serviceMonitor: {
         enabled: true,
       },
-      ...infraAffinityAndTolerations,
+      ...infraKubernetesScheduling,
       maxHistory: HELM_MAX_HISTORY_SIZE,
     },
   },


### PR DESCRIPTION
This PR:

- Add a new config value `kubernetesScheduling.computeClasses.enabled`.
- If the value is true, create two ComputeClasses, and change pod annotations from using the `cn_apps` key to using `loud.google.com/compute-class`. This _should_ trigger the autoscaler to use the ComputeClass definition for choosing which node pool to scale up.