### PR TITLE
Avoid racy synchronizer connection query

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
@@ -12,6 +12,7 @@ import com.digitalasset.canton.admin.api.client.data.{
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.data
+import com.digitalasset.canton.logging.pretty.Pretty
 import com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig
 import com.digitalasset.canton.sequencing.SequencerConnectionValidation
 import com.digitalasset.canton.topology.{PhysicalSynchronizerId, SynchronizerId}
@@ -160,6 +161,9 @@ trait ParticipantAdminSynchronizerConnection {
   ): Future[Unit] =
     runCmd(ParticipantAdminCommands.SynchronizerConnectivity.DisconnectSynchronizer(alias))
 
+  private implicit val prettyRegisteredSynchronizer: Pretty[RegisteredSynchronizer] =
+    Pretty.adHocPrettyInstance
+
   def ensureSynchronizerRegisteredWithManualConnect(
       config: SynchronizerConnectionConfig,
       retryFor: RetryFor,
@@ -169,15 +173,14 @@ trait ParticipantAdminSynchronizerConnection {
       "manualConnect must be true when trying to register only",
     )
     retryProvider
-      .ensureThat(
+      .ensureThatO(
         retryFor,
         "synchronizer_registered_no_handshake",
         s"participant registered ${config.synchronizerAlias}",
-        isSynchronizerRegistered(config.synchronizerAlias).map(Either.cond(_, (), ())),
-        (_: Unit) => registerSynchronizer(config),
+        listSynchronizerConnectionConfig(config.synchronizerAlias).map(_.headOption),
+        registerSynchronizer(config),
         logger,
       )
-      .flatMap(_ => getRegisteredSynchronizer(config.synchronizerAlias))
   }
 
   def ensureSynchronizerRegisteredAndConnected(


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/9447 and supersedes #6642

Imho this is the proper fix: Avoid making a separate query after the retry when the state may already have changed.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
