### PR TITLE
Expose sequencer rate-limit caps in the info endpoint

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
@@ -45,6 +45,7 @@ class DsoPreflightIntegrationTest
         s"${infoUrl}/runtime/dso.json",
         s"${infoUrl}/runtime/info.json",
         s"${infoUrl}/runtime/status.json",
+        s"${infoUrl}/runtime/sequencer-caps.json",
       )
 
       urls.foreach { url =>
@@ -64,9 +65,16 @@ class DsoPreflightIntegrationTest
             assert(json.isObject, s"Response body must be a JSON object, but got: $body")
             if (url == s"${infoUrl}/runtime/") {
               val expected = parse(
-                """{"dso":"/runtime/dso.json","info":"/runtime/info.json","status":"/runtime/status.json"}"""
+                """{"dso":"/runtime/dso.json","info":"/runtime/info.json","status":"/runtime/status.json","sequencerCaps":"/runtime/sequencer-caps.json"}"""
               ).getOrElse(fail("Hardcoded JSON invalid"))
               assert(json == expected, s"Expected $expected but got $json")
+            }
+            if (url == s"${infoUrl}/runtime/sequencer-caps.json") {
+              val rateLimits = json.hcursor.downField("rateLimits")
+              assert(
+                rateLimits.downField("messages").succeeded,
+                s"Expected sequencer-caps.json to have a rateLimits.messages field, but got: $body",
+              )
             }
           }
         }

--- a/cluster/helm/splice-info/scripts/get-sequencer-caps.sh
+++ b/cluster/helm/splice-info/scripts/get-sequencer-caps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Unlike the other runtime endpoints, the sequencer rate-limit caps are static
+# deployment config (not fetched over the network), so this just re-serves the
+# JSON it was handed via SEQUENCER_RATE_LIMITS_JSON.
+main() {
+  local rate_limits="${SEQUENCER_RATE_LIMITS_JSON:-}"
+
+  if [[ -z "$rate_limits" ]]; then
+    return 1
+  fi
+
+  jq -n \
+    --argjson rateLimits "$rate_limits" \
+    '
+      {
+        rateLimits: $rateLimits,
+        generatedAt: (now | todate),
+      }
+    '
+}
+
+main "$@"

--- a/cluster/helm/splice-info/scripts/updater.sh
+++ b/cluster/helm/splice-info/scripts/updater.sh
@@ -32,15 +32,20 @@ status_json_file="$html_dir/$status_json_path"
 info_json_path=runtime/info.json
 info_json_file="$html_dir/$info_json_path"
 
+sequencer_caps_json_path=runtime/sequencer-caps.json
+sequencer_caps_json_file="$html_dir/$sequencer_caps_json_path"
+
 jq -n \
   --arg dso "/$dso_json_path" \
   --arg status "/$status_json_path" \
   --arg info "/$info_json_path" \
+  --arg sequencerCaps "/$sequencer_caps_json_path" \
   '
     {
       $dso,
       $info,
       $status,
+      $sequencerCaps,
     }
   ' > "$runtime_index_file"
 
@@ -61,6 +66,12 @@ while true; do
 
   if result=$(/scripts/get-info.sh); then
     dest="$info_json_file"
+    echo "$result" > "$dest.new"
+    mv "$dest.new" "$dest"
+  fi &
+
+  if result=$(/scripts/get-sequencer-caps.sh); then
+    dest="$sequencer_caps_json_file"
     echo "$result" > "$dest.new"
     mv "$dest.new" "$dest"
   fi &

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
             value: {{ .Values.runtimeDetails.scanUrl | default "http://scan-app:5012" | quote }}
           - name: TLS_SKIP_VERIFY
             value: {{ .Values.runtimeDetails.tlsSkipVerify | default false | quote }}
+          {{- if .Values.runtimeDetails.sequencerRateLimits }}
+          - name: SEQUENCER_RATE_LIMITS_JSON
+            value: {{ .Values.runtimeDetails.sequencerRateLimits | toJson | quote }}
+          {{- end }}
         volumeMounts:
         - name: scripts
           mountPath: /scripts

--- a/cluster/helm/splice-info/tests/deployment_test.yaml
+++ b/cluster/helm/splice-info/tests/deployment_test.yaml
@@ -38,6 +38,43 @@ tests:
           path: spec.template.spec.containers[?(@.name=='updater')].env[?(@.name=='SERIAL_ID')].value
           value: "101"
 
+  - it: "includes the sequencer rate limits env var when set"
+    template: deployment.yaml
+    set:
+      runtimeDetails:
+        synchronizerSerialId: 101
+        sequencerRateLimits:
+          messages:
+            confirmationRequest:
+              globalTpsCap: 2
+              perClientTpsCap: 1
+              globalKbpsCap: 200
+              perClientKbpsCap: 100
+            topology:
+              globalTpsCap: 4
+              perClientTpsCap: 3
+              globalKbpsCap: 400
+              perClientKbpsCap: 300
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=='updater')].env[?(@.name=='SEQUENCER_RATE_LIMITS_JSON')].value
+          value: '{"messages":{"confirmationRequest":{"globalKbpsCap":200,"globalTpsCap":2,"perClientKbpsCap":100,"perClientTpsCap":1},"topology":{"globalKbpsCap":400,"globalTpsCap":4,"perClientKbpsCap":300,"perClientTpsCap":3}}}'
+
+  - it: "omits the sequencer rate limits env var when not set"
+    template: deployment.yaml
+    set:
+      runtimeDetails:
+        synchronizerSerialId: 101
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=='updater')].env[?(@.name=='SEQUENCER_RATE_LIMITS_JSON')]
+
   - it: "injects custom serviceAccountName into Deployment when specified"
     template: deployment.yaml
     set:

--- a/cluster/helm/splice-info/values-template.yaml
+++ b/cluster/helm/splice-info/values-template.yaml
@@ -9,6 +9,18 @@ contentType: "application/json"
 #   synchronizerSerialId: 5  # Serial ID of the current synchronizer to fetch metrics
 #   scanUrl: https://scan.sv.global.canton.network.xxx  # Optional, the default is the internal scan address, it's used to fetch the runtime configuration
 #   tlsSkipVerify: true  # Optional, the default is false
+#   sequencerRateLimits:  # Optional, exposed as-is under /runtime/sequencer-caps.json
+#     messages:
+#       confirmationRequest:
+#         globalTpsCap: 2
+#         perClientTpsCap: 1
+#         globalKbpsCap: 200
+#         perClientKbpsCap: 100
+#       topology:
+#         globalTpsCap: 4
+#         perClientTpsCap: 3
+#         globalKbpsCap: 400
+#         perClientKbpsCap: 300
 
 # deploymentDetails:  # Optional, exposes static configuration under path /
 #   network: "dev"

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -23,6 +23,17 @@
         "version": { "type": "string", "minLength": 1 }
       }
     },
+    "sequencer_rate_limit_message_config": {
+      "type": "object",
+      "required": [ "globalTpsCap", "perClientTpsCap", "globalKbpsCap", "perClientKbpsCap" ],
+      "additionalProperties": false,
+      "properties": {
+        "globalTpsCap": { "type": "integer", "minimum": 0 },
+        "perClientTpsCap": { "type": "integer", "minimum": 0 },
+        "globalKbpsCap": { "type": "integer", "minimum": 0 },
+        "perClientKbpsCap": { "type": "integer", "minimum": 0 }
+      }
+    },
     "digest": {
       "type": "object",
       "required": [ "type", "value" ],
@@ -84,7 +95,29 @@
       "properties": {
         "scanUrl": { "type": "string", "minLength": 1 },
         "synchronizerSerialId": { "type": "integer", "minimum": 0 },
-        "tlsSkipVerify": { "type": "boolean", "default": false }
+        "tlsSkipVerify": { "type": "boolean", "default": false },
+        "sequencerRateLimits": {
+          "description": "Optional. The sequencer block throughput caps applied by this SV's sequencer. When set, exposed at /runtime/sequencer-caps.json.",
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": [ "messages" ],
+              "additionalProperties": false,
+              "properties": {
+                "messages": {
+                  "type": "object",
+                  "required": [ "confirmationRequest", "topology" ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "confirmationRequest": { "$ref": "#/$defs/sequencer_rate_limit_message_config" },
+                    "topology": { "$ref": "#/$defs/sequencer_rate_limit_message_config" }
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     },
     "deploymentDetails": {

--- a/cluster/pulumi/common-sv/src/info.ts
+++ b/cluster/pulumi/common-sv/src/info.ts
@@ -6,6 +6,7 @@ import {
   DecentralizedSynchronizerMigrationConfig,
   ExactNamespace,
   externalIpRangesFile,
+  getSequencerRateLimits,
   installSpliceHelmChart,
 } from '@canton-network/splice-pulumi-common';
 import {
@@ -38,6 +39,7 @@ export function installInfo(
     runtimeDetails: {
       synchronizerSerialId: decentralizedSynchronizerMigrationConfig.active.id,
       scanUrl: scanUrl,
+      sequencerRateLimits: getSequencerRateLimits(),
     },
     deploymentDetails: {
       network: clusterNetwork,

--- a/cluster/pulumi/common/src/utils.ts
+++ b/cluster/pulumi/common/src/utils.ts
@@ -169,6 +169,30 @@ export function externalIpRangesFile(): string | undefined {
   return getPathToPrivateConfigFile('allowed-ip-ranges.json');
 }
 
+export interface SequencerRateLimitMessageConfig {
+  globalTpsCap: number;
+  perClientTpsCap: number;
+  globalKbpsCap: number;
+  perClientKbpsCap: number;
+}
+
+export interface SequencerRateLimitConfig {
+  messages: {
+    confirmationRequest: SequencerRateLimitMessageConfig;
+    topology: SequencerRateLimitMessageConfig;
+  };
+}
+
+// Reads the per-cluster sequencer rate-limit caps (block throughput caps applied by every SV's
+// sequencer), if configured. Returns undefined for clusters that don't set them.
+export function getSequencerRateLimits(): SequencerRateLimitConfig | undefined {
+  const rateLimitsFile = getPathToPrivateConfigFile('sequencer-rate-limits.json');
+  if (!rateLimitsFile) {
+    return undefined;
+  }
+  return loadJsonFromFile(rateLimitsFile);
+}
+
 // Typically used for overriding chart values.
 // The pulumi documentation also doesn't suggest a better type than this. ¯\_(ツ)_/¯
 

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -9,13 +9,13 @@ import {
   DomainMigrationIndex,
   ExactNamespace,
   getAdditionalJvmOptions,
-  getPathToPrivateConfigFile,
+  getSequencerRateLimits,
   installSpliceHelmChart,
-  loadJsonFromFile,
   loadYamlFromFile,
   LogLevel,
   persistentHeapDumpsPvc,
   sanitizedForPostgres,
+  SequencerRateLimitMessageConfig,
   sequencerTokenExpirationTime,
   SPLICE_ROOT,
   SpliceCustomResourceOptions,
@@ -33,13 +33,11 @@ import { Release } from '@pulumi/kubernetes/helm/v3';
 import { ComponentResource, Output, Resource } from '@pulumi/pulumi';
 
 const getSequencerRateLimitConfig = (): string | undefined => {
-  const rateLimitsFile = getPathToPrivateConfigFile('sequencer-rate-limits.json');
-  if (!rateLimitsFile) {
+  const rateLimits = getSequencerRateLimits();
+  if (!rateLimits) {
     return undefined;
   }
-  const rateLimits = loadJsonFromFile(rateLimitsFile);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const limitsForMessageType = (message: string, config: any): string =>
+  const limitsForMessageType = (message: string, config: SequencerRateLimitMessageConfig): string =>
     [
       `canton.sequencers.sequencer.sequencer.block.throughput-cap.messages.${message} {`,
       `  global-tps-cap = ${config.globalTpsCap}`,


### PR DESCRIPTION
## Summary

Every SV's sequencer already enforces block throughput caps (TPS/KBps, for confirmation-request and topology messages) sourced from the private `sequencer-rate-limits.json` config, but the effective values weren't visible anywhere outside that config file. Per @nicu-da's scoping comment on #6230:

- Added a shared `getSequencerRateLimits()` reader in `cluster/pulumi/common/src/utils.ts`, used both to build the existing HOCON sequencer config (`decentralizedSynchronizerNode.ts`) and to feed the raw values into the `splice-info` chart's `runtimeDetails` (`info.ts`).
- Added a `runtimeDetails.sequencerRateLimits` value to the `splice-info` chart, wired to a new updater sidecar script (`get-sequencer-caps.sh`) that serves it statically at `/runtime/sequencer-caps.json`, following the existing `dso.json`/`status.json`/`info.json` pattern.
- Added a `DsoPreflightIntegrationTest` sanity check for the new endpoint.

Fixes #6230

## Verification

**Locally verified:**
- Helm chart: `helm unittest` — 8/8 pass (including 2 new tests for the `SEQUENCER_RATE_LIMITS_JSON` env var, present/absent). `helm template` renders correctly with the new value set. `shellcheck` clean on both `updater.sh` and the new `get-sequencer-caps.sh`.
- Pulumi TS (`cluster/pulumi`): `tsc --noEmit` clean, `eslint --max-warnings=0` clean, `prettier --check` clean on all 3 changed files.

**Not locally verified:**
- The Scala change (`DsoPreflightIntegrationTest.scala`) — I don't have a working local build for the Scala/DAML side (needs the full Nix dev shell; hit `dpm build` errors on a previous attempt in #6845). Reviewed the circe API usage carefully (`hcursor`/`downField`/`succeeded`) but haven't compiled it. Happy to fix up per CI/review feedback.

## Test plan

- [ ] CI compiles and runs `DsoPreflightIntegrationTest`
- [ ] Helm chart tests pass in CI (already verified locally)