### PR TITLE
Add proposal form placeholder guidance

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/forms/offboard-sv-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/offboard-sv-form.test.tsx
@@ -18,6 +18,7 @@ import {
   PROPOSAL_REVIEW_TITLE,
   PROPOSAL_SUMMARY_PLACEHOLDER,
   PROPOSAL_SUMMARY_SUBTITLE,
+  SUPPORTING_URL_PLACEHOLDER,
 } from '../../../utils/constants';
 
 describe('SV user can', () => {
@@ -68,10 +69,12 @@ describe('Offboard SV Form', () => {
     const urlInput = screen.getByTestId('offboard-sv-url');
     expect(urlInput).toBeInTheDocument();
     expect(urlInput.getAttribute('value')).toBe('');
+    expect(urlInput).toHaveAttribute('placeholder', SUPPORTING_URL_PLACEHOLDER);
 
     const memberInput = screen.getByTestId('offboard-sv-member-dropdown');
     expect(memberInput).toBeInTheDocument();
     expect(memberInput.getAttribute('value')).toBe('');
+    expect(screen.getByText('Select a member')).toBeInTheDocument();
 
     expect(screen.getByText('Review Proposal')).toBeInTheDocument();
   });

--- a/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
@@ -12,7 +12,10 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, test } from 'vitest';
 import App from '../../../App';
 import { SetDsoConfigRulesForm } from '../../../components/forms/SetDsoConfigRulesForm';
-import { CREATE_PROPOSAL_LABEL_PROPOSAL_TYPE } from '../../../utils/constants';
+import {
+  CREATE_PROPOSAL_LABEL_PROPOSAL_TYPE,
+  DATE_TIME_PLACEHOLDER,
+} from '../../../utils/constants';
 import { SvConfigProvider } from '../../../utils';
 import { Wrapper } from '../../helpers';
 import { svPartyId } from '../../mocks/constants';
@@ -63,6 +66,15 @@ describe('Set DSO Config Rules Form', () => {
     const urlInput = screen.getByTestId('set-dso-config-rules-url');
     expect(urlInput).toBeInTheDocument();
     expect(urlInput.getAttribute('value')).toBe('');
+
+    expect(screen.getByTestId('set-dso-config-rules-expiry-date-field')).toHaveAttribute(
+      'placeholder',
+      DATE_TIME_PLACEHOLDER
+    );
+    expect(screen.getByTestId('set-dso-config-rules-effective-date-field')).toHaveAttribute(
+      'placeholder',
+      DATE_TIME_PLACEHOLDER
+    );
 
     const configLabels = screen.getAllByTestId(/config-label-/);
     expect(configLabels.length).toBeGreaterThan(15);

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -28,6 +28,7 @@ import {
   EFFECTIVE_AT_LABEL,
   PROPOSAL_CREATED_LABEL,
   PROPOSAL_SUMMARY_TITLE,
+  SUPPORTING_URL_PLACEHOLDER,
   SUPPORTING_URL_LABEL,
   THRESHOLD_DEADLINE_LABEL,
   VOTE_PROPOSAL_CONTRACT_ID_LABEL,
@@ -1051,6 +1052,7 @@ describe('Proposal Details > Votes & Voting', () => {
 
     const votingFormUrlInput = within(votingForm).getByTestId('your-vote-url-input');
     expect(votingFormUrlInput).toBeInTheDocument();
+    expect(votingFormUrlInput).toHaveAttribute('placeholder', SUPPORTING_URL_PLACEHOLDER);
 
     const votingFormReasonInput = within(votingForm).getByTestId('your-vote-reason-input');
     expect(votingFormReasonInput).toBeInTheDocument();

--- a/apps/sv/frontend/src/components/form-components/DateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/DateField.tsx
@@ -14,6 +14,7 @@ import {
 import { useFieldContext } from '../../hooks/formContext';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { datePickerFieldSx } from '../../themes/fieldStyles';
+import { DATE_TIME_PLACEHOLDER } from '../../utils/constants';
 
 export interface DateFieldProps {
   title?: string;
@@ -65,6 +66,7 @@ export const DateField: React.FC<DateFieldProps> = props => {
               sx: datePickerFieldSx,
               inputProps: {
                 'data-testid': `${id}-field`,
+                placeholder: DATE_TIME_PLACEHOLDER,
               },
             },
             openPickerButton: {

--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -11,6 +11,7 @@ import { EffectivityType } from '../../utils/types';
 import React, { useMemo } from 'react';
 import { RadioSelector } from './RadioSelector';
 import { datePickerFieldSx } from '../../themes/fieldStyles';
+import { DATE_TIME_PLACEHOLDER } from '../../utils/constants';
 
 const effectiveAtDisplayFormat = 'YYYY-MM-DD HH:mm';
 
@@ -110,6 +111,7 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                       sx: datePickerFieldSx,
                       inputProps: {
                         'data-testid': `${id}-field`,
+                        placeholder: DATE_TIME_PLACEHOLDER,
                       },
                     },
                   }}

--- a/apps/sv/frontend/src/components/form-components/SelectField.tsx
+++ b/apps/sv/frontend/src/components/form-components/SelectField.tsx
@@ -37,8 +37,10 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
     externalOnChange();
   };
 
-  const showPlaceholder = !!placeholder && !field.state.value;
-  const isError = !field.state.meta.isValid && !showPlaceholder;
+  const article = /^[aeiou]/i.test(title) ? 'an' : 'a';
+  const resolvedPlaceholder = placeholder ?? `Select ${article} ${title.toLowerCase()}`;
+  const showPlaceholder = !field.state.value;
+  const isError = !field.state.meta.isValid && !(placeholder && showPlaceholder);
 
   return (
     <Box data-testid={`${id}-select-component`}>
@@ -60,7 +62,7 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
             if (!selected) {
               return showPlaceholder ? (
                 <Typography component="span" color="text.secondary">
-                  {placeholder}
+                  {resolvedPlaceholder}
                 </Typography>
               ) : (
                 ''

--- a/apps/sv/frontend/src/components/governance/ProposalVoteForm.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalVoteForm.tsx
@@ -11,6 +11,7 @@ import { VoteRequest } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules'
 import { ProposalVote } from '../../utils/types';
 import { Alert, Box, Button, Stack, TextField, Typography } from '@mui/material';
 import {
+  SUPPORTING_URL_PLACEHOLDER,
   VOTE_REASON_PLACEHOLDER,
   VOTE_REASON_SUMMARY_LABEL,
   VOTE_REASON_URL_LABEL,
@@ -186,6 +187,7 @@ export const ProposalVoteForm: React.FC<ProposalVoteFormProps> = props => {
                         {field.state.meta.errors?.[0]}
                       </span>
                     }
+                    placeholder={SUPPORTING_URL_PLACEHOLDER}
                     inputProps={{ 'data-testid': 'your-vote-url-input' }}
                     sx={{
                       '& .MuiFilledInput-root': {

--- a/apps/sv/frontend/src/utils/constants.ts
+++ b/apps/sv/frontend/src/utils/constants.ts
@@ -5,18 +5,19 @@ export const PROPOSAL_SUMMARY_TITLE = 'Proposal Summary';
 export const PROPOSAL_REVIEW_TITLE = 'Proposal Review';
 export const PROPOSAL_SUMMARY_SUBTITLE = 'For CIP votes, consider copying the CIP abstract here';
 /** Figma initiate Proposal Summary empty/example prompt (Body M grey105 when empty). */
-export const PROPOSAL_SUMMARY_PLACEHOLDER = 'This is the summary.';
+export const PROPOSAL_SUMMARY_PLACEHOLDER = 'Add your reasoning here';
 export const DEFAULT_PROPOSAL_SUMMARY_MAX_LENGTH = 1024;
 export const THRESHOLD_DEADLINE_SUBTITLE =
   'Proposal remains open only if ⅔ of nodes place a vote before this date-time';
 export const DEFAULT_APP_ACTIVITY_WEIGHT = '1.0';
 
 export const SUPPORTING_URL_LABEL = 'Supporting URL';
-export const SUPPORTING_URL_PLACEHOLDER = 'https://';
+export const DATE_TIME_PLACEHOLDER = 'YYYY-MM-DD HH:MM';
+export const SUPPORTING_URL_PLACEHOLDER = 'https://example.com';
 export const VOTE_REASON_URL_LABEL = 'Vote Reason URL';
 export const VOTE_REASON_SUMMARY_LABEL = 'Reason';
 /** Figma Your Vote empty Reason prompt (`1013:1869`) — muted `#4F4F4F`. */
-export const VOTE_REASON_PLACEHOLDER = 'Your reason';
+export const VOTE_REASON_PLACEHOLDER = 'Add your reasoning here';
 export const VOTE_PROPOSAL_CONTRACT_ID_LABEL = 'Vote proposal contract id';
 export const THRESHOLD_DEADLINE_LABEL = 'Quorum Threshold Deadline';
 export const EFFECTIVE_AT_LABEL = 'Effective At';


### PR DESCRIPTION
## Summary
- add consistent date, reasoning, and URL placeholders to proposal forms
- derive dropdown placeholders from their field titles with the correct article
- cover initiate-proposal and vote-form placeholders in frontend tests

Closes #6910

## Validation
- generated Daml and OpenAPI TypeScript artifacts with the pinned DPM SDK 3.5.2 and OpenAPI Generator 6.6.0
- `npm run test:sbt -w @canton-network/splice-sv-frontend -- src/__tests__/governance/forms/offboard-sv-form.test.tsx src/__tests__/governance/forms/set-dso-rules-form.test.tsx src/__tests__/governance/proposal-details-content.test.tsx` (60 tests)
- `npm run check -w @canton-network/splice-sv-frontend`
- `npm run type:check -w @canton-network/splice-sv-frontend`
- `npm run build -w @canton-network/splice-sv-frontend`