### PR TITLE
Add PruneRewardAccountingTrigger to delete old reward-accounting data

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -1,7 +1,7 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.HasExecutionContext
-import com.digitalasset.canton.config.NonNegativeDuration
+import com.digitalasset.canton.config.{NonNegativeDuration, NonNegativeFiniteDuration}
 import com.digitalasset.canton.console.LocalInstanceReference
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.CloseContext
@@ -52,6 +52,7 @@ import org.lfdecentralizedtrust.splice.util.{
   AmuletConfigSchedule,
   AmuletConfigUtil,
   ScanTestUtil,
+  SpliceUtil,
   TimeTestUtil,
   TriggerTestUtil,
   WalletTestUtil,
@@ -85,6 +86,10 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
   // event-history consistency check cannot hold here.
   override protected def runEventHistorySanityCheck: Boolean = false
 
+  // Long enough that advancing a few rounds does not reach it
+  private val rewardAccountingRetentionPeriod: NonNegativeFiniteDuration =
+    NonNegativeFiniteDuration(SpliceUtil.defaultInitialTickDuration.asJava.multipliedBy(10))
+
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology4SvsWithSimTime(this.getClass.getSimpleName)
@@ -95,6 +100,11 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
             dryRunVersion = None,
             appRewardCouponThreshold = BigDecimal("0"),
           )
+        )(config)
+      )
+      .addConfigTransform((_, config) =>
+        ConfigTransforms.updateAllScanAppConfigs_(
+          _.copy(rewardAccountingRetentionPeriod = rewardAccountingRetentionPeriod)
         )(config)
       )
       // Prevent wallets from minting RewardCouponV2 before the test
@@ -839,6 +849,28 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       }
     }
 
+    def confirmPruningMetrics(
+        scan: LocalInstanceReference,
+        atLeastRound: Long,
+        timeUntilSuccess: FiniteDuration = 20.seconds,
+    ): Unit = {
+      def pruningMetricValue(name: String, labels: Map[String, String] = Map.empty): Long =
+        metricValue(scan, s"scan.reward_accounting_pruning.$name", labels)
+
+      eventually(timeUntilSuccess) {
+        pruningMetricValue("pruned_round") should be >= atLeastRound
+        forAll(
+          Seq(
+            "scan_rewards_reference_store_archived",
+            "app_activity_round_totals",
+            "app_reward_round_totals",
+          )
+        ) { table =>
+          pruningMetricValue("deleted_rows", Map("table" -> table)) should be > 0L
+        }
+      }
+    }
+
     // Simulate SV2 scan ingestion lag and confirm that pruning does not happen
     // until the ingestion has caught up.
     val newLowestOpen = pauseScanVerdictIngestionWithin(sv2ScanBackend) {
@@ -850,8 +882,16 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       // So advancing by 3 rounds is a safe way to achieve this.
       (1 to 3).foreach(_ => advanceRoundsToNextRoundOpening)
 
-      clue(s"sv1 prunes rounds below $newLowestOpen") {
+      clue(s"sv1 retains rounds below $newLowestOpen while within the retention period") {
+        hasUnprunedRewardAccountingDataBelow(sv1Db, sv1HistoryId, newLowestOpen) shouldBe true
+        hasUnprunedArchiveDataForRound(sv1RewardsRefStore, newLowestOpen - 1) shouldBe true
+      }
+
+      advanceTime(rewardAccountingRetentionPeriod.asJava)
+
+      clue(s"sv1 prunes rounds below $newLowestOpen once past the retention period") {
         confirmFullyPruned(sv1Db, sv1HistoryId, sv1RewardsRefStore, newLowestOpen)
+        confirmPruningMetrics(sv1ScanBackend, newLowestOpen - 1)
       }
 
       clue(
@@ -872,6 +912,7 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
         newLowestOpen,
         timeUntilSuccess = 90.seconds,
       )
+      confirmPruningMetrics(sv2ScanBackend, newLowestOpen - 1)
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -58,7 +58,7 @@ import org.lfdecentralizedtrust.splice.util.{
 }
 import org.slf4j.event.Level
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 // This test focuses on the SV app side triggers testing
@@ -829,11 +829,12 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
         historyId: Long,
         store: ScanRewardsReferenceStore,
         upperExclusive: Long,
+        timeUntilSuccess: FiniteDuration = 20.seconds,
     ): Unit = {
-      eventually() {
+      eventually(timeUntilSuccess) {
         hasUnprunedRewardAccountingDataBelow(db, historyId, upperExclusive) shouldBe false
       }
-      eventually() {
+      eventually(timeUntilSuccess) {
         hasUnprunedArchiveDataForRound(store, upperExclusive - 1) shouldBe false
       }
     }
@@ -843,6 +844,11 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     val newLowestOpen = pauseScanVerdictIngestionWithin(sv2ScanBackend) {
       advanceRoundsToNextRoundOpening
       val newLowestOpen = oldestOpenRound
+
+      // We need the archived_at of newLowestOpen + 1 to be lower than the
+      // the active open round's openAt.
+      // So advancing by 3 rounds is a safe way to achieve this.
+      (1 to 3).foreach(_ => advanceRoundsToNextRoundOpening)
 
       clue(s"sv1 prunes rounds below $newLowestOpen") {
         confirmFullyPruned(sv1Db, sv1HistoryId, sv1RewardsRefStore, newLowestOpen)
@@ -858,7 +864,14 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     }
 
     clue(s"sv2 eventually prunes data once verdict ingestion resumes") {
-      confirmFullyPruned(sv2Db, sv2HistoryId, sv2RewardsRefStore, newLowestOpen)
+      // This can occasionally take longer than the default 20s eventually window
+      confirmFullyPruned(
+        sv2Db,
+        sv2HistoryId,
+        sv2RewardsRefStore,
+        newLowestOpen,
+        timeUntilSuccess = 90.seconds,
+      )
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -46,6 +46,7 @@ import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.{
 }
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.scan.automation.RewardComputationTrigger
+import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.sv.config.InitialRewardConfig
 import org.lfdecentralizedtrust.splice.util.{
   AmuletConfigSchedule,
@@ -67,6 +68,8 @@ import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInt
 // - BFT read in all three SV app's reward processing triggers
 //
 // - Reporting of mismatches in 'Confirmation' of root-hash
+//
+// - Pruning of reward processing data
 @org.lfdecentralizedtrust.splice.util.scalatesttags.SpliceAmulet_0_1_19
 class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     extends IntegrationTestWithIsolatedEnvironment
@@ -354,6 +357,8 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       confirmBftRead(bobParty)
 
       confirmMismatchingRootHashIsFlagged(bobParty)
+
+      advanceRoundsAndConfirmAllPriorRoundsPruned()
   }
 
   // sv2's CalculateRewardsTrigger and SummarizingMiningRoundTrigger report the
@@ -766,6 +771,95 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
         }
       },
     )
+  }
+
+  private def advanceRoundsAndConfirmAllPriorRoundsPruned()(implicit
+      env: SpliceTestConsoleEnvironment
+  ): Unit = {
+    val sv1Db = sv1ScanBackend.appState.storage match {
+      case db: DbStorage => db
+      case _ => fail("Expected DbStorage")
+    }
+    val sv2Db = sv2ScanBackend.appState.storage match {
+      case db: DbStorage => db
+      case _ => fail("Expected DbStorage")
+    }
+    val sv1HistoryId = sv1ScanBackend.appState.eventStore.updateHistory.historyId
+    val sv2HistoryId = sv2ScanBackend.appState.eventStore.updateHistory.historyId
+    val sv1RewardsRefStore = sv1ScanBackend.appState.rewardsReferenceStore
+    val sv2RewardsRefStore = sv2ScanBackend.appState.rewardsReferenceStore
+
+    def hasUnprunedRewardAccountingDataBelow(
+        db: DbStorage,
+        historyId: Long,
+        upperExclusive: Long,
+    ): Boolean = {
+      implicit val closeContext: CloseContext = CloseContext(db)
+      db
+        .querySingle(
+          sql"""select
+                  exists(select 1 from app_activity_party_totals
+                         where history_id = $historyId and round_number < $upperExclusive)
+                  or exists(select 1 from app_activity_round_totals
+                         where history_id = $historyId and round_number < $upperExclusive)
+                  or exists(select 1 from app_reward_party_totals
+                         where history_id = $historyId and round_number < $upperExclusive)
+                  or exists(select 1 from app_reward_round_totals
+                         where history_id = $historyId and round_number < $upperExclusive)
+                  or exists(select 1 from app_reward_batch_hashes
+                         where history_id = $historyId and round_number < $upperExclusive)
+                  or exists(select 1 from app_reward_root_hashes
+                         where history_id = $historyId and round_number < $upperExclusive)
+             """.as[Boolean].headOption,
+          "test.hasUnprunedRewardAccountingDataBelow",
+        )
+        .value
+        .futureValueUS
+        .value
+    }
+
+    def hasUnprunedArchiveDataForRound(
+        store: ScanRewardsReferenceStore,
+        roundNumber: Long,
+    ): Boolean =
+      store.lookupArchivedAtForOpenMiningRound(roundNumber).futureValue.isDefined
+
+    def confirmFullyPruned(
+        db: DbStorage,
+        historyId: Long,
+        store: ScanRewardsReferenceStore,
+        upperExclusive: Long,
+    ): Unit = {
+      eventually() {
+        hasUnprunedRewardAccountingDataBelow(db, historyId, upperExclusive) shouldBe false
+      }
+      eventually() {
+        hasUnprunedArchiveDataForRound(store, upperExclusive - 1) shouldBe false
+      }
+    }
+
+    // Simulate SV2 scan ingestion lag and confirm that pruning does not happen
+    // until the ingestion has caught up.
+    val newLowestOpen = pauseScanVerdictIngestionWithin(sv2ScanBackend) {
+      advanceRoundsToNextRoundOpening
+      val newLowestOpen = oldestOpenRound
+
+      clue(s"sv1 prunes rounds below $newLowestOpen") {
+        confirmFullyPruned(sv1Db, sv1HistoryId, sv1RewardsRefStore, newLowestOpen)
+      }
+
+      clue(
+        s"sv2 does not prune rounds below $newLowestOpen while its verdict ingestion is paused"
+      ) {
+        hasUnprunedArchiveDataForRound(sv2RewardsRefStore, newLowestOpen - 1) shouldBe true
+      }
+
+      newLowestOpen
+    }
+
+    clue(s"sv2 eventually prunes data once verdict ingestion resumes") {
+      confirmFullyPruned(sv2Db, sv2HistoryId, sv2RewardsRefStore, newLowestOpen)
+    }
   }
 
   private def doTransfer(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -45,7 +45,10 @@ import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.{
   ProcessRewardsTrigger,
 }
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
-import org.lfdecentralizedtrust.splice.scan.automation.RewardComputationTrigger
+import org.lfdecentralizedtrust.splice.scan.automation.{
+  PruneRewardAccountingTrigger,
+  RewardComputationTrigger,
+}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.sv.config.InitialRewardConfig
 import org.lfdecentralizedtrust.splice.util.{
@@ -59,7 +62,8 @@ import org.lfdecentralizedtrust.splice.util.{
 }
 import org.slf4j.event.Level
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.annotation.tailrec
+import scala.concurrent.duration.DurationInt
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 // This test focuses on the SV app side triggers testing
@@ -798,6 +802,8 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     val sv2HistoryId = sv2ScanBackend.appState.eventStore.updateHistory.historyId
     val sv1RewardsRefStore = sv1ScanBackend.appState.rewardsReferenceStore
     val sv2RewardsRefStore = sv2ScanBackend.appState.rewardsReferenceStore
+    val sv1PruneTrigger = sv1ScanBackend.automation.trigger[PruneRewardAccountingTrigger]
+    val sv2PruneTrigger = sv2ScanBackend.automation.trigger[PruneRewardAccountingTrigger]
 
     def hasUnprunedRewardAccountingDataBelow(
         db: DbStorage,
@@ -834,30 +840,34 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     ): Boolean =
       store.lookupArchivedAtForOpenMiningRound(roundNumber).futureValue.isDefined
 
+    // The trigger prunes at most one round per invocation, so it is run until it
+    // reports that there is nothing left to prune.
+    def pruneUntilNothingLeftToPrune(trigger: PruneRewardAccountingTrigger): Unit = {
+      @tailrec def go(runs: Int): Unit = {
+        runs should be < 30
+        if (trigger.runOnce().futureValue) go(runs + 1) else ()
+      }
+      go(0)
+    }
+
     def confirmFullyPruned(
         db: DbStorage,
         historyId: Long,
         store: ScanRewardsReferenceStore,
         upperExclusive: Long,
-        timeUntilSuccess: FiniteDuration = 20.seconds,
     ): Unit = {
-      eventually(timeUntilSuccess) {
-        hasUnprunedRewardAccountingDataBelow(db, historyId, upperExclusive) shouldBe false
-      }
-      eventually(timeUntilSuccess) {
-        hasUnprunedArchiveDataForRound(store, upperExclusive - 1) shouldBe false
-      }
+      hasUnprunedRewardAccountingDataBelow(db, historyId, upperExclusive) shouldBe false
+      hasUnprunedArchiveDataForRound(store, upperExclusive - 1) shouldBe false
     }
 
     def confirmPruningMetrics(
         scan: LocalInstanceReference,
         atLeastRound: Long,
-        timeUntilSuccess: FiniteDuration = 20.seconds,
     ): Unit = {
       def pruningMetricValue(name: String, labels: Map[String, String] = Map.empty): Long =
         metricValue(scan, s"scan.reward_accounting_pruning.$name", labels)
 
-      eventually(timeUntilSuccess) {
+      eventually() {
         pruningMetricValue("pruned_round") should be >= atLeastRound
         forAll(
           Seq(
@@ -871,48 +881,55 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       }
     }
 
-    // Simulate SV2 scan ingestion lag and confirm that pruning does not happen
-    // until the ingestion has caught up.
-    val newLowestOpen = pauseScanVerdictIngestionWithin(sv2ScanBackend) {
-      advanceRoundsToNextRoundOpening
-      val newLowestOpen = oldestOpenRound
+    setTriggersWithin(triggersToPauseAtStart = Seq(sv1PruneTrigger, sv2PruneTrigger)) {
+      // Simulate SV2 scan ingestion lag and confirm that pruning does not happen
+      // until the ingestion has caught up.
+      val newLowestOpen = pauseScanVerdictIngestionWithin(sv2ScanBackend) {
+        advanceRoundsToNextRoundOpening
+        val newLowestOpen = oldestOpenRound
 
-      // We need the archived_at of newLowestOpen + 1 to be lower than the
-      // the active open round's openAt.
-      // So advancing by 3 rounds is a safe way to achieve this.
-      (1 to 3).foreach(_ => advanceRoundsToNextRoundOpening)
+        // We need the archived_at of newLowestOpen + 1 to be lower than the
+        // the active open round's openAt.
+        // So advancing by 3 rounds is a safe way to achieve this.
+        (1 to 3).foreach(_ => advanceRoundsToNextRoundOpening)
 
-      clue(s"sv1 retains rounds below $newLowestOpen while within the retention period") {
-        hasUnprunedRewardAccountingDataBelow(sv1Db, sv1HistoryId, newLowestOpen) shouldBe true
-        hasUnprunedArchiveDataForRound(sv1RewardsRefStore, newLowestOpen - 1) shouldBe true
+        clue(s"sv1 retains rounds below $newLowestOpen while within the retention period") {
+          pruneUntilNothingLeftToPrune(sv1PruneTrigger)
+          hasUnprunedRewardAccountingDataBelow(sv1Db, sv1HistoryId, newLowestOpen) shouldBe true
+          hasUnprunedArchiveDataForRound(sv1RewardsRefStore, newLowestOpen - 1) shouldBe true
+        }
+
+        advanceTime(rewardAccountingRetentionPeriod.asJava)
+
+        clue(s"sv1 prunes rounds below $newLowestOpen once past the retention period") {
+          // Retried, as a round only becomes prunable once the reference store has
+          // ingested the archival of all of its reward-accounting contracts.
+          eventually() {
+            pruneUntilNothingLeftToPrune(sv1PruneTrigger)
+            confirmFullyPruned(sv1Db, sv1HistoryId, sv1RewardsRefStore, newLowestOpen)
+          }
+          confirmPruningMetrics(sv1ScanBackend, newLowestOpen - 1)
+        }
+
+        clue(
+          s"sv2 does not prune rounds below $newLowestOpen while its verdict ingestion is paused"
+        ) {
+          pruneUntilNothingLeftToPrune(sv2PruneTrigger)
+          hasUnprunedArchiveDataForRound(sv2RewardsRefStore, newLowestOpen - 1) shouldBe true
+        }
+
+        newLowestOpen
       }
 
-      advanceTime(rewardAccountingRetentionPeriod.asJava)
-
-      clue(s"sv1 prunes rounds below $newLowestOpen once past the retention period") {
-        confirmFullyPruned(sv1Db, sv1HistoryId, sv1RewardsRefStore, newLowestOpen)
-        confirmPruningMetrics(sv1ScanBackend, newLowestOpen - 1)
+      clue(s"sv2 eventually prunes data once verdict ingestion resumes") {
+        // Because of the delay in catchup of the verdict ingestion
+        // this can occasionally take longer than the default 20s eventually window
+        eventually(90.seconds) {
+          pruneUntilNothingLeftToPrune(sv2PruneTrigger)
+          confirmFullyPruned(sv2Db, sv2HistoryId, sv2RewardsRefStore, newLowestOpen)
+        }
+        confirmPruningMetrics(sv2ScanBackend, newLowestOpen - 1)
       }
-
-      clue(
-        s"sv2 does not prune rounds below $newLowestOpen while its verdict ingestion is paused"
-      ) {
-        hasUnprunedArchiveDataForRound(sv2RewardsRefStore, newLowestOpen - 1) shouldBe true
-      }
-
-      newLowestOpen
-    }
-
-    clue(s"sv2 eventually prunes data once verdict ingestion resumes") {
-      // This can occasionally take longer than the default 20s eventually window
-      confirmFullyPruned(
-        sv2Db,
-        sv2HistoryId,
-        sv2RewardsRefStore,
-        newLowestOpen,
-        timeUntilSuccess = 90.seconds,
-      )
-      confirmPruningMetrics(sv2ScanBackend, newLowestOpen - 1)
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TriggerTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TriggerTestUtil.scala
@@ -66,11 +66,15 @@ trait TriggerTestUtil { self: BaseTest =>
   def pauseScanVerdictIngestionWithin[T](scan: ScanAppBackendReference)(codeBlock: => T): T = {
     try {
       logger.info(s"Pausing verdict ingestion for ${scan.name}")
-      scan.automation.services[ScanVerdictIngestionService].foreach(_.pause().futureValue)
+      scan.appState.verdictAutomation
+        .services[ScanVerdictIngestionService]
+        .foreach(
+          _.pause().futureValue
+        )
       codeBlock
     } finally {
       logger.info(s"Resuming verdict ingestion for ${scan.name}")
-      scan.automation.services[ScanVerdictIngestionService].foreach(_.resume())
+      scan.appState.verdictAutomation.services[ScanVerdictIngestionService].foreach(_.resume())
     }
   }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStore.scala
@@ -37,6 +37,8 @@ class DbTcsStore(
     with AcsQueries
     with TcsQueries {
 
+  import profile.api.jdbcActionExtensionMethods
+
   private val synchronizerId = synchronizerIdFromDescriptor(acsStore.acsStoreDescriptor)
 
   private val archiveTableName = acsStore.acsArchiveConfigOpt
@@ -167,5 +169,50 @@ class DbTcsStore(
             }
         }
     }
+  }
+
+  /** Deletes all rows from the archive table with `archived_at <= uptoInclusive`,
+    * and moves the earliest archived_at (ie the ingestion start) to the earliest
+    * archival after `uptoInclusive`. Fails without deleting anything if no such
+    * archival has been ingested, as the store would otherwise lose its ingestion start.
+    *
+    * Here we don't have a lower bound on the `archived_at`, so this API should
+    * be used with care, preferably ensuring that the deletion happens in small steps.
+    *
+    * Returns number of rows deleted.
+    */
+  def pruneArchivedUpTo(
+      uptoInclusive: CantonTimestamp
+  )(implicit tc: TraceContext): Future[Long] = acsStore.waitUntilAcsIngested {
+    val storeId = acsStore.acsStoreId
+    val migrationId = acsStore.domainMigrationId
+    val action = for {
+      earliestRemainingO <-
+        sql"""SELECT MIN(archived_at) FROM #$archiveTableName
+              WHERE store_id = $storeId
+                AND migration_id = $migrationId
+                AND archived_at > $uptoInclusive
+           """.as[Option[CantonTimestamp]].head
+
+      earliestRemaining = earliestRemainingO.getOrElse(
+        throw new IllegalStateException(
+          s"Cannot prune archived data up to $uptoInclusive as no archival after it has been ingested."
+        )
+      )
+
+      deleted <-
+        sql"""delete from #$archiveTableName
+              where store_id = $storeId and migration_id = $migrationId
+                and archived_at <= $uptoInclusive""".asUpdate
+
+      // Updating it as part of the transaction ensures that a rollback can
+      // only leave the value in the cache too recent, which is safer than
+      // having a value in cache for which we have already deleted the data.
+      _ = earliestArchivedAtCache.set(Some(earliestRemaining))
+    } yield deleted
+
+    futureUnlessShutdownToFuture(
+      storage.queryAndUpdate(action.transactionally, "pruneArchivedUpTo")
+    ).map(_.toLong)
   }
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
@@ -35,7 +35,10 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.{
   schedule as scheduleCodegen,
   validatorlicense as validatorLicenseCodegen,
 }
-import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.rewardaccountingv2 as rewardAccountingCodegen
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.{
+  cryptohash as cryptoHashCodegen,
+  rewardaccountingv2 as rewardAccountingCodegen,
+}
 import org.lfdecentralizedtrust.splice.environment.{BaseLedgerConnection, DarResource, DarResources}
 import org.lfdecentralizedtrust.splice.environment.ledger.api.{
   ActiveContract,
@@ -363,6 +366,27 @@ abstract class StoreTestBase
     contract(
       rewardAccountingCodegen.CalculateRewardsV2.TEMPLATE_ID_WITH_PACKAGE_ID,
       new rewardAccountingCodegen.CalculateRewardsV2.ContractId(nextCid()),
+      template,
+    )
+  }
+
+  protected def processRewardsV2(
+      dso: PartyId,
+      round: Long,
+      dryRun: Boolean = true,
+      batchHash: String = "00" * 32,
+  ) = {
+    val template = new rewardAccountingCodegen.ProcessRewardsV2(
+      dso.toProtoPrimitive,
+      new Round(round),
+      Instant.now().truncatedTo(ChronoUnit.MICROS),
+      dryRun,
+      new RelTime(600_000_000L),
+      new cryptoHashCodegen.Hash(batchHash),
+    )
+    contract(
+      rewardAccountingCodegen.ProcessRewardsV2.TEMPLATE_ID_WITH_PACKAGE_ID,
+      new rewardAccountingCodegen.ProcessRewardsV2.ContractId(nextCid()),
       template,
     )
   }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStoreTest.scala
@@ -264,6 +264,69 @@ class DbTcsStoreTest extends StoreTestBase with SplicePostgresTest with AcsJdbcT
       } yield succeed
     }
 
+    "pruneArchivedUpTo deletes the archived rows up to the given time and moves the earliest archived_at" in {
+      val store = mkStore(sync1)
+      val coupon1 = c(1).copy(createdAt = CantonTimestamp.ofEpochSecond(100).toInstant)
+      val coupon2 = c(2).copy(createdAt = CantonTimestamp.ofEpochSecond(100).toInstant)
+      val coupon3 = c(3).copy(createdAt = CantonTimestamp.ofEpochSecond(100).toInstant)
+      val coupon4 = c(4).copy(createdAt = CantonTimestamp.ofEpochSecond(100).toInstant)
+      for {
+        _ <- initWithAcs()(store.acsStore)
+        _ <- sync1.create(coupon1, recordTime = CantonTimestamp.ofEpochSecond(100).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.create(coupon2, recordTime = CantonTimestamp.ofEpochSecond(100).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.create(coupon3, recordTime = CantonTimestamp.ofEpochSecond(100).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.create(coupon4, recordTime = CantonTimestamp.ofEpochSecond(100).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.archive(coupon1, recordTime = CantonTimestamp.ofEpochSecond(150).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.archive(coupon2, recordTime = CantonTimestamp.ofEpochSecond(250).toInstant)(
+          store.acsStore
+        )
+        _ <- sync1.archive(coupon3, recordTime = CantonTimestamp.ofEpochSecond(350).toInstant)(
+          store.acsStore
+        )
+        // Populate the cache before pruning
+        beforePrune <- store.getEarliestArchivedAt()
+        _ = beforePrune shouldBe Some(CantonTimestamp.ofEpochSecond(150))
+
+        deleted <- store.pruneArchivedUpTo(CantonTimestamp.ofEpochSecond(250))
+        _ = deleted shouldBe 2L
+        afterPrune <- store.getEarliestArchivedAt()
+        _ = afterPrune shouldBe Some(CantonTimestamp.ofEpochSecond(350))
+
+        // Nothing to delete between the two archivals
+        deletedNothing <- store.pruneArchivedUpTo(CantonTimestamp.ofEpochSecond(300))
+        _ = deletedNothing shouldBe 0L
+        afterNoopPrune <- store.getEarliestArchivedAt()
+        _ = afterNoopPrune shouldBe Some(CantonTimestamp.ofEpochSecond(350))
+
+        // Fails without deleting anything while no archival after the given
+        // time has been ingested, as that would leave the store with no ingestion start.
+        failure <- store.pruneArchivedUpTo(CantonTimestamp.ofEpochSecond(350)).failed
+        _ = failure shouldBe an[IllegalStateException]
+        afterFailedPrune <- store.getEarliestArchivedAt()
+        _ = afterFailedPrune shouldBe Some(CantonTimestamp.ofEpochSecond(350))
+
+        // Succeeds once a later archival has been ingested
+        _ <- sync1.archive(coupon4, recordTime = CantonTimestamp.ofEpochSecond(450).toInstant)(
+          store.acsStore
+        )
+
+        deletedAfterNewArchival <- store.pruneArchivedUpTo(CantonTimestamp.ofEpochSecond(350))
+        _ = deletedAfterNewArchival shouldBe 1L
+        afterNewArchival <- store.getEarliestArchivedAt()
+        _ = afterNewArchival shouldBe Some(CantonTimestamp.ofEpochSecond(450))
+      } yield succeed
+    }
+
     "waitUntilRecordTimeReached completes when record time is reached via offset checkpoint" in {
       val store = mkStore(sync1).acsStore
       val sync1CheckpointTime = CantonTimestamp.ofEpochSecond(200)

--- a/apps/metrics-docs/src/main/scala/org/lfdecentralizedtrust/splice/metrics/MetricsDocs.scala
+++ b/apps/metrics-docs/src/main/scala/org/lfdecentralizedtrust/splice/metrics/MetricsDocs.scala
@@ -14,6 +14,7 @@ import org.lfdecentralizedtrust.splice.admin.api.client.DamlGrpcClientMetrics
 import org.lfdecentralizedtrust.splice.automation.TriggerMetrics
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanStoreMetrics
 import org.lfdecentralizedtrust.splice.scan.metrics.{
+  RewardAccountingPruningMetrics,
   RewardComputationMetrics,
   ScanMediatorVerdictIngestionMetrics,
 }
@@ -128,6 +129,7 @@ object MetricsDocs {
     )
     new ScanMediatorVerdictIngestionMetrics(generator)
     new RewardComputationMetrics(generator)(MetricsContext.Empty)
+    new RewardAccountingPruningMetrics(generator)(MetricsContext.Empty)
     val scanMetrics = generator.getAll()
     generator.reset()
     GeneratedMetrics(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -378,6 +378,7 @@ class ScanApp(
         )
         automation.registerRewardsReferenceStoreIngestion(rewardsStore)
         automation.registerRewardComputationTrigger(rewardsStore)
+        automation.registerPruneRewardAccountingTrigger(rewardsStore, scanVerdictStore)
         rewardsStore
       }
       verdictAutomation = new ScanVerdictAutomationService(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
@@ -1,0 +1,118 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.scan.automation
+
+import org.apache.pekko.stream.Materializer
+import org.lfdecentralizedtrust.splice.automation.{
+  PollingParallelTaskExecutionTrigger,
+  TaskOutcome,
+  TaskSuccess,
+  TriggerContext,
+}
+import org.lfdecentralizedtrust.splice.scan.automation.PruneRewardAccountingTrigger.Task
+import org.lfdecentralizedtrust.splice.scan.store.{ScanAppRewardsStore, ScanRewardsReferenceStore}
+import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore
+import org.lfdecentralizedtrust.splice.store.UpdateHistory
+import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
+import com.digitalasset.canton.tracing.TraceContext
+import io.opentelemetry.api.trace.Tracer
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Periodically deletes reward-accounting data that is no longer needed, one
+  * round at a time. Prunes the following
+  *   - Computed values from six reward-accounting tables in ScanAppRewardsStore:
+  *     `app_activity_party_totals`
+  *     `app_activity_round_totals`
+  *     `app_reward_party_totals`
+  *     `app_reward_round_totals`
+  *     `app_reward_batch_hashes`
+  *     `app_reward_root_hashes`
+  *
+  *   - Archived contracts from `ScanRewardsReferenceStore` archive table
+  *     which archived <= the archival time of the OpenMiningRound
+  *
+  * A round only becomes eligible for pruning once none of its `OpenMiningRound`,
+  * `CalculateRewardsV2`, or `ProcessRewardsV2` contracts -- nor those of any
+  * lower round -- remain active. AND the verdict ingestion has moved past the
+  * `record_time` of OpenMiningRound's archival.
+  */
+class PruneRewardAccountingTrigger(
+    appRewardsStore: ScanAppRewardsStore,
+    rewardsReferenceStore: ScanRewardsReferenceStore,
+    verdictStore: DbScanVerdictStore,
+    updateHistory: UpdateHistory,
+    triggerContext: TriggerContext,
+)(implicit
+    override val ec: ExecutionContext,
+    mat: Materializer,
+    override val tracer: Tracer,
+) extends PollingParallelTaskExecutionTrigger[Task] {
+
+  override protected def context: TriggerContext = triggerContext.copy(
+    config = triggerContext.config.copy(
+      parallelism = 1
+    )
+  )
+
+  override def retrieveTasks()(implicit tc: TraceContext): Future[Seq[Task]] =
+    if (!updateHistory.isReady) {
+      logger.debug("Waiting for UpdateHistory to become ready.")
+      Future.successful(Seq.empty)
+    } else
+      rewardsReferenceStore.lookupLowestPrunableArchivedRewardRound().flatMap {
+        case None =>
+          Future.successful(Seq.empty)
+        case Some(roundNumber) =>
+          rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(roundNumber).map {
+            case None =>
+              logger.warn(
+                s"This should never happen, could not resolve archived_at for round $roundNumber."
+              )
+              Seq.empty
+            case Some(uptoInclusive) =>
+              if (verdictStore.lastIngestedRecordTime.exists(_ >= uptoInclusive)) {
+                Seq(Task(roundNumber))
+              } else {
+                logger.debug(
+                  s"Skipping pruning as the verdict ingestion (last ingested record time: ${verdictStore.lastIngestedRecordTime}) " +
+                    s"has not yet caught up to round $roundNumber's archivedAt ($uptoInclusive)"
+                )
+                Seq.empty
+              }
+          }
+      }
+
+  override def completeTask(task: Task)(implicit tc: TraceContext): Future[TaskOutcome] =
+    for {
+      /* The two deletes happen on different stores, and the deletes are being
+       * done in independent transactions.
+       * Because both are idempotent operations and re-running either for the
+       * same or an older round is a no-op.
+       * If pruning of either store fails, the task will be retried.
+       *
+       * Also here it is assumed that ScanAppRewardsStore only has the data for
+       * rounds for which we have data in ScanRewardsReferenceStore. Which is a
+       * fair assumption as the reward calculations require the data to be
+       * present in ScanRewardsReferenceStore for that round.
+       */
+      summary <- appRewardsStore.deleteRewardAccountingDataForRound(task.roundNumber)
+      deletedArchiveRows <- rewardsReferenceStore.pruneArchivedDataForRound(task.roundNumber)
+    } yield TaskSuccess(
+      s"Pruned reward accounting data for round ${task.roundNumber}: " +
+        s"removed $deletedArchiveRows archived rows; and $summary."
+    )
+
+  override def isStaleTask(task: Task)(implicit tc: TraceContext): Future[Boolean] =
+    rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(task.roundNumber).map(_.isEmpty)
+}
+
+object PruneRewardAccountingTrigger {
+  final case class Task(roundNumber: Long) extends PrettyPrinting {
+    override def pretty: Pretty[this.type] =
+      prettyOfClass(
+        param("round", _.roundNumber)
+      )
+  }
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
@@ -14,6 +14,7 @@ import org.lfdecentralizedtrust.splice.scan.automation.PruneRewardAccountingTrig
 import org.lfdecentralizedtrust.splice.scan.store.{ScanAppRewardsStore, ScanRewardsReferenceStore}
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore
 import org.lfdecentralizedtrust.splice.store.UpdateHistory
+import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
@@ -65,22 +66,61 @@ class PruneRewardAccountingTrigger(
         case None =>
           Future.successful(Seq.empty)
         case Some(roundNumber) =>
-          rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(roundNumber).map {
+          // For ScanRewardsReferenceStore the earliest archived_at row act as
+          // an indicator of the "ingestion start", and therefore we need to ensure
+          // that we keep at least one archived row in the store with record_time lower than
+          // the lastIngestedRecordTime's oldest active round's `openAt` time.
+          //
+          // A simple way to ensure this is to compare the `openAt` with the roundNumber + 1 archived_at.
+          verdictStore.lastIngestedRecordTime match {
             case None =>
-              logger.warn(
-                s"This should never happen, could not resolve archived_at for round $roundNumber."
-              )
-              Seq.empty
-            case Some(uptoInclusive) =>
-              if (verdictStore.lastIngestedRecordTime.exists(_ >= uptoInclusive)) {
-                Seq(Task(roundNumber))
-              } else {
-                logger.debug(
-                  s"Skipping pruning as the verdict ingestion (last ingested record time: ${verdictStore.lastIngestedRecordTime}) " +
-                    s"has not yet caught up to round $roundNumber's archivedAt ($uptoInclusive)"
-                )
-                Seq.empty
-              }
+              logger.debug("Skipping pruning as no verdict has been ingested yet.")
+              Future.successful(Seq.empty)
+            case Some(lastIngestedRecordTime) =>
+              rewardsReferenceStore
+                .lookupActiveOpenMiningRounds(Seq(lastIngestedRecordTime))
+                .flatMap(_.get(lastIngestedRecordTime) match {
+                  case None =>
+                    logger.warn(
+                      s"We should never hit this, as we should always have an active OpenMiningRound" +
+                        s"as of the last ingested verdict record time ($lastIngestedRecordTime)."
+                    )
+                    Future.successful(Seq.empty)
+                  case Some((activeRoundNumber, _)) =>
+                    for {
+                      activeRoundO <- rewardsReferenceStore.lookupOpenMiningRoundByNumber(
+                        activeRoundNumber
+                      )
+                      archivedAtNextO <- rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(
+                        roundNumber + 1
+                      )
+                    } yield (activeRoundO, archivedAtNextO) match {
+                      case (Some(activeRound), Some(archivedAtNext)) =>
+                        if (
+                          CantonTimestamp
+                            .assertFromInstant(activeRound.payload.opensAt) > archivedAtNext
+                        ) {
+                          Seq(Task(roundNumber))
+                        } else {
+                          logger.debug(
+                            s"Skipping pruning of round $roundNumber as the ingestion's currently active round " +
+                              s"$activeRoundNumber opened at ${activeRound.payload.opensAt}, which is not yet " +
+                              s"past round ${roundNumber + 1}'s archivedAt ($archivedAtNext)."
+                          )
+                          Seq.empty
+                        }
+                      case (_, None) =>
+                        logger.debug(
+                          s"Skipping pruning of round $roundNumber as round ${roundNumber + 1} has not archived yet."
+                        )
+                        Seq.empty
+                      case (None, _) =>
+                        logger.warn(
+                          s"This should never happen, could not resolve OpenMiningRound $activeRoundNumber."
+                        )
+                        Seq.empty
+                    }
+                })
           }
       }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/PruneRewardAccountingTrigger.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.scan.automation
 
 import org.apache.pekko.stream.Materializer
+import com.daml.metrics.api.MetricsContext
 import org.lfdecentralizedtrust.splice.automation.{
   PollingParallelTaskExecutionTrigger,
   TaskOutcome,
@@ -11,10 +12,12 @@ import org.lfdecentralizedtrust.splice.automation.{
   TriggerContext,
 }
 import org.lfdecentralizedtrust.splice.scan.automation.PruneRewardAccountingTrigger.Task
+import org.lfdecentralizedtrust.splice.scan.metrics.RewardAccountingPruningMetrics
 import org.lfdecentralizedtrust.splice.scan.store.{ScanAppRewardsStore, ScanRewardsReferenceStore}
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore
 import org.lfdecentralizedtrust.splice.store.UpdateHistory
-import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import com.digitalasset.canton.lifecycle.{AsyncOrSyncCloseable, SyncCloseable}
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
@@ -34,16 +37,19 @@ import scala.concurrent.{ExecutionContext, Future}
   *   - Archived contracts from `ScanRewardsReferenceStore` archive table
   *     which archived <= the archival time of the OpenMiningRound
   *
-  * A round only becomes eligible for pruning once none of its `OpenMiningRound`,
-  * `CalculateRewardsV2`, or `ProcessRewardsV2` contracts -- nor those of any
-  * lower round -- remain active. AND the verdict ingestion has moved past the
-  * `record_time` of OpenMiningRound's archival.
+  * A round only becomes eligible for pruning once
+  *   - None of its `OpenMiningRound`, `CalculateRewardsV2`, or `ProcessRewardsV2` contracts,
+  *     nor those of any lower round, remain active.
+  *   - The verdict ingestion has moved past sufficiently,
+  *     such that lookup of data for a subsequent round won't be affected by the pruning.
+  *   - The archival time of the round is older than the configured `retentionPeriod`.
   */
 class PruneRewardAccountingTrigger(
     appRewardsStore: ScanAppRewardsStore,
     rewardsReferenceStore: ScanRewardsReferenceStore,
     verdictStore: DbScanVerdictStore,
     updateHistory: UpdateHistory,
+    retentionPeriod: NonNegativeFiniteDuration,
     triggerContext: TriggerContext,
 )(implicit
     override val ec: ExecutionContext,
@@ -57,71 +63,32 @@ class PruneRewardAccountingTrigger(
     )
   )
 
+  private val pruningMetrics = new RewardAccountingPruningMetrics(context.metricsFactory)(
+    MetricsContext(
+      "current_migration_id" -> updateHistory.domainMigrationId.toString
+    )
+  )
+
   override def retrieveTasks()(implicit tc: TraceContext): Future[Seq[Task]] =
     if (!updateHistory.isReady) {
       logger.debug("Waiting for UpdateHistory to become ready.")
       Future.successful(Seq.empty)
     } else
-      rewardsReferenceStore.lookupLowestPrunableArchivedRewardRound().flatMap {
+      verdictStore.lastIngestedRecordTime match {
         case None =>
+          logger.debug("Skipping pruning as no verdict has been ingested yet.")
           Future.successful(Seq.empty)
-        case Some(roundNumber) =>
-          // For ScanRewardsReferenceStore the earliest archived_at row act as
-          // an indicator of the "ingestion start", and therefore we need to ensure
-          // that we keep at least one archived row in the store with record_time lower than
-          // the lastIngestedRecordTime's oldest active round's `openAt` time.
-          //
-          // A simple way to ensure this is to compare the `openAt` with the roundNumber + 1 archived_at.
-          verdictStore.lastIngestedRecordTime match {
-            case None =>
-              logger.debug("Skipping pruning as no verdict has been ingested yet.")
-              Future.successful(Seq.empty)
-            case Some(lastIngestedRecordTime) =>
-              rewardsReferenceStore
-                .lookupActiveOpenMiningRounds(Seq(lastIngestedRecordTime))
-                .flatMap(_.get(lastIngestedRecordTime) match {
-                  case None =>
-                    logger.warn(
-                      s"We should never hit this, as we should always have an active OpenMiningRound" +
-                        s"as of the last ingested verdict record time ($lastIngestedRecordTime)."
-                    )
-                    Future.successful(Seq.empty)
-                  case Some((activeRoundNumber, _)) =>
-                    for {
-                      activeRoundO <- rewardsReferenceStore.lookupOpenMiningRoundByNumber(
-                        activeRoundNumber
-                      )
-                      archivedAtNextO <- rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(
-                        roundNumber + 1
-                      )
-                    } yield (activeRoundO, archivedAtNextO) match {
-                      case (Some(activeRound), Some(archivedAtNext)) =>
-                        if (
-                          CantonTimestamp
-                            .assertFromInstant(activeRound.payload.opensAt) > archivedAtNext
-                        ) {
-                          Seq(Task(roundNumber))
-                        } else {
-                          logger.debug(
-                            s"Skipping pruning of round $roundNumber as the ingestion's currently active round " +
-                              s"$activeRoundNumber opened at ${activeRound.payload.opensAt}, which is not yet " +
-                              s"past round ${roundNumber + 1}'s archivedAt ($archivedAtNext)."
-                          )
-                          Seq.empty
-                        }
-                      case (_, None) =>
-                        logger.debug(
-                          s"Skipping pruning of round $roundNumber as round ${roundNumber + 1} has not archived yet."
-                        )
-                        Seq.empty
-                      case (None, _) =>
-                        logger.warn(
-                          s"This should never happen, could not resolve OpenMiningRound $activeRoundNumber."
-                        )
-                        Seq.empty
-                    }
-                })
-          }
+        case Some(lastIngestedRecordTime) =>
+          rewardsReferenceStore
+            .lookupPrunableRewardRound(
+              lastIngestedRecordTime,
+              context.clock.now,
+              retentionPeriod,
+            )
+            .map {
+              case Some(roundNumber) => Seq(Task(roundNumber))
+              case None => Seq.empty
+            }
       }
 
   override def completeTask(task: Task)(implicit tc: TraceContext): Future[TaskOutcome] =
@@ -132,20 +99,31 @@ class PruneRewardAccountingTrigger(
        * same or an older round is a no-op.
        * If pruning of either store fails, the task will be retried.
        *
+       * Even if the task is abandoned, a subsequent invocation of the trigger
+       * will work because the task creation depends only on the contents of
+       * rewardsReferenceStore which is deleted after the appRewardsStore
+       *
        * Also here it is assumed that ScanAppRewardsStore only has the data for
        * rounds for which we have data in ScanRewardsReferenceStore. Which is a
        * fair assumption as the reward calculations require the data to be
        * present in ScanRewardsReferenceStore for that round.
        */
       summary <- appRewardsStore.deleteRewardAccountingDataForRound(task.roundNumber)
-      deletedArchiveRows <- rewardsReferenceStore.pruneArchivedDataForRound(task.roundNumber)
-    } yield TaskSuccess(
-      s"Pruned reward accounting data for round ${task.roundNumber}: " +
-        s"removed $deletedArchiveRows archived rows; and $summary."
-    )
+      deletedArchiveRows <- rewardsReferenceStore.pruneArchivedUpToRound(task.roundNumber)
+    } yield {
+      pruningMetrics.record(task.roundNumber, summary, deletedArchiveRows)
+      TaskSuccess(
+        s"Pruned reward accounting data for round ${task.roundNumber}: " +
+          s"removed $deletedArchiveRows archived rows; and $summary."
+      )
+    }
 
   override def isStaleTask(task: Task)(implicit tc: TraceContext): Future[Boolean] =
     rewardsReferenceStore.lookupArchivedAtForOpenMiningRound(task.roundNumber).map(_.isEmpty)
+
+  override def closeAsync(): Seq[AsyncOrSyncCloseable] =
+    super.closeAsync() :+
+      SyncCloseable("RewardAccountingPruningMetrics", pruningMetrics.close())
 }
 
 object PruneRewardAccountingTrigger {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
@@ -27,7 +27,7 @@ import org.lfdecentralizedtrust.splice.scan.store.{
   ScanStore,
 }
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
-import org.lfdecentralizedtrust.splice.scan.store.db.DbScanAppRewardsStore
+import org.lfdecentralizedtrust.splice.scan.store.db.{DbScanAppRewardsStore, DbScanVerdictStore}
 import org.lfdecentralizedtrust.splice.util.TemplateJsonDecoder
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.resource.DbStorage
@@ -84,6 +84,20 @@ class ScanAutomationService(
         appRewardsStore,
         appActivityStore,
         rewardsReferenceStore,
+        updateHistory,
+        triggerContext,
+      )
+    )
+
+  def registerPruneRewardAccountingTrigger(
+      rewardsReferenceStore: ScanRewardsReferenceStore,
+      verdictStore: DbScanVerdictStore,
+  ): Unit =
+    registerTrigger(
+      new PruneRewardAccountingTrigger(
+        appRewardsStore,
+        rewardsReferenceStore,
+        verdictStore,
         updateHistory,
         triggerContext,
       )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
@@ -99,6 +99,7 @@ class ScanAutomationService(
         rewardsReferenceStore,
         verdictStore,
         updateHistory,
+        config.rewardAccountingRetentionPeriod,
         triggerContext,
       )
     )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -81,6 +81,9 @@ case class ScanAppBackendConfig(
     // Max rounding error tolerated wrt actual total of minting allowances
     // and the per-round minting allowance from the CC whitepaper.
     rewardMintingAllowanceTolerance: BigDecimal = BigDecimal(0.1),
+    // Reward-accounting data is retained for this duration and may get pruned afterwards.
+    rewardAccountingRetentionPeriod: NonNegativeFiniteDuration =
+      NonNegativeFiniteDuration.ofDays(7),
     miningRoundsCacheTimeToLiveOverride: Option[NonNegativeFiniteDuration] = None,
     enableForcedAcsSnapshots: Boolean = false,
     // The migration id is normally read from the DB (the highest known migration id in the

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/RewardAccountingPruningMetrics.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/RewardAccountingPruningMetrics.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.scan.metrics
+
+import com.daml.metrics.api.MetricHandle.{Gauge, LabeledMetricsFactory, Meter}
+import com.daml.metrics.api.MetricQualification.{Debug, Traffic}
+import com.daml.metrics.api.{MetricInfo, MetricName, MetricsContext}
+import org.lfdecentralizedtrust.splice.environment.SpliceMetrics
+import org.lfdecentralizedtrust.splice.scan.store.db.DbScanAppRewardsStore.RewardAccountingPruneSummary
+
+class RewardAccountingPruningMetrics(metricsFactory: LabeledMetricsFactory)(implicit
+    metricsContext: MetricsContext
+) extends AutoCloseable {
+  private val prefix: MetricName =
+    SpliceMetrics.MetricsPrefix :+ "scan" :+ "reward_accounting_pruning"
+
+  // In normal operation this advances by one round per tick, so it stalling is
+  // the signal that pruning stopped making progress.
+  val prunedRound: Gauge[Long] = metricsFactory.gauge(
+    MetricInfo(
+      name = prefix :+ "pruned_round",
+      summary = "The round whose reward accounting data was deleted most recently",
+      qualification = Debug,
+    ),
+    -1L,
+  )(metricsContext)
+
+  private val deletedRows: Meter = metricsFactory.meter(
+    MetricInfo(
+      name = prefix :+ "deleted_rows",
+      summary = "Number of reward accounting rows deleted by pruning",
+      description = "The total number of rows deleted by the reward accounting pruning, " +
+        "labeled with the table they were deleted from.",
+      qualification = Traffic,
+      labelsWithDescription = Map("table" -> "The table the rows were deleted from"),
+    )
+  )(metricsContext)
+
+  private def markDeletedRows(table: String, rows: Long): Unit =
+    deletedRows.mark(rows)(metricsContext.withExtraLabels("table" -> table))
+
+  def record(
+      roundNumber: Long,
+      summary: RewardAccountingPruneSummary,
+      deletedArchiveRows: Long,
+  ): Unit = {
+    markDeletedRows("app_activity_party_totals", summary.activityPartyTotals)
+    markDeletedRows("app_activity_round_totals", summary.activityRoundTotals)
+    markDeletedRows("app_reward_party_totals", summary.rewardPartyTotals)
+    markDeletedRows("app_reward_round_totals", summary.rewardRoundTotals)
+    markDeletedRows("app_reward_batch_hashes", summary.batchHashes)
+    markDeletedRows("app_reward_root_hashes", summary.rootHashes)
+    markDeletedRows("scan_rewards_reference_store_archived", deletedArchiveRows)
+    prunedRound.updateValue(roundNumber)
+  }
+
+  override def close(): Unit = {
+    prunedRound.close()
+  }
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -11,7 +11,6 @@ import com.digitalasset.daml.lf.data.Numeric
 import com.digitalasset.daml.lf.data.{assertRight as damlRight}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
-import org.lfdecentralizedtrust.splice.store.TimestampWithMigrationId
 
 import java.math.RoundingMode
 import scala.collection.immutable.SortedMap
@@ -56,7 +55,7 @@ class AppActivityComputation(
   )(implicit tc: TraceContext): Future[Option[Long]] =
     rewardsReferenceStore
       .lookupActiveOpenMiningRounds(Seq(asOf))
-      .map(_.get(asOf).map { case TimestampWithMigrationId(_, roundNumber) => roundNumber })
+      .map(_.get(asOf).map { case (roundNumber, _) => roundNumber })
 
   /** Compute app activity records for a batch of verdicts.
     *
@@ -105,7 +104,7 @@ class AppActivityComputation(
             Future.successful((summary, verdict, None))
           case (summary, verdict, true) =>
             roundInfoByTime.get(summary.sequencingTime) match {
-              case Some(TimestampWithMigrationId(roundOpensAt, roundNumber)) =>
+              case Some((roundNumber, roundOpensAt)) =>
                 for {
                   featuredAppWeights <- rewardsReferenceStore.lookupFeaturedAppPartiesAsOf(
                     roundOpensAt

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -92,6 +92,21 @@ class CachingScanRewardsReferenceStore private[splice] (
   ): Future[Seq[Contract[CalculateRewardsV2.ContractId, CalculateRewardsV2]]] =
     store.listActiveCalculateRewardsV2ForRound(roundNumber)
 
+  override def lookupArchivedAtForOpenMiningRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Option[CantonTimestamp]] =
+    store.lookupArchivedAtForOpenMiningRound(roundNumber)
+
+  override def lookupLowestPrunableArchivedRewardRound()(implicit
+      tc: TraceContext
+  ): Future[Option[Long]] =
+    store.lookupLowestPrunableArchivedRewardRound()
+
+  override def pruneArchivedDataForRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Long] =
+    store.pruneArchivedDataForRound(roundNumber)
+
   override val storeName: String = store.storeName
   override def defaultLimit: Limit = store.defaultLimit
   override lazy val acsContractFilter = store.acsContractFilter

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -97,10 +97,10 @@ class CachingScanRewardsReferenceStore private[splice] (
   ): Future[Option[Long]] =
     store.lookupLowestPrunableArchivedRewardRound()
 
-  override def pruneArchivedDataForRound(
+  override def pruneArchivedUpToRound(
       roundNumber: Long
   )(implicit tc: TraceContext): Future[Long] =
-    store.pruneArchivedDataForRound(roundNumber)
+    store.pruneArchivedUpToRound(roundNumber)
 
   override val storeName: String = store.storeName
   override def defaultLimit: Limit = store.defaultLimit

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -10,12 +10,7 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.github.blemale.scaffeine.Scaffeine
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.rewardaccountingv2.CalculateRewardsV2
 import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
-import org.lfdecentralizedtrust.splice.store.{
-  Limit,
-  MultiDomainAcsStore,
-  SynchronizerStore,
-  TimestampWithMigrationId,
-}
+import org.lfdecentralizedtrust.splice.store.{Limit, MultiDomainAcsStore, SynchronizerStore}
 import org.lfdecentralizedtrust.splice.util.Contract
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -57,7 +52,7 @@ class CachingScanRewardsReferenceStore private[splice] (
 
   override def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]] =
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]] =
     store.lookupActiveOpenMiningRounds(recordTimes)
 
   override def lookupFeaturedAppPartiesAsOf(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanAppRewardsStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanAppRewardsStore.scala
@@ -5,7 +5,10 @@ package org.lfdecentralizedtrust.splice.scan.store
 
 import com.digitalasset.canton.tracing.TraceContext
 import org.lfdecentralizedtrust.splice.scan.rewards.RewardComputationInputs
-import org.lfdecentralizedtrust.splice.scan.store.db.DbScanAppRewardsStore.RewardComputationSummary
+import org.lfdecentralizedtrust.splice.scan.store.db.DbScanAppRewardsStore.{
+  RewardAccountingPruneSummary,
+  RewardComputationSummary,
+}
 
 import scala.concurrent.Future
 
@@ -31,4 +34,11 @@ trait ScanAppRewardsStore {
       batchSize: Int,
       inputs: RewardComputationInputs,
   )(implicit tc: TraceContext): Future[RewardComputationSummary]
+
+  /** Deletes all reward-accounting data for a single round across all six
+    * reward-accounting tables.
+    */
+  def deleteRewardAccountingDataForRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[RewardAccountingPruneSummary]
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -99,6 +99,30 @@ trait ScanRewardsReferenceStore extends AppStore {
       tc: TraceContext
   ): Future[Seq[Contract[CalculateRewardsV2.ContractId, CalculateRewardsV2]]]
 
+  def lookupArchivedAtForOpenMiningRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Option[CantonTimestamp]]
+
+  /** The lowest round number that may be safe to prune
+    * The criterion is based on the prescence of `OpenMiningRound`,
+    *  `CalculateRewardsV2`, or `ProcessRewardsV2` for a round in the active table.
+    * If all of these contracts for a round are archived then the reward processing is done.
+    * In addition we also check that none of these three contracts are active for any lower round.
+    */
+  def lookupLowestPrunableArchivedRewardRound()(implicit tc: TraceContext): Future[Option[Long]]
+
+  /** Deletes all rows from the archive table with `archived_at <=` the record_time at
+    * which round's `OpenMiningRound` contract was archived.
+    *
+    * Here we don't have a lower bound on the `archived_at`, so this API should
+    * be used with care, preferably ensuring that the deletion happens one round at a time.
+    *
+    * Returns number of rows deleted.
+    */
+  def pruneArchivedDataForRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Long]
+
   /** List active CalculateRewardsV2 contracts for the given round.
     */
   def listActiveCalculateRewardsV2ForRound(roundNumber: Long)(implicit

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -149,11 +149,6 @@ trait ScanRewardsReferenceStore extends AppStore {
               )
               None
             } else Some(roundNumber)
-          case (_, None) =>
-            logger.debug(
-              s"Skipping pruning of round $roundNumber as round ${roundNumber + 1} has not archived yet."
-            )
-            None
           case (None, _) =>
             // This happens after bootstrapping this store while the round
             // advancement is lagging, as then the oldest open round as of
@@ -161,6 +156,15 @@ trait ScanRewardsReferenceStore extends AppStore {
             logger.debug(
               s"Skipping pruning of round $roundNumber as no active OpenMiningRound could be " +
                 s"resolved as of the last ingested verdict record time ($lastIngestedRecordTime)."
+            )
+            None
+          case (_, None) =>
+            // We can't have lookupActiveOpenMiningRounds resolve an activeRoundO
+            // while the roundNumber is the lowest prunable round in store, and the roundNumber + 1 has not archived
+            // as the roundNumber + 1 must have opened before roundNumber - 1 was archived.
+            logger.warn(
+              s"This should never happen. Skipping pruning of round $roundNumber as round ${roundNumber + 1} has not archived yet " +
+                s"even though an active OpenMiningRound resolved as of $lastIngestedRecordTime."
             )
             None
         }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -133,19 +133,19 @@ trait ScanRewardsReferenceStore extends AppStore {
         } yield (activeRoundO, archivedAtNextO) match {
           case (Some((activeRoundNumber, activeRoundOpensAt)), Some(archivedAtNext)) =>
             val retainUntil = now.minus(retentionPeriod.asJava)
-            if (activeRoundOpensAt <= archivedAtNext) {
-              logger.debug(
-                s"Skipping pruning of round $roundNumber as the ingestion's currently active round " +
-                  s"$activeRoundNumber opened at $activeRoundOpensAt, which is not yet past round " +
-                  s"${roundNumber + 1}'s archivedAt ($archivedAtNext)."
-              )
-              None
-            } else if (retainUntil <= archivedAtNext) {
+            if (retainUntil <= archivedAtNext) {
               // We compare retentionPeriod with archived_at of roundNumber + 1
               // just to avoid an additional DB lookup of archived_at of roundNumber
               logger.debug(
                 s"Skipping pruning of round $roundNumber as round ${roundNumber + 1}'s archivedAt " +
                   s"($archivedAtNext) is still within the retention period."
+              )
+              None
+            } else if (activeRoundOpensAt <= archivedAtNext) {
+              logger.debug(
+                s"Skipping pruning of round $roundNumber as the ingestion's currently active round " +
+                  s"$activeRoundNumber opened at $activeRoundOpensAt, which is not yet past round " +
+                  s"${roundNumber + 1}'s archivedAt ($archivedAtNext)."
               )
               None
             } else Some(roundNumber)

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.store
 
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.CloseContext
 import com.digitalasset.canton.logging.NamedLoggerFactory
@@ -99,22 +100,83 @@ trait ScanRewardsReferenceStore extends AppStore {
   )(implicit tc: TraceContext): Future[Option[CantonTimestamp]]
 
   /** The lowest round number that may be safe to prune
-    * The criterion is based on the prescence of `OpenMiningRound`,
+    * The criterion is based on the presence of `OpenMiningRound`,
     *  `CalculateRewardsV2`, or `ProcessRewardsV2` for a round in the active table.
     * If all of these contracts for a round are archived then the reward processing is done.
     * In addition we also check that none of these three contracts are active for any lower round.
     */
   def lookupLowestPrunableArchivedRewardRound()(implicit tc: TraceContext): Future[Option[Long]]
 
+  /** The lowest round number that is safe to prune given that verdicts have been
+    * ingested up to `lastIngestedRecordTime`, and that data is retained for at
+    * least `retentionPeriod` before it may be pruned.
+    */
+  def lookupPrunableRewardRound(
+      lastIngestedRecordTime: CantonTimestamp,
+      now: CantonTimestamp,
+      retentionPeriod: NonNegativeFiniteDuration,
+  )(implicit tc: TraceContext): Future[Option[Long]] =
+    lookupLowestPrunableArchivedRewardRound().flatMap {
+      case None => Future.successful(None)
+      case Some(roundNumber) =>
+        // The earliest archived_at row acts as an indicator of the "ingestion
+        // start" of this store, and therefore we need to ensure that we keep at
+        // least one archived row with a record_time lower than the `opensAt` of
+        // the oldest round that is still open as of lastIngestedRecordTime.
+        //
+        // A simple way to ensure this is to compare that `opensAt` with the
+        // archived_at of round roundNumber + 1.
+        for {
+          activeRoundO <- lookupActiveOpenMiningRounds(Seq(lastIngestedRecordTime))
+            .map(_.get(lastIngestedRecordTime))
+          archivedAtNextO <- lookupArchivedAtForOpenMiningRound(roundNumber + 1)
+        } yield (activeRoundO, archivedAtNextO) match {
+          case (Some((activeRoundNumber, activeRoundOpensAt)), Some(archivedAtNext)) =>
+            val retainUntil = now.minus(retentionPeriod.asJava)
+            if (activeRoundOpensAt <= archivedAtNext) {
+              logger.debug(
+                s"Skipping pruning of round $roundNumber as the ingestion's currently active round " +
+                  s"$activeRoundNumber opened at $activeRoundOpensAt, which is not yet past round " +
+                  s"${roundNumber + 1}'s archivedAt ($archivedAtNext)."
+              )
+              None
+            } else if (retainUntil <= archivedAtNext) {
+              // We compare retentionPeriod with archived_at of roundNumber + 1
+              // just to avoid an additional DB lookup of archived_at of roundNumber
+              logger.debug(
+                s"Skipping pruning of round $roundNumber as round ${roundNumber + 1}'s archivedAt " +
+                  s"($archivedAtNext) is still within the retention period."
+              )
+              None
+            } else Some(roundNumber)
+          case (_, None) =>
+            logger.debug(
+              s"Skipping pruning of round $roundNumber as round ${roundNumber + 1} has not archived yet."
+            )
+            None
+          case (None, _) =>
+            // This happens after bootstrapping this store while the round
+            // advancement is lagging, as then the oldest open round as of
+            // lastIngestedRecordTime opened before the store's ingestion start.
+            logger.debug(
+              s"Skipping pruning of round $roundNumber as no active OpenMiningRound could be " +
+                s"resolved as of the last ingested verdict record time ($lastIngestedRecordTime)."
+            )
+            None
+        }
+    }
+
   /** Deletes all rows from the archive table with `archived_at <=` the record_time at
-    * which round's `OpenMiningRound` contract was archived.
+    * which round's `OpenMiningRound` contract was archived, and thereby moves
+    * the ingestion start of this store to the earliest remaining archival.
+    * Fails if there is no such archival, or if the round's archival has not been observed.
     *
     * Here we don't have a lower bound on the `archived_at`, so this API should
     * be used with care, preferably ensuring that the deletion happens one round at a time.
     *
     * Returns number of rows deleted.
     */
-  def pruneArchivedDataForRound(
+  def pruneArchivedUpToRound(
       roundNumber: Long
   )(implicit tc: TraceContext): Future[Long]
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -16,12 +16,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
 import org.lfdecentralizedtrust.splice.config.IngestionConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.scan.store.db.ScanRewardsReferenceTables.ScanRewardsReferenceStoreRowData
-import org.lfdecentralizedtrust.splice.store.{
-  AppStore,
-  Limit,
-  MultiDomainAcsStore,
-  TimestampWithMigrationId,
-}
+import org.lfdecentralizedtrust.splice.store.{AppStore, Limit, MultiDomainAcsStore}
 import org.lfdecentralizedtrust.splice.store.db.AcsInterfaceViewRowData
 import org.lfdecentralizedtrust.splice.util.{Contract, TemplateJsonDecoder}
 
@@ -62,7 +57,7 @@ trait ScanRewardsReferenceStore extends AppStore {
     */
   def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]]
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]]
 
   def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
@@ -89,6 +89,16 @@ object DbScanAppRewardsStore {
       batchesCreatedCount: Long,
   )
 
+  /** Row counts deleted per table by `deleteRewardAccountingDataForRound`. */
+  final case class RewardAccountingPruneSummary(
+      activityPartyTotals: Long,
+      activityRoundTotals: Long,
+      rewardPartyTotals: Long,
+      rewardRoundTotals: Long,
+      batchHashes: Long,
+      rootHashes: Long,
+  )
+
   /** A SHA-256 hash stored as raw bytes, avoiding unnecessary Array[Byte] ↔
     * ByteString conversions at the DB boundary. Conversion to hex strings
     * for the HTTP layer is done via `toHex` / `fromHex`.
@@ -1021,6 +1031,49 @@ class DbScanAppRewardsStore(
               where history_id = $historyId and round_number = $roundNumber
             )
     """.asUpdate
+
+  /** Deletes all reward-accounting data for a single round across all six
+    * tables, in a single transaction.
+    */
+  def deleteRewardAccountingDataForRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[DbScanAppRewardsStore.RewardAccountingPruneSummary] = {
+    import profile.api.jdbcActionExtensionMethods
+
+    runUpdate(
+      (for {
+        batchHashes <-
+          sql"""delete from #${Tables.appRewardBatchHashes}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+        rootHashes <-
+          sql"""delete from #${Tables.appRewardRootHashes}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+        rewardPartyTotals <-
+          sql"""delete from #${Tables.appRewardPartyTotals}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+        rewardRoundTotals <-
+          sql"""delete from #${Tables.appRewardRoundTotals}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+        activityPartyTotals <-
+          sql"""delete from #${Tables.appActivityPartyTotals}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+        activityRoundTotals <-
+          sql"""delete from #${Tables.appActivityRoundTotals}
+                where history_id = $historyId and round_number = $roundNumber""".asUpdate
+      } yield DbScanAppRewardsStore.RewardAccountingPruneSummary(
+        activityPartyTotals = activityPartyTotals.toLong,
+        activityRoundTotals = activityRoundTotals.toLong,
+        rewardPartyTotals = rewardPartyTotals.toLong,
+        rewardRoundTotals = rewardRoundTotals.toLong,
+        batchHashes = batchHashes.toLong,
+        rootHashes = rootHashes.toLong,
+      )).map { summary =>
+        logger.debug(s"Pruned reward accounting data for round $roundNumber: $summary")
+        summary
+      }.transactionally,
+      "appRewards.deleteRewardAccountingDataForRound",
+    )
+  }
 
   // -- Private helpers -------------------------------------------------------
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -278,6 +278,85 @@ class DbScanRewardsReferenceStore(
       case _ => Future.successful(None)
     }
 
+  def lookupArchivedAtForOpenMiningRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Option[CantonTimestamp]] =
+    waitUntilInitialized.flatMap { _ =>
+      val storeId = multiDomainAcsStore.acsStoreId
+      val migrationId = multiDomainAcsStore.domainMigrationId
+      val pqn = PackageQualifiedName.fromJavaCodegenCompanion(OpenMiningRound.COMPANION)
+      futureUnlessShutdownToFuture(
+        storage.query(
+          sql"""select acs.archived_at
+                from #${ScanRewardsReferenceTables.archiveTableName} acs
+                where acs.store_id = $storeId
+                  and acs.migration_id = $migrationId
+                  and acs.package_name = ${pqn.packageName}
+                  and acs.template_id_qualified_name = ${pqn.qualifiedName}
+                  and acs.round = $roundNumber
+                limit 1
+           """.as[CantonTimestamp].headOption,
+          "lookupArchivedAtForOpenMiningRound",
+        )
+      )
+    }
+
+  override def lookupLowestPrunableArchivedRewardRound()(implicit
+      tc: TraceContext
+  ): Future[Option[Long]] =
+    waitUntilInitialized.flatMap { _ =>
+      val storeId = multiDomainAcsStore.acsStoreId
+      val migrationId = multiDomainAcsStore.domainMigrationId
+      // It is important to limit the query for the round to OpenMiningRound
+      // as we prune only the contracts <= OpenMiningRound's archived_at
+      // and the db will likely still have other contracts for this round
+      // even after the pruning.
+      val pqn = PackageQualifiedName.fromJavaCodegenCompanion(OpenMiningRound.COMPANION)
+      futureUnlessShutdownToFuture(
+        storage.query(
+          sql"""select min(archived.round)
+                from #${ScanRewardsReferenceTables.archiveTableName} archived
+                where archived.store_id = $storeId and archived.migration_id = $migrationId
+                  and archived.package_name = ${pqn.packageName}
+                  and archived.template_id_qualified_name = ${pqn.qualifiedName}
+                  and archived.round is not null
+                  and not exists (
+                    select 1
+                    from #${ScanRewardsReferenceTables.acsTableName} active
+                    where active.store_id = archived.store_id
+                      and active.migration_id = archived.migration_id
+                      and active.round <= archived.round
+                  )
+           """.as[Option[Long]].head,
+          "lookupLowestPrunableArchivedRewardRound",
+        )
+      )
+    }
+
+  // Returns number of rows deleted
+  def pruneArchivedDataForRound(
+      roundNumber: Long
+  )(implicit tc: TraceContext): Future[Long] =
+    lookupArchivedAtForOpenMiningRound(roundNumber).flatMap {
+      case None =>
+        Future.failed(
+          new IllegalStateException(
+            s"Cannot prune archived data for round $roundNumber: its OpenMiningRound has not been observed as archived."
+          )
+        )
+      case Some(uptoInclusive) =>
+        val storeId = multiDomainAcsStore.acsStoreId
+        val migrationId = multiDomainAcsStore.domainMigrationId
+        futureUnlessShutdownToFuture(
+          storage.update(
+            sql"""delete from #${ScanRewardsReferenceTables.archiveTableName}
+                  where store_id = $storeId and migration_id = $migrationId
+                    and archived_at <= $uptoInclusive""".asUpdate,
+            "pruneArchivedDataForRound",
+          )
+        ).map(_.toLong)
+    }
+
   override def listActiveCalculateRewardsV2(limit: Limit = defaultLimit)(implicit
       tc: TraceContext
   ): Future[Seq[Contract[CalculateRewardsV2.ContractId, CalculateRewardsV2]]] =

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -17,12 +17,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound
 import org.lfdecentralizedtrust.splice.config.IngestionConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.store.{
-  Limit,
-  LimitHelpers,
-  TcsStore,
-  TimestampWithMigrationId,
-}
+import org.lfdecentralizedtrust.splice.store.{Limit, LimitHelpers, TcsStore}
 import org.lfdecentralizedtrust.splice.store.db.{
   AcsArchiveConfig,
   AcsQueries,
@@ -108,7 +103,7 @@ class DbScanRewardsReferenceStore(
 
   override def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
-  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, TimestampWithMigrationId]] = {
+  )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]] = {
     tcsStore.getEarliestArchivedAt().flatMap {
       case None =>
         Future.successful(Map.empty)
@@ -130,10 +125,7 @@ class DbScanRewardsReferenceStore(
                 .flatMap { r =>
                   val opensAt = CantonTimestamp.assertFromInstant(r.contract.payload.opensAt)
                   Option.when(opensAt >= ingestionStart) {
-                    recordTime -> TimestampWithMigrationId(
-                      opensAt,
-                      r.contract.payload.round.number.toLong,
-                    )
+                    recordTime -> (r.contract.payload.round.number.toLong, opensAt)
                   }
                 }
             }.toMap

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -270,7 +270,7 @@ class DbScanRewardsReferenceStore(
       case _ => Future.successful(None)
     }
 
-  def lookupArchivedAtForOpenMiningRound(
+  override def lookupArchivedAtForOpenMiningRound(
       roundNumber: Long
   )(implicit tc: TraceContext): Future[Option[CantonTimestamp]] =
     waitUntilInitialized.flatMap { _ =>
@@ -311,7 +311,6 @@ class DbScanRewardsReferenceStore(
                 where archived.store_id = $storeId and archived.migration_id = $migrationId
                   and archived.package_name = ${pqn.packageName}
                   and archived.template_id_qualified_name = ${pqn.qualifiedName}
-                  and archived.round is not null
                   and not exists (
                     select 1
                     from #${ScanRewardsReferenceTables.acsTableName} active
@@ -326,7 +325,7 @@ class DbScanRewardsReferenceStore(
     }
 
   // Returns number of rows deleted
-  def pruneArchivedDataForRound(
+  override def pruneArchivedUpToRound(
       roundNumber: Long
   )(implicit tc: TraceContext): Future[Long] =
     lookupArchivedAtForOpenMiningRound(roundNumber).flatMap {
@@ -336,17 +335,7 @@ class DbScanRewardsReferenceStore(
             s"Cannot prune archived data for round $roundNumber: its OpenMiningRound has not been observed as archived."
           )
         )
-      case Some(uptoInclusive) =>
-        val storeId = multiDomainAcsStore.acsStoreId
-        val migrationId = multiDomainAcsStore.domainMigrationId
-        futureUnlessShutdownToFuture(
-          storage.update(
-            sql"""delete from #${ScanRewardsReferenceTables.archiveTableName}
-                  where store_id = $storeId and migration_id = $migrationId
-                    and archived_at <= $uptoInclusive""".asUpdate,
-            "pruneArchivedDataForRound",
-          )
-        ).map(_.toLong)
+      case Some(uptoInclusive) => tcsStore.pruneArchivedUpTo(uptoInclusive)
     }
 
   override def listActiveCalculateRewardsV2(limit: Limit = defaultLimit)(implicit

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
@@ -11,7 +11,6 @@ import com.google.protobuf.timestamp.Timestamp as ProtoTimestamp
 import com.google.protobuf.ByteString
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
-import org.lfdecentralizedtrust.splice.store.TimestampWithMigrationId
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Future
@@ -220,7 +219,7 @@ class AppActivityComputationTest extends AnyWordSpec with BaseTest {
     val store = mock[ScanRewardsReferenceStore]
     when(store.lookupActiveOpenMiningRounds(any[Seq[CantonTimestamp]])(any[TraceContext]))
       .thenAnswer { (times: Seq[CantonTimestamp]) =>
-        Future.successful(times.map(_ -> TimestampWithMigrationId(roundOpensAt, 0L)).toMap)
+        Future.successful(times.map(_ -> (0L, roundOpensAt)).toMap)
       }
     when(store.lookupFeaturedAppPartiesAsOf(any[CantonTimestamp])(any[TraceContext]))
       .thenReturn(Future.successful(featuredWeights))

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -1075,6 +1075,96 @@ class DbScanAppRewardsStoreTest
     }
   }
 
+  "deleteRewardAccountingDataForRound" should {
+    "deletes only the given round, keeps other rounds and other histories" in {
+      val dummyHash = RewardHash(Array.fill(32)(0: Byte))
+
+      def insertAllTables(
+          store: DbScanAppRewardsStore,
+          historyId: Long,
+          round: Long,
+      ): Future[Unit] =
+        for {
+          _ <- store.insertAppActivityPartyTotals(
+            Seq(AppActivityPartyTotalT(historyId, round, 100L, s"party-$round", 1L))
+          )
+          _ <- store.insertAppActivityRoundTotals(
+            Seq(AppActivityRoundTotalT(historyId, round, 100L, 1L, 1L))
+          )
+          _ <- store.insertAppRewardPartyTotals(
+            Seq(AppRewardPartyTotalT(historyId, round, 0, s"party-$round", BigDecimal(1)))
+          )
+          _ <- store.insertAppRewardRoundTotals(
+            Seq(
+              AppRewardRoundTotalT(
+                historyId,
+                round,
+                BigDecimal(1),
+                BigDecimal(0),
+                BigDecimal(0),
+                1L,
+              )
+            )
+          )
+          _ <- store.insertAppRewardBatchHashes(
+            Seq(AppRewardBatchHashT(historyId, round, 0, 0, 1, dummyHash))
+          )
+          _ <- store.insertAppRewardRootHashes(
+            Seq(AppRewardRootHashT(historyId, round, dummyHash))
+          )
+        } yield ()
+
+      for {
+        (store, historyId) <- newStore()
+        (otherStore, otherHistoryId) <- newStore()
+        _ <- insertAllTables(store, historyId, 1L)
+        _ <- insertAllTables(store, historyId, 2L)
+        _ <- insertAllTables(store, historyId, 3L)
+        _ <- insertAllTables(otherStore, otherHistoryId, 1L)
+        _ <- store.deleteRewardAccountingDataForRound(2L)
+        activityPartyRound1 <- store.getAppActivityPartyTotalsByRound(1L)
+        activityPartyRound2 <- store.getAppActivityPartyTotalsByRound(2L)
+        activityPartyRound3 <- store.getAppActivityPartyTotalsByRound(3L)
+        activityRoundRound1 <- store.getAppActivityRoundTotalByRound(1L)
+        activityRoundRound2 <- store.getAppActivityRoundTotalByRound(2L)
+        activityRoundRound3 <- store.getAppActivityRoundTotalByRound(3L)
+        rewardPartyRound1 <- store.getAppRewardPartyTotalsByRound(1L)
+        rewardPartyRound2 <- store.getAppRewardPartyTotalsByRound(2L)
+        rewardPartyRound3 <- store.getAppRewardPartyTotalsByRound(3L)
+        rewardRoundRound1 <- store.getAppRewardRoundTotalByRound(1L)
+        rewardRoundRound2 <- store.getAppRewardRoundTotalByRound(2L)
+        rewardRoundRound3 <- store.getAppRewardRoundTotalByRound(3L)
+        batchHashesRound1 <- store.getAppRewardBatchHashesByRound(1L)
+        batchHashesRound2 <- store.getAppRewardBatchHashesByRound(2L)
+        batchHashesRound3 <- store.getAppRewardBatchHashesByRound(3L)
+        rootHashRound1 <- store.getAppRewardRootHashByRound(1L)
+        rootHashRound2 <- store.getAppRewardRootHashByRound(2L)
+        rootHashRound3 <- store.getAppRewardRootHashByRound(3L)
+        otherActivityPartyRound1 <- otherStore.getAppActivityPartyTotalsByRound(1L)
+      } yield {
+        activityPartyRound1 should have size 1
+        activityPartyRound2 shouldBe empty
+        activityPartyRound3 should have size 1
+        activityRoundRound1 shouldBe defined
+        activityRoundRound2 shouldBe empty
+        activityRoundRound3 shouldBe defined
+        rewardPartyRound1 should have size 1
+        rewardPartyRound2 shouldBe empty
+        rewardPartyRound3 should have size 1
+        rewardRoundRound1 shouldBe defined
+        rewardRoundRound2 shouldBe empty
+        rewardRoundRound3 shouldBe defined
+        batchHashesRound1 should have size 1
+        batchHashesRound2 shouldBe empty
+        batchHashesRound3 should have size 1
+        rootHashRound1 shouldBe defined
+        rootHashRound2 shouldBe empty
+        rootHashRound3 shouldBe defined
+        otherActivityPartyRound1 should have size 1
+      }
+    }
+  }
+
   private val verdictCounter = new java.util.concurrent.atomic.AtomicLong(1)
 
   /** Insert a parent row into scan_verdict_store then a child row into

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
@@ -426,6 +426,199 @@ class DbScanRewardsReferenceStoreTest
       }
     }
 
+    "lookupArchivedAtForOpenMiningRound returns the archival record_time for a round" in {
+      val store = mkStore()
+      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+        .copy(createdAt = ts(100).toInstant)
+      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.5)
+        .copy(createdAt = ts(200).toInstant)
+      val omr5 = openMiningRound(dsoParty, round = 5, amuletPrice = 2.0)
+        .copy(createdAt = ts(300).toInstant)
+      val cr3 = calculateRewardsV2(dsoParty, round = 3)
+        .copy(createdAt = ts(350).toInstant)
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+        _ <- sync1.create(omr3, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr4, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr5, recordTime = ts(300).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(omr3, recordTime = ts(350).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr3, recordTime = ts(350).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(omr4, recordTime = ts(450).toInstant)(store.multiDomainAcsStore)
+
+        archivedAt3 <- store.lookupArchivedAtForOpenMiningRound(3)
+        archivedAt4 <- store.lookupArchivedAtForOpenMiningRound(4)
+        archivedAt5 <- store.lookupArchivedAtForOpenMiningRound(5)
+        archivedAt9 <- store.lookupArchivedAtForOpenMiningRound(9)
+      } yield {
+        archivedAt3 shouldBe Some(ts(350))
+        archivedAt4 shouldBe Some(ts(450))
+        archivedAt5 shouldBe None
+        // Round doesn't exist
+        archivedAt9 shouldBe None
+      }
+    }
+
+    "pruneArchivedDataForRound deletes all archived rows with archived_at at or before the round archival time" in {
+      val store = mkStore()
+      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+        .copy(createdAt = ts(50).toInstant)
+      val cr3 = calculateRewardsV2(dsoParty, round = 3)
+        .copy(createdAt = ts(50).toInstant)
+      val far1 = featuredAppRight(userParty(1))
+        .copy(createdAt = ts(50).toInstant)
+      val far2 = featuredAppRight(userParty(2))
+        .copy(createdAt = ts(50).toInstant)
+      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.5)
+        .copy(createdAt = ts(200).toInstant)
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(far1, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(far2, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr4, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+
+        _ <- sync1.archive(far1, recordTime = ts(340).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(omr3, recordTime = ts(350).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(far1, recordTime = ts(360).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(cr3, recordTime = ts(380).toInstant)(store.multiDomainAcsStore)
+
+        lowestPrunableBeforePrune <- store.lookupLowestPrunableArchivedRewardRound()
+
+        deletedCount <- store.pruneArchivedDataForRound(roundNumber = 3)
+
+        lowestPrunableAfterPrune <- store.lookupLowestPrunableArchivedRewardRound()
+
+        afterPruneRound3 <- store.lookupOpenMiningRoundByNumber(3)
+        farAfterPrune <- store.lookupFeaturedAppPartiesAsOf(ts(300))
+        afterPruneRound4 <- store.lookupOpenMiningRoundByNumber(4)
+      } yield {
+        deletedCount shouldBe 2L
+        lowestPrunableBeforePrune shouldBe Some(3L)
+        lowestPrunableAfterPrune shouldBe None
+        afterPruneRound3 shouldBe None
+        farAfterPrune.keySet should not contain userParty(1).toProtoPrimitive
+        farAfterPrune.keySet should contain(userParty(2).toProtoPrimitive)
+        afterPruneRound4 shouldBe defined
+      }
+    }
+
+    "pruneArchivedDataForRound fails when the round has not been observed as archived" in {
+      val store = mkStore()
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+        result <- store.pruneArchivedDataForRound(roundNumber = 2).failed
+      } yield {
+        result shouldBe an[IllegalStateException]
+      }
+    }
+
+    "lookupLowestPrunableArchivedRewardRound returns the lowest archived round processed completely" in {
+      val store = mkStore()
+      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+        .copy(createdAt = ts(100).toInstant)
+      val cr3 = calculateRewardsV2(dsoParty, round = 3)
+        .copy(createdAt = ts(200).toInstant)
+      val pr5 = processRewardsV2(dsoParty, round = 5)
+        .copy(createdAt = ts(300).toInstant)
+      // Archiving this must not affect the result even though it archives earliest.
+      val far1 = featuredAppRight(userParty(1))
+        .copy(createdAt = ts(100).toInstant)
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+
+        beforeAnyArchival <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = beforeAnyArchival shouldBe None
+
+        _ <- sync1.create(far1, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(pr5, recordTime = ts(300).toInstant)(store.multiDomainAcsStore)
+
+        _ <- sync1.archive(far1, recordTime = ts(150).toInstant)(store.multiDomainAcsStore)
+        onlyRoundlessArchived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = onlyRoundlessArchived shouldBe None
+
+        _ <- sync1.archive(omr4, recordTime = ts(400).toInstant)(store.multiDomainAcsStore)
+        onlyOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = onlyOmr4Archived shouldBe None
+
+        _ <- sync1.archive(cr3, recordTime = ts(410).toInstant)(store.multiDomainAcsStore)
+
+        // Round 3's OpenMiningRound was never ingested, so round 3 itself is
+        // not a candidate; round 4 is the lowest round with an archived
+        // OpenMiningRound with no active reward contract at or below it.
+        cr3AndOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = cr3AndOmr4Archived shouldBe Some(4L)
+
+        _ <- sync1.archive(pr5, recordTime = ts(420).toInstant)(store.multiDomainAcsStore)
+
+        // All of 3, 4, and 5 are archived
+        allThreeArchived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = allThreeArchived shouldBe Some(4L)
+      } yield succeed
+    }
+
+    "lookupLowestPrunableArchivedRewardRound excludes a round when a lower round still has an active CalculateRewardsV2" in {
+      val store = mkStore()
+      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+        .copy(createdAt = ts(50).toInstant)
+      val cr3 = calculateRewardsV2(dsoParty, round = 3)
+        .copy(createdAt = ts(60).toInstant)
+      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+        .copy(createdAt = ts(100).toInstant)
+      val cr4 = calculateRewardsV2(dsoParty, round = 4)
+        .copy(createdAt = ts(110).toInstant)
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+
+        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+
+        _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
+        whileCr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = whileCr3StillActive shouldBe None
+
+        _ <- sync1.archive(cr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
+        afterCr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = afterCr3Archived shouldBe Some(3L)
+      } yield succeed
+    }
+
+    "lookupLowestPrunableArchivedRewardRound excludes a round when a lower round still has an active ProcessRewardsV2" in {
+      val store = mkStore()
+      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+        .copy(createdAt = ts(50).toInstant)
+      val pr3 = processRewardsV2(dsoParty, round = 3)
+        .copy(createdAt = ts(60).toInstant)
+      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+        .copy(createdAt = ts(100).toInstant)
+      val cr4 = calculateRewardsV2(dsoParty, round = 4)
+        .copy(createdAt = ts(110).toInstant)
+      for {
+        _ <- initWithAcs()(store.multiDomainAcsStore)
+
+        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(pr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+
+        _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
+        _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
+        whilePr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = whilePr3StillActive shouldBe None
+
+        _ <- sync1.archive(pr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
+        afterPr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
+        _ = afterPr3Archived shouldBe Some(3L)
+      } yield succeed
+    }
+
     "lookupActiveOpenMiningRounds" in {
       val store = mkStore()
       // Timeline (ingestion start = 250, earliest archived_at):

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
@@ -24,14 +24,7 @@ import org.lfdecentralizedtrust.splice.environment.ledger.api.TreeUpdateOrOffset
 import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.store.{
-  HardLimit,
-  Limit,
-  PageLimit,
-  StoreTestBase,
-  TcsStore,
-  TimestampWithMigrationId,
-}
+import org.lfdecentralizedtrust.splice.store.{HardLimit, Limit, PageLimit, StoreTestBase, TcsStore}
 import org.lfdecentralizedtrust.splice.util.{ResourceTemplateDecoder, TemplateJsonDecoder}
 import slick.jdbc.JdbcProfile
 
@@ -679,16 +672,10 @@ class DbScanRewardsReferenceStoreTest
         result.get(ts(275)) shouldBe None // round4.opensAt before earliest archived_at
         result.get(ts(350)) shouldBe None // round4.opensAt before earliest archived_at
         result.get(ts(375)) shouldBe None // gap: round4 archived, round5 not yet open
-        result(ts(400)) shouldBe TimestampWithMigrationId(ts(400), 5L)
+        result(ts(400)) shouldBe (5L, ts(400))
         result.get(ts(401)) shouldBe None // 401 was not present in request
-        result(ts(450)) shouldBe TimestampWithMigrationId(
-          ts(400),
-          5L,
-        ) // round5 open, round6 not yet open
-        result(ts(550)) shouldBe TimestampWithMigrationId(
-          ts(400),
-          5L,
-        ) // both open, lowest round selected
+        result(ts(450)) shouldBe (5L, ts(400)) // round5 open, round6 not yet open
+        result(ts(550)) shouldBe (5L, ts(400)) // both open, lowest round selected
       }
     }
   }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyList
 import com.daml.ledger.javaapi.data.{OffsetCheckpoint, SynchronizerTime}
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.digitalasset.canton.concurrent.FutureSupervisor
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.resource.DbStorage
@@ -29,6 +30,7 @@ import org.lfdecentralizedtrust.splice.util.{ResourceTemplateDecoder, TemplateJs
 import slick.jdbc.JdbcProfile
 
 import java.util.{Collections, Optional}
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 
 class DbScanRewardsReferenceStoreTest
@@ -451,165 +453,374 @@ class DbScanRewardsReferenceStoreTest
       }
     }
 
-    "pruneArchivedDataForRound deletes all archived rows with archived_at at or before the round archival time" in {
-      val store = mkStore()
-      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
-        .copy(createdAt = ts(50).toInstant)
-      val cr3 = calculateRewardsV2(dsoParty, round = 3)
-        .copy(createdAt = ts(50).toInstant)
-      val far1 = featuredAppRight(userParty(1))
-        .copy(createdAt = ts(50).toInstant)
-      val far2 = featuredAppRight(userParty(2))
-        .copy(createdAt = ts(50).toInstant)
-      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.5)
-        .copy(createdAt = ts(200).toInstant)
-      for {
-        _ <- initWithAcs()(store.multiDomainAcsStore)
-        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(cr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(far1, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(far2, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(omr4, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+    "pruneArchivedUpToRound" should {
 
-        _ <- sync1.archive(far1, recordTime = ts(340).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(omr3, recordTime = ts(350).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(far1, recordTime = ts(360).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(cr3, recordTime = ts(380).toInstant)(store.multiDomainAcsStore)
+      "delete all archived rows with archived_at at or before the round archival time" in {
+        val store = mkStore()
+        val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+          .copy(createdAt = ts(50).toInstant)
+        val cr3 = calculateRewardsV2(dsoParty, round = 3)
+          .copy(createdAt = ts(50).toInstant)
+        val far1 = featuredAppRight(userParty(1))
+          .copy(createdAt = ts(50).toInstant)
+        val far2 = featuredAppRight(userParty(2))
+          .copy(createdAt = ts(50).toInstant)
+        val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.5)
+          .copy(createdAt = ts(200).toInstant)
+        for {
+          _ <- initWithAcs()(store.multiDomainAcsStore)
+          _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(cr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(far1, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(far2, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(omr4, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
 
-        lowestPrunableBeforePrune <- store.lookupLowestPrunableArchivedRewardRound()
+          _ <- sync1.archive(far1, recordTime = ts(340).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(omr3, recordTime = ts(350).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(far1, recordTime = ts(360).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(cr3, recordTime = ts(380).toInstant)(store.multiDomainAcsStore)
 
-        deletedCount <- store.pruneArchivedDataForRound(roundNumber = 3)
+          lowestPrunableBeforePrune <- store.lookupLowestPrunableArchivedRewardRound()
 
-        lowestPrunableAfterPrune <- store.lookupLowestPrunableArchivedRewardRound()
+          deletedCount <- store.pruneArchivedUpToRound(roundNumber = 3)
 
-        afterPruneRound3 <- store.lookupOpenMiningRoundByNumber(3)
-        farAfterPrune <- store.lookupFeaturedAppPartiesAsOf(ts(300))
-        afterPruneRound4 <- store.lookupOpenMiningRoundByNumber(4)
-      } yield {
-        deletedCount shouldBe 2L
-        lowestPrunableBeforePrune shouldBe Some(3L)
-        lowestPrunableAfterPrune shouldBe None
-        afterPruneRound3 shouldBe None
-        farAfterPrune.keySet should not contain userParty(1).toProtoPrimitive
-        farAfterPrune.keySet should contain(userParty(2).toProtoPrimitive)
-        afterPruneRound4 shouldBe defined
+          lowestPrunableAfterPrune <- store.lookupLowestPrunableArchivedRewardRound()
+
+          afterPruneRound3 <- store.lookupOpenMiningRoundByNumber(3)
+          farAfterPrune <- store.lookupFeaturedAppPartiesAsOf(ts(300))
+          afterPruneRound4 <- store.lookupOpenMiningRoundByNumber(4)
+        } yield {
+          deletedCount shouldBe 2L
+          lowestPrunableBeforePrune shouldBe Some(3L)
+          lowestPrunableAfterPrune shouldBe None
+          afterPruneRound3 shouldBe None
+          farAfterPrune.keySet should not contain userParty(1).toProtoPrimitive
+          farAfterPrune.keySet should contain(userParty(2).toProtoPrimitive)
+          afterPruneRound4 shouldBe defined
+        }
       }
-    }
 
-    "pruneArchivedDataForRound fails when the round has not been observed as archived" in {
-      val store = mkStore()
-      for {
-        _ <- initWithAcs()(store.multiDomainAcsStore)
-        result <- store.pruneArchivedDataForRound(roundNumber = 2).failed
-      } yield {
-        result shouldBe an[IllegalStateException]
+      "moves the ingestion start to the earliest remaining archival" in {
+        val store = mkStore()
+        for {
+          _ <- ingestOverlappingRounds(store)
+
+          beforePrune <- store.lookupActiveOpenMiningRounds(Seq(ts(450), ts(620)))
+          _ = beforePrune shouldBe Map(ts(450) -> (5L, ts(300)), ts(620) -> (7L, ts(500)))
+
+          deleted <- store.pruneArchivedUpToRound(3)
+          _ = deleted shouldBe 1L
+
+          // The store's "ingestion start" now moved to round 4's archival at t=400
+          // so we no longer have the complete data for 450.
+          afterPrune <- store.lookupActiveOpenMiningRounds(Seq(ts(450), ts(620)))
+          _ = afterPrune shouldBe Map(ts(620) -> (7L, ts(500)))
+        } yield succeed
       }
+
+      "fail when the round has not been observed as archived" in {
+        val store = mkStore()
+        for {
+          _ <- initWithAcs()(store.multiDomainAcsStore)
+          result <- store.pruneArchivedUpToRound(roundNumber = 2).failed
+        } yield {
+          result shouldBe an[IllegalStateException]
+        }
+      }
+
     }
 
-    "lookupLowestPrunableArchivedRewardRound returns the lowest archived round processed completely" in {
-      val store = mkStore()
-      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
-        .copy(createdAt = ts(100).toInstant)
-      val cr3 = calculateRewardsV2(dsoParty, round = 3)
-        .copy(createdAt = ts(200).toInstant)
-      val pr5 = processRewardsV2(dsoParty, round = 5)
-        .copy(createdAt = ts(300).toInstant)
-      // Archiving this must not affect the result even though it archives earliest.
-      val far1 = featuredAppRight(userParty(1))
-        .copy(createdAt = ts(100).toInstant)
-      for {
-        _ <- initWithAcs()(store.multiDomainAcsStore)
+    "lookupLowestPrunableArchivedRewardRound" should {
 
-        beforeAnyArchival <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = beforeAnyArchival shouldBe None
+      "return the lowest archived round processed completely" in {
+        val store = mkStore()
+        val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+          .copy(createdAt = ts(100).toInstant)
+        val cr3 = calculateRewardsV2(dsoParty, round = 3)
+          .copy(createdAt = ts(200).toInstant)
+        val pr5 = processRewardsV2(dsoParty, round = 5)
+          .copy(createdAt = ts(300).toInstant)
+        // Archiving this must not affect the result even though it archives earliest.
+        val far1 = featuredAppRight(userParty(1))
+          .copy(createdAt = ts(100).toInstant)
+        for {
+          _ <- initWithAcs()(store.multiDomainAcsStore)
 
-        _ <- sync1.create(far1, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(cr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(pr5, recordTime = ts(300).toInstant)(store.multiDomainAcsStore)
+          beforeAnyArchival <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = beforeAnyArchival shouldBe None
 
-        _ <- sync1.archive(far1, recordTime = ts(150).toInstant)(store.multiDomainAcsStore)
-        onlyRoundlessArchived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = onlyRoundlessArchived shouldBe None
+          _ <- sync1.create(far1, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(cr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(pr5, recordTime = ts(300).toInstant)(store.multiDomainAcsStore)
 
-        _ <- sync1.archive(omr4, recordTime = ts(400).toInstant)(store.multiDomainAcsStore)
-        onlyOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = onlyOmr4Archived shouldBe None
+          _ <- sync1.archive(far1, recordTime = ts(150).toInstant)(store.multiDomainAcsStore)
+          onlyRoundlessArchived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = onlyRoundlessArchived shouldBe None
 
-        _ <- sync1.archive(cr3, recordTime = ts(410).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(omr4, recordTime = ts(400).toInstant)(store.multiDomainAcsStore)
+          onlyOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = onlyOmr4Archived shouldBe None
 
-        // Round 3's OpenMiningRound was never ingested, so round 3 itself is
-        // not a candidate; round 4 is the lowest round with an archived
-        // OpenMiningRound with no active reward contract at or below it.
-        cr3AndOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = cr3AndOmr4Archived shouldBe Some(4L)
+          _ <- sync1.archive(cr3, recordTime = ts(410).toInstant)(store.multiDomainAcsStore)
 
-        _ <- sync1.archive(pr5, recordTime = ts(420).toInstant)(store.multiDomainAcsStore)
+          // Round 3's OpenMiningRound was never ingested, so round 3 itself is
+          // not a candidate; round 4 is the lowest round with an archived
+          // OpenMiningRound with no active reward contract at or below it.
+          cr3AndOmr4Archived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = cr3AndOmr4Archived shouldBe Some(4L)
 
-        // All of 3, 4, and 5 are archived
-        allThreeArchived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = allThreeArchived shouldBe Some(4L)
-      } yield succeed
+          _ <- sync1.archive(pr5, recordTime = ts(420).toInstant)(store.multiDomainAcsStore)
+
+          // All of 3, 4, and 5 are archived
+          allThreeArchived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = allThreeArchived shouldBe Some(4L)
+        } yield succeed
+      }
+
+      "exclude a round when a lower round still has an active CalculateRewardsV2" in {
+        val store = mkStore()
+        val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+          .copy(createdAt = ts(50).toInstant)
+        val cr3 = calculateRewardsV2(dsoParty, round = 3)
+          .copy(createdAt = ts(60).toInstant)
+        val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+          .copy(createdAt = ts(100).toInstant)
+        val cr4 = calculateRewardsV2(dsoParty, round = 4)
+          .copy(createdAt = ts(110).toInstant)
+        for {
+          _ <- initWithAcs()(store.multiDomainAcsStore)
+
+          _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(cr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+
+          _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
+          whileCr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = whileCr3StillActive shouldBe None
+
+          _ <- sync1.archive(cr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
+          afterCr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = afterCr3Archived shouldBe Some(3L)
+        } yield succeed
+      }
+
+      "exclude a round when a lower round still has an active ProcessRewardsV2" in {
+        val store = mkStore()
+        val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
+          .copy(createdAt = ts(50).toInstant)
+        val pr3 = processRewardsV2(dsoParty, round = 3)
+          .copy(createdAt = ts(60).toInstant)
+        val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
+          .copy(createdAt = ts(100).toInstant)
+        val cr4 = calculateRewardsV2(dsoParty, round = 4)
+          .copy(createdAt = ts(110).toInstant)
+        for {
+          _ <- initWithAcs()(store.multiDomainAcsStore)
+
+          _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(pr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+
+          _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
+          _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
+          whilePr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = whilePr3StillActive shouldBe None
+
+          _ <- sync1.archive(pr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
+          afterPr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = afterPr3Archived shouldBe Some(3L)
+        } yield succeed
+      }
+
     }
 
-    "lookupLowestPrunableArchivedRewardRound excludes a round when a lower round still has an active CalculateRewardsV2" in {
-      val store = mkStore()
-      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
-        .copy(createdAt = ts(50).toInstant)
-      val cr3 = calculateRewardsV2(dsoParty, round = 3)
-        .copy(createdAt = ts(60).toInstant)
-      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
-        .copy(createdAt = ts(100).toInstant)
-      val cr4 = calculateRewardsV2(dsoParty, round = 4)
-        .copy(createdAt = ts(110).toInstant)
-      for {
-        _ <- initWithAcs()(store.multiDomainAcsStore)
+    "lookupPrunableRewardRound" should {
 
-        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(cr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+      // Assuming that the verdict ingestion is lagging, and we have no retention window
+      // confirm that we don't prune a round until the verdict ingestion has moved past
+      // the prunable round's next round's archival
+      "return the round once the ingestion moved past the next round's archival" in {
+        val store = mkStore()
+        for {
+          _ <- ingestOverlappingRounds(store)
 
-        _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
-        whileCr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = whileCr3StillActive shouldBe None
+          // Round 3 is the lowest round with an archived OpenMiningRound and no
+          // active reward contract at or below it, and round 4 archived at t=400.
+          lowestPrunable <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = lowestPrunable shouldBe Some(3L)
+          archivedAt4 <- store.lookupArchivedAtForOpenMiningRound(4)
+          _ = archivedAt4 shouldBe Some(ts(400))
 
-        _ <- sync1.archive(cr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
-        afterCr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = afterCr3Archived shouldBe Some(3L)
-      } yield succeed
-    }
+          // Oldest open round 5, opened at t=300, ie before round 4's archival.
+          atRound5 <- store.lookupPrunableRewardRound(ts(420), timeAfterAllRounds, noRetention)
+          _ = atRound5 shouldBe None
+          // Oldest open round 6, opened exactly at round 4's archival.
+          atRound6 <- store.lookupPrunableRewardRound(ts(520), timeAfterAllRounds, noRetention)
+          _ = atRound6 shouldBe None
+          // Oldest open round 7, opened at t=500, ie past round 4's archival.
+          atRound7 <- store.lookupPrunableRewardRound(ts(620), timeAfterAllRounds, noRetention)
+          _ = atRound7 shouldBe Some(3L)
 
-    "lookupLowestPrunableArchivedRewardRound excludes a round when a lower round still has an active ProcessRewardsV2" in {
-      val store = mkStore()
-      val omr3 = openMiningRound(dsoParty, round = 3, amuletPrice = 1.0)
-        .copy(createdAt = ts(50).toInstant)
-      val pr3 = processRewardsV2(dsoParty, round = 3)
-        .copy(createdAt = ts(60).toInstant)
-      val omr4 = openMiningRound(dsoParty, round = 4, amuletPrice = 1.0)
-        .copy(createdAt = ts(100).toInstant)
-      val cr4 = calculateRewardsV2(dsoParty, round = 4)
-        .copy(createdAt = ts(110).toInstant)
-      for {
-        _ <- initWithAcs()(store.multiDomainAcsStore)
+          activeAtRound7 <- store.lookupActiveOpenMiningRounds(Seq(ts(620)))
+          _ = activeAtRound7 shouldBe Map(ts(620) -> ((7L, ts(500))))
 
-        _ <- sync1.create(omr3, recordTime = ts(50).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(pr3, recordTime = ts(60).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.create(cr4, recordTime = ts(110).toInstant)(store.multiDomainAcsStore)
+          // Doing prune here confirms that the lookupPrunableRewardRound works with the new db state
+          deleted <- store.pruneArchivedUpToRound(3)
+          _ = deleted shouldBe 1L
 
-        _ <- sync1.archive(omr3, recordTime = ts(200).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(omr4, recordTime = ts(210).toInstant)(store.multiDomainAcsStore)
-        _ <- sync1.archive(cr4, recordTime = ts(220).toInstant)(store.multiDomainAcsStore)
-        whilePr3StillActive <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = whilePr3StillActive shouldBe None
+          // Lookup works even after prune
+          activeAtRound7AfterDelete <- store.lookupActiveOpenMiningRounds(Seq(ts(620)))
+          _ = activeAtRound7AfterDelete shouldBe Map(ts(620) -> ((7L, ts(500))))
 
-        _ <- sync1.archive(pr3, recordTime = ts(230).toInstant)(store.multiDomainAcsStore)
-        afterPr3Archived <- store.lookupLowestPrunableArchivedRewardRound()
-        _ = afterPr3Archived shouldBe Some(3L)
-      } yield succeed
+          // Round 4 is now the lowest prunable round, and round 5 archived at t=500.
+          afterPruneAtRound7 <- store.lookupPrunableRewardRound(
+            ts(620),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound7 shouldBe None
+
+          // Oldest open round 8, opened at t=600, ie past round 5's archival.
+          afterPruneAtRound8 <- store.lookupPrunableRewardRound(
+            ts(720),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound8 shouldBe Some(4L)
+
+          // Pruning round 4 as well, ie two rounds are pruned in a row.
+          deletedRound4 <- store.pruneArchivedUpToRound(4)
+          _ = deletedRound4 shouldBe 1L
+
+          // At the same record time round 5 is kept, as round 8 opened exactly at
+          // round 6's archival (t=600).
+          afterPruneAtRound4 <- store.lookupPrunableRewardRound(
+            ts(720),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound4 shouldBe None
+        } yield succeed
+      }
+
+      // Similar to above, but confirm that logic works correct even when we have a lag in round archival
+      "return the round once the ingestion moved past the next round's archival even when round advancement lags" in {
+        val store = mkStore()
+        for {
+          _ <- ingestLaggingArchivalRounds(store)
+
+          // Round 3 is the lowest round with an archived OpenMiningRound and no
+          // active reward contract at or below it, and round 4 archived at t=500.
+          lowestPrunable <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = lowestPrunable shouldBe Some(3L)
+          archivedAt4 <- store.lookupArchivedAtForOpenMiningRound(4)
+          _ = archivedAt4 shouldBe Some(ts(500))
+
+          // Round 5, the oldest open round as of t=520, opened at t=300, ie before
+          // the ingestion start (t=350), so no active round resolves for t=520.
+          activeAtRound5 <- store.lookupActiveOpenMiningRounds(Seq(ts(520)))
+          _ = activeAtRound5 shouldBe empty
+          atRound5 <- store.lookupPrunableRewardRound(ts(520), timeAfterAllRounds, noRetention)
+          _ = atRound5 shouldBe None
+          // Round 6, opened at t=450, ie before round 4's archival.
+          atRound6 <- store.lookupPrunableRewardRound(ts(670), timeAfterAllRounds, noRetention)
+          _ = atRound6 shouldBe None
+          // Round 7, opened at t=600, ie past round 4's archival.
+          atRound7 <- store.lookupPrunableRewardRound(ts(820), timeAfterAllRounds, noRetention)
+          _ = atRound7 shouldBe Some(3L)
+
+          activeAtRound7 <- store.lookupActiveOpenMiningRounds(Seq(ts(820)))
+          _ = activeAtRound7 shouldBe Map(ts(820) -> ((7L, ts(600))))
+
+          // Doing prune here confirms that the lookupPrunableRewardRound works with the new db state
+          deleted <- store.pruneArchivedUpToRound(3)
+          _ = deleted shouldBe 1L
+
+          // Lookup works even after prune
+          activeAtRound7AfterDelete <- store.lookupActiveOpenMiningRounds(Seq(ts(820)))
+          _ = activeAtRound7AfterDelete shouldBe Map(ts(820) -> ((7L, ts(600))))
+
+          // Round 4 is now the lowest prunable round, and round 5 archived at t=650.
+          afterPruneAtRound7 <- store.lookupPrunableRewardRound(
+            ts(820),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound7 shouldBe None
+
+          // Round 8, active as of t=970, opened at t=750, ie past round 5's archival.
+          afterPruneAtRound8 <- store.lookupPrunableRewardRound(
+            ts(970),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound8 shouldBe Some(4L)
+
+          // Pruning round 4 as well, ie two rounds are pruned in a row.
+          deletedRound4 <- store.pruneArchivedUpToRound(4)
+          _ = deletedRound4 shouldBe 1L
+
+          // At the same record time round 5 is kept, as round 8 opened at t=750,
+          // ie before round 6's archival (t=800).
+          afterPruneAtRound4 <- store.lookupPrunableRewardRound(
+            ts(970),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = afterPruneAtRound4 shouldBe None
+        } yield succeed
+      }
+
+      "keep a round until it falls outside the retention period" in {
+        val store = mkStore()
+        val retentionPeriod = NonNegativeFiniteDuration.ofSeconds(300)
+        for {
+          _ <- ingestOverlappingRounds(store)
+
+          noRetentionLookupAt620 <- store.lookupPrunableRewardRound(ts(620), ts(620), noRetention)
+          _ = noRetentionLookupAt620 shouldBe Some(3L)
+
+          withinRetention <- store.lookupPrunableRewardRound(ts(620), ts(620), retentionPeriod)
+          _ = withinRetention shouldBe None
+
+          atRetentionBoundary <- store.lookupPrunableRewardRound(ts(620), ts(700), retentionPeriod)
+          _ = atRetentionBoundary shouldBe None
+
+          pastRetention <- store.lookupPrunableRewardRound(ts(620), ts(701), retentionPeriod)
+          _ = pastRetention shouldBe Some(3L)
+        } yield succeed
+      }
+
+      // This test just describes the behavior, but it should never occur in
+      // practice as verdict ingestion should itself wait on the
+      // ScanRewardsReferenceStore.
+      "wait until the store's ingestion reaches the last ingested verdict record time" in {
+        val store = mkStore()
+        for {
+          _ <- ingestOverlappingRounds(store)
+
+          atIngestedRecordTime <- store.lookupPrunableRewardRound(
+            ts(800),
+            timeAfterAllRounds,
+            noRetention,
+          )
+          _ = atIngestedRecordTime shouldBe Some(3L)
+
+          // A lastIngestedRecordTimes value past it waits for the ingestion to catch up
+          pending = store.lookupPrunableRewardRound(ts(900), timeAfterAllRounds, noRetention)
+          _ = pending.isCompleted shouldBe false
+
+          _ <- advanceRecordTime(store, ts(900))
+          prunableRound <- pending
+          _ = prunableRound shouldBe Some(3L)
+        } yield succeed
+      }
     }
 
     "lookupActiveOpenMiningRounds" in {
@@ -682,6 +893,109 @@ class DbScanRewardsReferenceStoreTest
 
   private def ts(epochSecond: Long): CantonTimestamp =
     CantonTimestamp.ofEpochSecond(epochSecond)
+
+  /** A `now` past every timeline used here, to ensure that when paired with a noRetention
+    * it never gates lookupPrunableRewardRound.
+    */
+  private val timeAfterAllRounds: CantonTimestamp = ts(2000)
+  private val noRetention: NonNegativeFiniteDuration = NonNegativeFiniteDuration.Zero
+
+  /** Advance the record time so that lookups waiting for ingestion to reach a
+    * given time are unblocked.
+    */
+  private def advanceRecordTime(
+      store: DbScanRewardsReferenceStore,
+      recordTime: CantonTimestamp,
+  ): Future[?] =
+    store.multiDomainAcsStore.testIngestionSink.ingestUpdateBatch(
+      NonEmptyList.of(
+        TreeUpdateOrOffsetCheckpoint.Checkpoint(
+          new OffsetCheckpoint(
+            nextOffset(),
+            java.util.List.of(new SynchronizerTime(sync1.toProtoPrimitive, recordTime.toInstant)),
+          )
+        )
+      )
+    )
+
+  /** Ingests rounds 3 to 9, with advancement (creation+archive) happening
+    * according to the daml logic of AmuletRules_AdvanceOpenMiningRounds.
+    * Specifically advancement happens with the diff of a tick (100) and at the openAt of latest round
+    * {{{
+    *   round:     3    4    5    6    7    8    9
+    *   created:   75   100  200  300  400  500  600
+    *   opensAt:   100  200  300  400  500  600  700
+    *   archived:  300  400  500  600  700  -    -
+    * }}}
+    */
+  private def ingestOverlappingRounds(store: DbScanRewardsReferenceStore): Future[?] = {
+    def omr(round: Long, createdAt: Long, opensAt: Long) =
+      openMiningRound(dsoParty, round = round, amuletPrice = 1.0, opensAt = ts(opensAt).toInstant)
+        .copy(createdAt = ts(createdAt).toInstant)
+    val omr3 = omr(3, createdAt = 75, opensAt = 100)
+    val omr4 = omr(4, createdAt = 100, opensAt = 200)
+    val omr5 = omr(5, createdAt = 200, opensAt = 300)
+    val omr6 = omr(6, createdAt = 300, opensAt = 400)
+    val omr7 = omr(7, createdAt = 400, opensAt = 500)
+    val omr8 = omr(8, createdAt = 500, opensAt = 600)
+    val omr9 = omr(9, createdAt = 600, opensAt = 700)
+    val acsStore = store.multiDomainAcsStore
+    for {
+      _ <- initWithAcs()(acsStore)
+      _ <- sync1.create(omr3, recordTime = ts(75).toInstant)(acsStore)
+      _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(acsStore)
+      _ <- sync1.create(omr5, recordTime = ts(200).toInstant)(acsStore)
+      _ <- sync1.create(omr6, recordTime = ts(300).toInstant)(acsStore)
+      _ <- sync1.archive(omr3, recordTime = ts(300).toInstant)(acsStore)
+      _ <- sync1.create(omr7, recordTime = ts(400).toInstant)(acsStore)
+      _ <- sync1.archive(omr4, recordTime = ts(400).toInstant)(acsStore)
+      _ <- sync1.create(omr8, recordTime = ts(500).toInstant)(acsStore)
+      _ <- sync1.archive(omr5, recordTime = ts(500).toInstant)(acsStore)
+      _ <- sync1.create(omr9, recordTime = ts(600).toInstant)(acsStore)
+      _ <- sync1.archive(omr6, recordTime = ts(600).toInstant)(acsStore)
+      _ <- sync1.archive(omr7, recordTime = ts(700).toInstant)(acsStore)
+      _ <- advanceRecordTime(store, ts(800))
+    } yield ()
+  }
+
+  /** Similar to ingestOverlappingRounds. But here the round advancement lags behind
+    * by 50 (with a tick of 100)
+    * {{{
+    *   round:     3    4    5    6    7    8    9
+    *   created:   75   100  200  350  500  650  800
+    *   opensAt:   100  200  300  450  600  750  900
+    *   archived:  350  500  650  800  950  -    -
+    * }}}
+    */
+  private def ingestLaggingArchivalRounds(store: DbScanRewardsReferenceStore): Future[?] = {
+    def omr(round: Long, createdAt: Long, opensAt: Long) =
+      openMiningRound(dsoParty, round = round, amuletPrice = 1.0, opensAt = ts(opensAt).toInstant)
+        .copy(createdAt = ts(createdAt).toInstant)
+    val omr3 = omr(3, createdAt = 75, opensAt = 100)
+    val omr4 = omr(4, createdAt = 100, opensAt = 200)
+    val omr5 = omr(5, createdAt = 200, opensAt = 300)
+    val omr6 = omr(6, createdAt = 350, opensAt = 450)
+    val omr7 = omr(7, createdAt = 500, opensAt = 600)
+    val omr8 = omr(8, createdAt = 650, opensAt = 750)
+    val omr9 = omr(9, createdAt = 800, opensAt = 900)
+    val acsStore = store.multiDomainAcsStore
+    for {
+      _ <- initWithAcs()(acsStore)
+      _ <- sync1.create(omr3, recordTime = ts(75).toInstant)(acsStore)
+      _ <- sync1.create(omr4, recordTime = ts(100).toInstant)(acsStore)
+      _ <- sync1.create(omr5, recordTime = ts(200).toInstant)(acsStore)
+      _ <- sync1.create(omr6, recordTime = ts(350).toInstant)(acsStore)
+      _ <- sync1.archive(omr3, recordTime = ts(350).toInstant)(acsStore)
+      _ <- sync1.create(omr7, recordTime = ts(500).toInstant)(acsStore)
+      _ <- sync1.archive(omr4, recordTime = ts(500).toInstant)(acsStore)
+      _ <- sync1.create(omr8, recordTime = ts(650).toInstant)(acsStore)
+      _ <- sync1.archive(omr5, recordTime = ts(650).toInstant)(acsStore)
+      _ <- sync1.create(omr9, recordTime = ts(800).toInstant)(acsStore)
+      _ <- sync1.archive(omr6, recordTime = ts(800).toInstant)(acsStore)
+      _ <- sync1.archive(omr7, recordTime = ts(950).toInstant)(acsStore)
+      _ <- advanceRecordTime(store, ts(1100))
+    } yield ()
+  }
 
   private def svInfo(name: String, participant: ParticipantId): dsorulesCodegen.SvInfo =
     new dsorulesCodegen.SvInfo(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/DbScanRewardsReferenceStoreTest.scala
@@ -821,6 +821,48 @@ class DbScanRewardsReferenceStoreTest
           _ = prunableRound shouldBe Some(3L)
         } yield succeed
       }
+
+      // Right after bootstrapping, only a single OpenMiningRound has been archived, so
+      // there is no archival for the next round yet. The active round cannot resolve
+      // either, as the next round opened before the store's ingestion start.
+      "skip after bootstrap while only a single round has been archived" in {
+        val store = mkStore()
+        def omr(round: Long, createdAt: Long, opensAt: Long) =
+          openMiningRound(
+            dsoParty,
+            round = round,
+            amuletPrice = 1.0,
+            opensAt = ts(opensAt).toInstant,
+          )
+            .copy(createdAt = ts(createdAt).toInstant)
+        // Round n is archived (and round n+3 created) when round n+2 opens, so
+        // round 2 was archived at t=200 together with round 5's creation. The store
+        // bootstraps after that, with rounds 3, 4 and 5 open in the initial ACS.
+        val omr3 = omr(3, createdAt = 0, opensAt = 100)
+        val omr4 = omr(4, createdAt = 100, opensAt = 200)
+        val omr5 = omr(5, createdAt = 200, opensAt = 300)
+        val omr6 = omr(6, createdAt = 300, opensAt = 400)
+        val acsStore = store.multiDomainAcsStore
+        for {
+          _ <- initWithAcs(
+            Seq(omr3, omr4, omr5).map(StoreTestBase.AcsImportEntry(_, sync1, 0L))
+          )(acsStore)
+          _ <- sync1.create(omr6, recordTime = ts(300).toInstant)(acsStore)
+          _ <- sync1.archive(omr3, recordTime = ts(300).toInstant)(acsStore)
+          _ <- advanceRecordTime(store, ts(350))
+
+          lowestPrunable <- store.lookupLowestPrunableArchivedRewardRound()
+          _ = lowestPrunable shouldBe Some(3L)
+          archivedAt4 <- store.lookupArchivedAtForOpenMiningRound(4)
+          _ = archivedAt4 shouldBe None
+          // Round 4 opened at t=200, before the ingestion start at t=300
+          active <- store.lookupActiveOpenMiningRounds(Seq(ts(350)))
+          _ = active shouldBe empty
+
+          result <- store.lookupPrunableRewardRound(ts(350), timeAfterAllRounds, noRetention)
+          _ = result shouldBe None
+        } yield succeed
+      }
     }
 
     "lookupActiveOpenMiningRounds" in {

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -26,6 +26,11 @@ release-notes:: Upcoming
         - Added a new public ``/v0/events/latest-record-time`` endpoint that returns the latest
           record time for which ``/v0/events`` will be able to return events.
 
+        - Added an automation to prune the DB tables having the temporary data used
+          by the verdict ingestion service and the traffic-based app reward calculations.
+
+          The default retention period is 1 week for this automation, after which the data will be removed from the DB.
+
     - Validator App
 
         - The minting-delegation reward collection for external parties now also collects


### PR DESCRIPTION
Fixes #6136



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
