### PR TITLE
in splitwell test, wait longer for checkWallets via argument rather than wrapped eventually

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -174,11 +174,21 @@ class SplitwellFrontendIntegrationTest
         }
       }
 
-      eventually() {
-        // Check final amounts in the wallets
-        checkWallet(aliceUserParty, aliceWalletClient, Seq((400.0, 400)))
-        checkWallet(bobUserParty, bobWalletClient, Seq((39.0, 39.0)))
-        checkWallet(charlieUserParty, charlieWalletClient, Seq((111.0, 111.0)))
+      withClue("check final amounts in the wallets") {
+        val waitTime = 20.seconds
+        checkWallet(
+          aliceUserParty,
+          aliceWalletClient,
+          Seq((400.0, 400)),
+          timeUntilSuccess = waitTime,
+        )
+        checkWallet(bobUserParty, bobWalletClient, Seq((39.0, 39.0)), timeUntilSuccess = waitTime)
+        checkWallet(
+          charlieUserParty,
+          charlieWalletClient,
+          Seq((111.0, 111.0)),
+          timeUntilSuccess = waitTime,
+        )
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -66,11 +66,12 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
       wallet: WalletAppClientReference,
       expectedAmountRanges: Seq[(BigDecimal, BigDecimal)],
       holdingFee: BigDecimal = defaultHoldingFeeAmulet.bigDecimal,
+      timeUntilSuccess: FiniteDuration = 10.seconds,
   ): Unit = clue(s"checking wallet with $expectedAmountRanges") {
     val expectedRatePerRound = new feesCodegen.RatePerRound(
       holdingFee.bigDecimal setScale 10
     )
-    eventually(10.seconds, 500.millis) {
+    eventually(timeUntilSuccess, 500.millis) {
       val amulets =
         wallet.list().amulets.sortBy(amulet => amulet.contract.payload.amount.initialAmount)
       amulets should have size (expectedAmountRanges.size.toLong)


### PR DESCRIPTION
`checkWallet` does an eventually wrapped in a clue

https://github.com/canton-network/splice/blob/1f77fba09e1e4ccf129288de7776566fde8f44e1/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala#L69-L73

since DACH-NY/canton-network-node#1458; we don't need an overall eventually

https://github.com/canton-network/splice/blob/74f6cf2478e9ae146750243939cf072c5dd2ab9d/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala#L177-L182

wrapping the `checkWallet` calls, and the `clue` causes a log problem if the outer `eventually` does anything at all.

Instead we pick a more generous inner `eventually` here. 20 seconds to match `eventually`'s default.

Fixes DACH-NY/cn-test-failures#9706.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
