### PR TITLE
Enable test that verifies high tapped amount

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -2,7 +2,6 @@ package org.lfdecentralizedtrust.splice.integration.tests
 
 import org.lfdecentralizedtrust.splice.auth.AuthUtil
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet as amuletCodegen
-import org.lfdecentralizedtrust.splice.codegen.java.splice.types.Round
 import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.payment as walletCodegen
 import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.transferpreapproval.TransferPreapprovalProposal
 import org.lfdecentralizedtrust.splice.http.v0.definitions.TapRequest
@@ -12,11 +11,7 @@ import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.BracketSynchronous.bracket
 import org.lfdecentralizedtrust.splice.integration.tests.WalletTxLogTestUtil
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.ContractState
-import org.lfdecentralizedtrust.splice.util.{
-  SpliceUtil,
-  WalletTestUtil,
-  JavaDecodeUtil as DecodeUtil,
-}
+import org.lfdecentralizedtrust.splice.util.{WalletTestUtil, JavaDecodeUtil as DecodeUtil}
 import org.lfdecentralizedtrust.splice.validator.automation.AcceptTransferPreapprovalProposalTrigger
 import org.lfdecentralizedtrust.splice.wallet.admin.api.client.commands.HttpWalletAppClient.CreateTransferPreapprovalResponse
 import org.lfdecentralizedtrust.splice.wallet.store.{
@@ -60,31 +55,29 @@ class WalletIntegrationTest
 
   "A wallet" should {
 
-    // TODO (#2336): unignore this test
-    "tap stupid amount" ignore { implicit env =>
+    val tapLimit = 100000000
+
+    s"tap $tapLimit amount" in { implicit env =>
       import com.digitalasset.daml.lf.data.Numeric
       val aliceParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
       val round = sv1ScanBackend.getLatestOpenMiningRound(env.environment.clock.now)
       val price = round.contract.payload.amuletPrice
       val decimalScale = Numeric.Scale.assertFromInt(10)
-      // We subtract one to allow some slack in back/forth conversions from CC to USD. Otherwise,
-      // the command gets rejected by the participant and we test nothing.
-      val maxDecimal = Numeric
-        .subtract(Numeric.maxValue(decimalScale), Numeric.assertFromBigDecimal(decimalScale, 1))
-        .value
       val maxUsd = Numeric
-        .multiply(decimalScale, maxDecimal, Numeric.assertFromBigDecimal(decimalScale, price))
+        .multiply(
+          decimalScale,
+          Numeric.assertFromBigDecimal(decimalScale, tapLimit),
+          Numeric.assertFromBigDecimal(decimalScale, price),
+        )
         .value
       // Integration test that the tap goes through
       aliceWalletClient.tap(maxUsd)
       val amulet = aliceValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
         .filterJava(amuletCodegen.Amulet.COMPANION)(aliceParty, _ => true)
         .loneElement
-      // Unit test that expiry does the right thing
-      SpliceUtil.amuletExpiresAt(amulet.data) shouldBe new Round(Long.MaxValue)
-      // Test that the USD/CC conversions get us to the max Decimal value ignoring decimal points
+      // Test that the USD/CC conversions get us to the limit ignoring decimal points
       amulet.data.amount.initialAmount.setScale(0, java.math.RoundingMode.DOWN) shouldBe Numeric
-        .maxValue(decimalScale)
+        .assertFromBigDecimal(decimalScale, tapLimit)
         .setScale(0, java.math.RoundingMode.DOWN)
     }
 


### PR DESCRIPTION
Fixes #2336

Since #2336 was filed, #4113 deprecated `scan_txlog.py` and removed the code that ran it, but #5922 added a max tap amount of 100,000,000, so the existing test code failed with a "requirement ... was not met" error. This updates the test code to instead tap the max amount, per @OriolMunoz-da's suggestion.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
