### PR TITLE
Align vote URL display length with SV IDs

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -831,6 +831,14 @@ describe('Proposal Details > Votes & Voting', () => {
     expect(screen.getAllByTestId('proposal-details-voter-party-id')[0]).toHaveStyle({
       width: '100%',
     });
+    // Vote URLs use the same full-width slot as SV IDs.
+    expect(screen.getAllByTestId('proposal-details-vote-url')[0]).toHaveStyle({
+      width: '100%',
+    });
+    expect(screen.getAllByTestId('proposal-details-vote-url-scroll')[0]).toHaveStyle({
+      overflowX: 'auto',
+      maxWidth: '100%',
+    });
   });
 
   test('should filter votes by tabs', async () => {

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -645,7 +645,7 @@ const VoteItem: React.FC<VoteItemProps> = ({
             <Typography variant="caption" color="text.secondary" display="block" mb={1}>
               {VOTE_REASON_URL_LABEL}
             </Typography>
-            <CopyableUrl url={url} size="small" data-testid="proposal-details-vote-url" />
+            <CopyableUrl url={url} size="large" fullWidth data-testid="proposal-details-vote-url" />
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Summary
- let `CopyableUrl` accept a caller-specific visible content length while preserving its existing default
- render vote-reason URLs with the same typography and total character count as the corresponding SV ID
- keep the sanitized full URL in the link target and clipboard value
- add a focused proposal-details regression test

Closes #6914

## Validation
- reused Daml and OpenAPI TypeScript artifacts generated with the pinned DPM SDK 3.5.2 and OpenAPI Generator 6.6.0
- `npm run test:sbt -w @canton-network/splice-sv-frontend -- src/__tests__/governance/proposal-details-content.test.tsx` (32 tests)
- `npm run check -w @canton-network/splice-sv-frontend`
- `npm run type:check -w @canton-network/splice-sv-frontend`
- `npm run build -w @canton-network/splice-sv-frontend`