### PR TITLE
Use configured client IP headers in request logs

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/api/HttpRequestLogger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/api/HttpRequestLogger.scala
@@ -4,12 +4,13 @@
 package org.lfdecentralizedtrust.splice.admin.api
 
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, RemoteAddress}
-import org.apache.pekko.http.scaladsl.server.{Directive0, RequestContext}
+import org.apache.pekko.http.scaladsl.server.{Directive0, Directive1, RequestContext}
 import org.apache.pekko.http.scaladsl.server.Directives.*
 import com.digitalasset.canton.config.ApiLoggingConfig
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
+import org.lfdecentralizedtrust.splice.http.ClientIpDirectives
 
 object HttpRequestLogger {
   def apply(
@@ -17,6 +18,7 @@ object HttpRequestLogger {
       maxPathLength: Int,
       maxStringLength: Int,
       maxMetadataSize: Int,
+      clientIpHeaders: Seq[String],
       loggerFactory: NamedLoggerFactory,
   )(implicit traceContext: TraceContext): Directive0 = {
     new HttpRequestLogger(
@@ -24,6 +26,7 @@ object HttpRequestLogger {
       maxPathLength,
       maxStringLength,
       maxMetadataSize,
+      clientIpHeaders,
       loggerFactory,
     ).directive
   }
@@ -31,12 +34,14 @@ object HttpRequestLogger {
   // ignores maxMethodLength and maxMessageLines
   def apply(
       loggingConfig: ApiLoggingConfig,
+      clientIpHeaders: Seq[String],
       loggerFactory: NamedLoggerFactory,
   )(implicit traceContext: TraceContext): Directive0 = apply(
     messagePayloads = loggingConfig.messagePayloads,
     maxPathLength = loggingConfig.maxMethodLength,
     maxStringLength = loggingConfig.maxStringLength,
     maxMetadataSize = loggingConfig.maxMetadataSize,
+    clientIpHeaders = clientIpHeaders,
     loggerFactory = loggerFactory,
   )
 }
@@ -46,6 +51,7 @@ final class HttpRequestLogger(
     maxPathLength: Int,
     maxStringLength: Int,
     maxMetadataSize: Int,
+    clientIpHeaders: Seq[String],
     override protected val loggerFactory: NamedLoggerFactory,
 ) extends NamedLogging {
   def createLogMessage(ctx: RequestContext, remoteAddress: RemoteAddress)(
@@ -56,8 +62,14 @@ final class HttpRequestLogger(
     s"HTTP ${ctx.request.method.name} ${pathLimited} from (${remoteAddress}): ${message}"
   }
 
+  private def extractConfiguredClientIp: Directive1[RemoteAddress] =
+    ClientIpDirectives.extractClientIp(clientIpHeaders).flatMap {
+      case Some(remoteAddress) => provide(remoteAddress)
+      case None => extractClientIP
+    }
+
   private def directive(implicit traceContext: TraceContext): Directive0 = {
-    extractClientIP.flatMap { remoteAddress =>
+    extractConfiguredClientIp.flatMap { remoteAddress =>
       extractRequestContext.flatMap { ctx =>
         val msg = createLogMessage(ctx, remoteAddress)
         logger.debug(msg("received request."))

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpAdminService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpAdminService.scala
@@ -36,6 +36,7 @@ object HttpAdminService {
       adminApi: AdminServerConfig,
       parameterConfig: CantonNodeParameters,
       apiLoggingConfig: ApiLoggingConfig,
+      clientIpHeaders: Seq[String],
       loggerFactory: NamedLoggerFactory,
       node: => Option[CantonNode],
   )(implicit
@@ -49,6 +50,7 @@ object HttpAdminService {
     adminApi.port,
     parameterConfig,
     apiLoggingConfig,
+    clientIpHeaders,
     loggerFactory,
     node,
   )
@@ -59,6 +61,7 @@ object HttpAdminService {
       port: Port,
       parameterConfig: CantonNodeParameters,
       apiLoggingConfig: ApiLoggingConfig,
+      clientIpHeaders: Seq[String],
       loggerFactory: NamedLoggerFactory,
       node: => Option[CantonNode],
   )(implicit ac: ActorSystem, ec: ExecutionContext, tracer: Tracer, elc: ErrorLoggingContext)
@@ -98,7 +101,7 @@ object HttpAdminService {
         // handleRejections (inside the logger) seals the route: rejections are
         // converted to HTTP responses so mapResponse sees all outcomes and logs
         // exactly one "Responding with status code" per request.
-        HttpRequestLogger(apiLoggingConfig, loggerFactory)(traceContext) {
+        HttpRequestLogger(apiLoggingConfig, clientIpHeaders, loggerFactory)(traceContext) {
           handleRejections(RejectionHandler.default) {
             encodeResponse(
               handleRejections(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -25,6 +25,7 @@ abstract class SpliceBackendConfig extends LocalNodeConfig {
 
   def participantClient: BaseParticipantClientConfig
   def automation: AutomationConfig
+  def parameters: SpliceParametersConfig
 
 }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/NodeBootstrapBase.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/NodeBootstrapBase.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
 import com.daml.nameof.NameOf.functionFullName
 import org.lfdecentralizedtrust.splice.SpliceMetrics
 import com.digitalasset.canton.concurrent.ExecutionContextIdlenessExecutorService
-import com.digitalasset.canton.config.{LocalNodeConfig, ProcessingTimeout}
+import com.digitalasset.canton.config.ProcessingTimeout
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.crypto.Crypto
 import com.digitalasset.canton.environment.{CantonNode, CantonNodeBootstrap, CantonNodeParameters}
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.concurrent.{blocking, Future}
 import scala.util.{Failure, Success}
 import org.lfdecentralizedtrust.splice.admin.http.{AdminRoutes, HttpAdminService}
+import org.lfdecentralizedtrust.splice.config.SpliceBackendConfig
 
 /** Modelled after CantonNodeBootstrap
   */
@@ -66,7 +67,7 @@ trait NodeBootstrap[+N <: CantonNode]
   */
 abstract class NodeBootstrapBase[
     T <: CantonNode,
-    NodeConfig <: LocalNodeConfig,
+    NodeConfig <: SpliceBackendConfig,
     ParameterConfig <: CantonNodeParameters,
 ](
     nodeConfig: NodeConfig,
@@ -109,6 +110,7 @@ abstract class NodeBootstrapBase[
       nodeConfig.adminApi,
       parameterConfig,
       parameterConfig.loggingConfig.api,
+      nodeConfig.parameters.rateLimiting.clientIpHeaders,
       loggerFactory,
       getNode,
     )

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/admin/api/HttpRequestLoggerTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/admin/api/HttpRequestLoggerTest.scala
@@ -6,19 +6,22 @@ package org.lfdecentralizedtrust.splice.admin.api
 import com.digitalasset.canton.config.ApiLoggingConfig
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.BaseTest
-import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, RemoteAddress, StatusCodes}
+import org.apache.pekko.http.scaladsl.model.headers.{RawHeader, `X-Forwarded-For`}
 import org.apache.pekko.http.scaladsl.server.{RejectionHandler, Route}
 import org.apache.pekko.http.scaladsl.server.Directives.*
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.wordspec.AnyWordSpec
 import org.slf4j.event.Level
+import org.lfdecentralizedtrust.splice.config.RateLimitersConfig
 
 class HttpRequestLoggerTest extends AnyWordSpec with BaseTest with ScalatestRouteTest {
 
   private val apiLoggingConfig = ApiLoggingConfig()
 
-  private def loggerDirective = HttpRequestLogger(
+  private def loggerDirective(clientIpHeaders: Seq[String]) = HttpRequestLogger(
     apiLoggingConfig,
+    clientIpHeaders,
     loggerFactory,
   )
 
@@ -28,8 +31,10 @@ class HttpRequestLoggerTest extends AnyWordSpec with BaseTest with ScalatestRout
     * all outcomes and logs exactly one "Responding with status code" per request —
     * whether matched or rejected.
     */
-  private def route: Route =
-    loggerDirective {
+  private def routeFor(
+      clientIpHeaders: Seq[String] = RateLimitersConfig.DefaultClientIpHeaders
+  ): Route =
+    loggerDirective(clientIpHeaders) {
       handleRejections(RejectionHandler.default) {
         concat(
           pathPrefix("api" / "admin") {
@@ -42,7 +47,43 @@ class HttpRequestLoggerTest extends AnyWordSpec with BaseTest with ScalatestRout
       }
     }
 
+  private lazy val route = routeFor()
+
+  private def assertLoggedClientIp(request: HttpRequest, expectedClientIp: String): Unit =
+    loggerFactory.assertLogsSeq(SuppressionRule.Level(Level.DEBUG))(
+      {
+        request ~> routeFor(Seq("x-envoy-external-address")) ~> check {
+          status shouldBe StatusCodes.OK
+        }
+      },
+      logEntries =>
+        forExactly(1, logEntries) { entry =>
+          entry.message should include("received request")
+          entry.message should include(s"from ($expectedClientIp)")
+        },
+    )
+
   "HttpRequestLogger" should {
+
+    "prefer the configured client IP header" in {
+      assertLoggedClientIp(
+        Get("/api/app").withHeaders(
+          RawHeader("X-Envoy-External-Address", "5.5.5.5"),
+          RawHeader("X-Forwarded-For", "1.1.1.1"),
+        ),
+        "5.5.5.5",
+      )
+    }
+
+    "fall back to the existing client IP extraction" in {
+      assertLoggedClientIp(
+        Get("/api/app").withHeaders(
+          RawHeader("X-Envoy-External-Address", "not-an-ip"),
+          `X-Forwarded-For`(Seq(RemoteAddress(Array[Byte](2, 2, 2, 2)))),
+        ),
+        "2.2.2.2",
+      )
+    }
 
     "log exactly one 'received request' and one response for a matching route" in {
       loggerFactory.assertLogsSeq(SuppressionRule.Level(Level.DEBUG))(
@@ -84,7 +125,7 @@ class HttpRequestLoggerTest extends AnyWordSpec with BaseTest with ScalatestRout
 
     "one log entry per request when methods conflict across siblings" in {
       val newStyleMethodRoute: Route =
-        loggerDirective {
+        loggerDirective(RateLimitersConfig.DefaultClientIpHeaders) {
           handleRejections(RejectionHandler.default) {
             concat(
               pathPrefix("api" / "data") {


### PR DESCRIPTION
## Summary

- use the configured rate-limiter client IP headers for request logging
- fall back to Pekko client IP extraction when configured headers yield no IP
- cover configured-header precedence and fallback behavior

Closes #6895

## Validation

- `apps-common/testOnly org.lfdecentralizedtrust.splice.admin.api.HttpRequestLoggerTest`
- `apps-common/scalafmtAll`
- `apps-common/Test/scalafmtAll`
- `git diff --check`