### PR TITLE
Warn when client IP rate limiting uses fallback headers

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/ClientIpDirectives.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/ClientIpDirectives.scala
@@ -37,7 +37,7 @@ object ClientIpDirectives {
     firstDefined(sources*)
   }
 
-  private def trustedClientIp(headerName: String): Directive1[Option[RemoteAddress]] = {
+  private[splice] def trustedClientIp(headerName: String): Directive1[Option[RemoteAddress]] = {
     val trimmedHeaderName = headerName.trim
     if (trimmedHeaderName.isEmpty) provide(None)
     else

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiter.scala
@@ -6,6 +6,7 @@ package org.lfdecentralizedtrust.splice.http
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
 import com.daml.metrics.api.MetricsContext
 import com.digitalasset.canton.logging.TracedLogger
+import com.digitalasset.canton.tracing.TraceContext
 import org.apache.pekko.http.scaladsl.model.{HttpEntity, RemoteAddress, StatusCodes}
 import org.apache.pekko.http.scaladsl.server.{Directive0, Directive1}
 import org.lfdecentralizedtrust.splice.config.RateLimitersConfig
@@ -16,6 +17,8 @@ import org.lfdecentralizedtrust.splice.util.{
 }
 
 import java.net.{Inet6Address, InetAddress}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 class HttpRateLimiter(
     config: RateLimitersConfig,
@@ -34,6 +37,11 @@ class HttpRateLimiter(
 
   private val trustedClientIpHeader: String =
     config.trustedClientIpHeader.trim
+
+  private val lastMissingTrustedClientIpHeaderWarning =
+    new AtomicLong(
+      System.nanoTime() - HttpRateLimiter.MissingTrustedClientIpHeaderWarningIntervalNanos
+    )
 
   private def metricsFor(service: String): SpliceRateLimitMetrics =
     metrics.getOrElseUpdate(
@@ -96,8 +104,10 @@ class HttpRateLimiter(
 
     import org.apache.pekko.http.scaladsl.server.Directives.*
 
-    HttpRateLimiter
-      .extractClientIpKey(trustedClientIpHeader, config.enableClientProvidedIpHeaders)
+    val perClientIpRateLimitingEnabled =
+      globalClientIpLimiter.enabled || operationClientIpLimiter.enabled
+
+    extractClientIpKey(perClientIpRateLimitingEnabled)
       .flatMap { clientIp =>
         // The per client IP limiters are checked first (and `&&` short-circuits) so that a request
         // rejected because of its own client IP does not consume budget from the shared overall
@@ -123,12 +133,50 @@ class HttpRateLimiter(
       }
   }
 
+  private def extractClientIpKey(warnOnFallback: Boolean): Directive1[Option[String]] = {
+    import org.apache.pekko.http.scaladsl.server.Directives.*
+
+    ClientIpDirectives.trustedClientIp(trustedClientIpHeader).flatMap {
+      case Some(RemoteAddress.IP(ip, _)) => provide(Some(HttpRateLimiter.rateLimitKey(ip)))
+      case Some(_) => provide(None)
+      case None =>
+        HttpRateLimiter
+          .extractClientIpKey("", config.enableClientProvidedIpHeaders)
+          .map { clientIp =>
+            if (warnOnFallback && trustedClientIpHeader.nonEmpty && clientIp.nonEmpty) {
+              warnAboutMissingTrustedClientIpHeader()
+            }
+            clientIp
+          }
+    }
+  }
+
+  private def warnAboutMissingTrustedClientIpHeader(): Unit = {
+    val now = System.nanoTime()
+    val last = lastMissingTrustedClientIpHeaderWarning.get()
+    if (
+      now - last >= HttpRateLimiter.MissingTrustedClientIpHeaderWarningIntervalNanos &&
+      lastMissingTrustedClientIpHeaderWarning.compareAndSet(last, now)
+    ) {
+      implicit val traceContext: TraceContext = TraceContext.empty
+      logger.warn(
+        s"The configured trusted client IP header '$trustedClientIpHeader' is missing or does not " +
+          "contain a valid IP address. Per-client-IP rate limiting is falling back to a " +
+          "client-provided X-Forwarded-For or X-Real-Ip header, which may allow clients to spoof " +
+          "their rate-limit identity."
+      )
+    }
+  }
+
   def close(): Unit = metrics.view.values.foreach(_.close())
 }
 
 object HttpRateLimiter {
 
   private val ClientIpAttribute = "client_ip"
+
+  private val MissingTrustedClientIpHeaderWarningIntervalNanos: Long =
+    TimeUnit.MINUTES.toNanos(1)
 
   private[splice] val GlobalLimiter = "global"
   private[splice] val GlobalService = "global"

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiter.scala
@@ -216,6 +216,8 @@ class PerAttributeRateLimiter(
   private val isEnabled = perAttributeConfig.enabled && perAttributeConfig.ratePerSecond > 0
   private val attributeLabel = Map("limiter_attribute" -> attribute)
 
+  private[splice] def enabled: Boolean = isEnabled
+
   // evictions by size can happen for every single request (e.g. when a large number of distinct
   // attribute values is seen), so the warning is throttled to avoid flooding the logs
   private val lastSizeEvictionWarning =

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/HttpRateLimiterTest.scala
@@ -5,6 +5,7 @@ package org.lfdecentralizedtrust.splice.http
 
 import com.daml.metrics.api.testing.InMemoryMetricsFactory
 import com.digitalasset.canton.BaseTest
+import com.digitalasset.canton.logging.SuppressionRule
 import org.apache.pekko.http.scaladsl.model.headers.{RawHeader, `X-Forwarded-For`, `X-Real-Ip`}
 import org.apache.pekko.http.scaladsl.model.{
   AttributeKeys,
@@ -23,6 +24,7 @@ import org.lfdecentralizedtrust.splice.util.{
   SpliceRateLimiter,
 }
 import org.scalatest.wordspec.AnyWordSpec
+import org.slf4j.event.Level
 
 import java.net.{Inet6Address, InetAddress}
 
@@ -210,6 +212,35 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
   }
 
   "the http rate limiter" should {
+
+    "warn once when the trusted client IP header is unavailable and a client-provided header is used" in {
+      loggerFactory.assertLogsSeq(SuppressionRule.Level(Level.WARN))(
+        withRoutes(
+          globalPerClientIp = perClientIp(1000),
+          trustedClientIpHeader = "X-Trusted-Client-Ip",
+        )("testOperation") { routes =>
+          call(routes("testOperation"), ip = Some("1.1.1.1")) should be(StatusCodes.OK)
+          call(routes("testOperation"), ip = Some("1.1.1.1")) should be(StatusCodes.OK)
+        },
+        logEntries => {
+          logEntries should have size 1
+          logEntries.head.message should include("X-Trusted-Client-Ip")
+          logEntries.head.message should include("X-Forwarded-For")
+          logEntries.head.message should include("spoof")
+        },
+      )
+    }
+
+    "not warn about a missing trusted client IP header when per-client-IP limiting is disabled" in {
+      loggerFactory.assertLogsSeq(SuppressionRule.Level(Level.WARN))(
+        withRoutes(
+          trustedClientIpHeader = "X-Trusted-Client-Ip"
+        )("testOperation") { routes =>
+          call(routes("testOperation"), ip = Some("1.1.1.1")) should be(StatusCodes.OK)
+        },
+        _ shouldBe empty,
+      )
+    }
 
     "reject requests of a client IP over the global per client IP limit" in {
       // the global per client IP limiter is enabled by default
@@ -494,6 +525,7 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
       global: SpliceRateLimitConfig = SpliceRateLimitConfig(ratePerSecond = 1000),
       globalPerClientIp: PerAttributeRateLimitConfig = PerAttributeRateLimitConfig.Disabled,
       perClientIpOverrides: Map[String, PerAttributeRateLimitConfig] = Map.empty,
+      trustedClientIpHeader: String = RateLimitersConfig.DefaultTrustedClientIpHeader,
   )(operations: String*)(f: HttpRateLimiterTest.Fixture => A): A = {
     // Any operation with a per client IP override needs its own overall limiter entry so that the
     // embedded per client IP limiter is used instead of the `default` one.
@@ -510,6 +542,7 @@ class HttpRateLimiterTest extends AnyWordSpec with BaseTest with ScalatestRouteT
         default = withPerClientIp(default, PerAttributeRateLimitConfig.Disabled),
         rateLimiters = perOperationConfigs,
         global = withPerClientIp(global, globalPerClientIp),
+        trustedClientIpHeader = trustedClientIpHeader,
       ),
       metricsFactory,
       loggerFactory.getTracedLogger(classOf[HttpRateLimiterTest]),


### PR DESCRIPTION
Fixes #6799.

Warn at most once per minute when per-client-IP rate limiting falls back from the configured trusted header to client-controlled `X-Forwarded-For` or `X-Real-Ip` values.

Tests:
- `apps-common/scalafmtAll`
- `apps-common/Test/scalafmtAll`
- `apps-common/testOnly org.lfdecentralizedtrust.splice.http.HttpRateLimiterTest` *(not run locally: the Nix-provided `dpm` and `openapi-generator-cli` tools are unavailable)*
