### PR TITLE
Remove in-app rate limit override for `getDateOfMostRecentSnapshotBefore`

### DIFF
--- a/cluster/images/scan-app/app.conf
+++ b/cluster/images/scan-app/app.conf
@@ -77,7 +77,6 @@ canton {
           rate-limiters {
             getAcsSnapshot.rate-per-second = 20
             getAcsSnapshotAt.rate-per-second = 10
-            getDateOfMostRecentSnapshotBefore.rate-per-second = 10
           }
         }
         # TODO(DACH-NY/canton-network-internal#2125) Revisit timeouts on 3.4


### PR DESCRIPTION
[static]

A client gets rate limited on this on MainNet DA-2. Upon closer inspection, this endpoint triggers a very cheap query answered by an index scan: https://github.com/canton-network/splice/blob/1973921ef727fded6d6d3734b00e7eeca4010b51/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala#L72

This doesn't sound as if special rate-limiting is needed at all.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
