### PR TITLE
Expose sv app endpoints to the minimum users

### DIFF
--- a/apps/sv/src/main/openapi/sv-internal.yaml
+++ b/apps/sv/src/main/openapi/sv-internal.yaml
@@ -76,6 +76,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: none
       operationId: "getCometBftNodeStatus"
       responses:
         "200":
@@ -96,6 +97,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: none
       operationId: "cometBftJsonRpcRequest"
       requestBody:
         required: true
@@ -393,6 +395,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: validators
       operationId: "onboardValidator"
       requestBody:
         required: true
@@ -411,6 +414,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: sv-operators
       operationId: "startSvOnboarding"
       requestBody:
         required: true
@@ -429,6 +433,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: sv-operators
       operationId: "getSvOnboardingStatus"
       parameters:
         - name: "candidate_party_id_or_name"
@@ -451,6 +456,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: sv-operators
       operationId: "onboardSvPartyMigrationAuthorize"
       requestBody:
         required: true
@@ -477,6 +483,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: sv-operators
       operationId: "onboardSvSequencer"
       requestBody:
         required: true
@@ -497,6 +504,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: validators
       description: "faucet for validator candidates self-service"
       operationId: "devNetOnboardValidatorPrepare"
       responses:
@@ -515,6 +523,7 @@ paths:
       tags: [sv]
       # TODO(DACH-NY/canton-network-internal#2106) Move to sv_operator
       x-jvm-package: sv_public
+      x-public-audience: validators
       operationId: "getDsoInfo"
       responses:
         "200":
@@ -528,6 +537,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
+      x-public-audience: sv-operators
       operationId: "getMigrationId"
       description: |
         Returns the synchronizer migration id this SV is currently using.

--- a/apps/sv/src/main/openapi/sv-internal.yaml
+++ b/apps/sv/src/main/openapi/sv-internal.yaml
@@ -76,7 +76,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: none
+      x-external-audience: none
       operationId: "getCometBftNodeStatus"
       responses:
         "200":
@@ -97,7 +97,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: none
+      x-external-audience: none
       operationId: "cometBftJsonRpcRequest"
       requestBody:
         required: true
@@ -395,7 +395,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: validators
+      x-external-audience: validators
       operationId: "onboardValidator"
       requestBody:
         required: true
@@ -414,7 +414,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: sv-operators
+      x-external-audience: svs
       operationId: "startSvOnboarding"
       requestBody:
         required: true
@@ -433,7 +433,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: sv-operators
+      x-external-audience: svs
       operationId: "getSvOnboardingStatus"
       parameters:
         - name: "candidate_party_id_or_name"
@@ -456,7 +456,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: sv-operators
+      x-external-audience: svs
       operationId: "onboardSvPartyMigrationAuthorize"
       requestBody:
         required: true
@@ -483,7 +483,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: sv-operators
+      x-external-audience: svs
       operationId: "onboardSvSequencer"
       requestBody:
         required: true
@@ -504,7 +504,7 @@ paths:
     post:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: validators
+      x-external-audience: validators
       description: "faucet for validator candidates self-service"
       operationId: "devNetOnboardValidatorPrepare"
       responses:
@@ -523,7 +523,7 @@ paths:
       tags: [sv]
       # TODO(DACH-NY/canton-network-internal#2106) Move to sv_operator
       x-jvm-package: sv_public
-      x-public-audience: validators
+      x-external-audience: validators
       operationId: "getDsoInfo"
       responses:
         "200":
@@ -537,7 +537,7 @@ paths:
     get:
       tags: [sv]
       x-jvm-package: sv_public
-      x-public-audience: sv-operators
+      x-external-audience: svs
       operationId: "getMigrationId"
       description: |
         Returns the synchronizer migration id this SV is currently using.

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2825,7 +2825,7 @@
       "apiVersion": "security.istio.io/v1beta1",
       "kind": "AuthorizationPolicy",
       "metadata": {
-        "name": "sv-app-sv-operators-ip-whitelist-0",
+        "name": "sv-app-svs-ip-whitelist-0",
         "namespace": "cluster-ingress"
       },
       "spec": {
@@ -2875,7 +2875,7 @@
         }
       }
     },
-    "name": "sv-app-sv-operators-ip-whitelist-0",
+    "name": "sv-app-svs-ip-whitelist-0",
     "provider": "",
     "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2235,7 +2235,7 @@
       "apiVersion": "security.istio.io/v1beta1",
       "kind": "AuthorizationPolicy",
       "metadata": {
-        "name": "scan-sv-app-ip-whitelist-0",
+        "name": "scan-app-ip-whitelist-0",
         "namespace": "cluster-ingress"
       },
       "spec": {
@@ -2266,17 +2266,11 @@
                 "operation": {
                   "hosts": [
                     "scan.sv-2.mock.network.canton.global",
-                    "sv.sv-2.mock.network.canton.global",
                     "scan.sv-2.mock.global.canton.network.digitalasset.com",
-                    "sv.sv-2.mock.global.canton.network.digitalasset.com",
                     "scan.sv-1.mock.network.canton.global",
-                    "sv.sv-1.mock.network.canton.global",
                     "scan.sv-1.mock.global.canton.network.digitalasset.com",
-                    "sv.sv-1.mock.global.canton.network.digitalasset.com",
                     "scan.sv.mock.network.canton.global",
-                    "sv.sv.mock.network.canton.global",
-                    "scan.sv.mock.global.canton.network.digitalasset.com",
-                    "sv.sv.mock.global.canton.network.digitalasset.com"
+                    "scan.sv.mock.global.canton.network.digitalasset.com"
                   ]
                 }
               }
@@ -2290,7 +2284,7 @@
         }
       }
     },
-    "name": "scan-sv-app-ip-whitelist-0",
+    "name": "scan-app-ip-whitelist-0",
     "provider": "",
     "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },
@@ -2823,6 +2817,132 @@
     "name": "sv-2-deny-onboard-prepare-endpoint",
     "provider": "",
     "type": "kubernetes:security.istio.io/v1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "sv-app-sv-operators-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sv.sv-2.mock.network.canton.global",
+                    "sv.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-1.mock.network.canton.global",
+                    "sv.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sv.sv.mock.network.canton.global",
+                    "sv.sv.mock.global.canton.network.digitalasset.com"
+                  ],
+                  "paths": [
+                    "/api/sv/v0/migration-id",
+                    "/api/sv/v0/onboard/sv/party-migration/authorize",
+                    "/api/sv/v0/onboard/sv/sequencer",
+                    "/api/sv/v0/onboard/sv/start",
+                    "/api/sv/v0/onboard/sv/status/*"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "sv-app-sv-operators-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "sv-app-validators-ip-whitelist-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "<internal IPs>",
+                    "1.2.3.4/32",
+                    "5.6.7.8/32",
+                    "11.12.13.14/32",
+                    "4.3.2.1/32",
+                    "8.7.6.5/32",
+                    "8.7.6.4/32",
+                    "9.8.7.6/32",
+                    "11.22.33.45/32",
+                    "12.34.56.78/32",
+                    "2.3.4.5/32"
+                  ]
+                }
+              }
+            ],
+            "to": [
+              {
+                "operation": {
+                  "hosts": [
+                    "sv.sv-2.mock.network.canton.global",
+                    "sv.sv-2.mock.global.canton.network.digitalasset.com",
+                    "sv.sv-1.mock.network.canton.global",
+                    "sv.sv-1.mock.global.canton.network.digitalasset.com",
+                    "sv.sv.mock.network.canton.global",
+                    "sv.sv.mock.global.canton.network.digitalasset.com"
+                  ],
+                  "paths": [
+                    "/api/sv/v0/devnet/onboard/validator/prepare",
+                    "/api/sv/v0/dso",
+                    "/api/sv/v0/onboard/validator"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress"
+          }
+        }
+      }
+    },
+    "name": "sv-app-validators-ip-whitelist-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },
   {
     "custom": true,

--- a/cluster/pulumi/infra/src/whitelisting/index.ts
+++ b/cluster/pulumi/infra/src/whitelisting/index.ts
@@ -14,7 +14,10 @@ export function installAppWhitelisting(
   if (infraConfig.istio.enableGeneralIpWhitelist) {
     return [];
   } else {
-    return [configureScanAndSvAppWhitelist(namespace), ...configureSequencerWhitelist(namespace)];
+    return [
+      ...configureScanAndSvAppWhitelist(namespace),
+      ...configureSequencerWhitelist(namespace),
+    ];
   }
 }
 

--- a/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
+++ b/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
@@ -41,11 +41,11 @@ export function configureScanAndSvAppWhitelist(
       to: [{ operation: { hosts: svHosts, paths: publicPaths['validators'] } }],
     }),
     createIstioIpAllowPolicies({
-      namePrefix: 'sv-app-sv-operators-ip-whitelist',
+      namePrefix: 'sv-app-svs-ip-whitelist',
       namespace: namespace.metadata.name,
       selector: istioIngressSelector,
       ipRanges: loadIPRanges(true),
-      to: [{ operation: { hosts: svHosts, paths: publicPaths['sv-operators'] } }],
+      to: [{ operation: { hosts: svHosts, paths: publicPaths['svs'] } }],
     }),
   ];
 }

--- a/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
+++ b/cluster/pulumi/infra/src/whitelisting/scanAndSvApp.ts
@@ -2,24 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
-import { getDnsNames } from '@canton-network/splice-pulumi-common';
+import { getDnsNames, SPLICE_ROOT } from '@canton-network/splice-pulumi-common';
 import { allSvsToDeployBasic } from '@canton-network/splice-pulumi-common-sv/src/svConfigsBasic';
 
 import { loadIPRanges } from './ipRanges';
 import { createIstioIpAllowPolicies, istioIngressSelector } from './policies';
+import { readSvPublicIngressPathsByAudience } from './svPublicEndpoints';
+
+export const svOpenApiFile = `${SPLICE_ROOT}/apps/sv/src/main/openapi/sv-internal.yaml`;
+
+function hostsFor(prefix: string): string[] {
+  const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
+  return allSvsToDeployBasic.flatMap(sv =>
+    dnsNames.map(dns => `${prefix}.${sv.ingressName}.${dns}`)
+  );
+}
 
 export function configureScanAndSvAppWhitelist(
   namespace: k8s.core.v1.Namespace
-): pulumi.Output<pulumi.Resource[]> {
-  const dnsNames = [getDnsNames().cantonDnsName, getDnsNames().daDnsName];
-  const hosts = allSvsToDeployBasic.flatMap(sv =>
-    dnsNames.flatMap(dns => [`scan.${sv.ingressName}.${dns}`, `sv.${sv.ingressName}.${dns}`])
-  );
-  return createIstioIpAllowPolicies({
-    namePrefix: 'scan-sv-app-ip-whitelist',
-    namespace: namespace.metadata.name,
-    selector: istioIngressSelector,
-    ipRanges: loadIPRanges(),
-    to: [{ operation: { hosts } }],
-  });
+): pulumi.Output<pulumi.Resource[]>[] {
+  const scanHosts = hostsFor('scan');
+  const svHosts = hostsFor('sv');
+  const publicPaths = readSvPublicIngressPathsByAudience(svOpenApiFile);
+
+  return [
+    createIstioIpAllowPolicies({
+      namePrefix: 'scan-app-ip-whitelist',
+      namespace: namespace.metadata.name,
+      selector: istioIngressSelector,
+      ipRanges: loadIPRanges(),
+      to: [{ operation: { hosts: scanHosts } }],
+    }),
+    createIstioIpAllowPolicies({
+      namePrefix: 'sv-app-validators-ip-whitelist',
+      namespace: namespace.metadata.name,
+      selector: istioIngressSelector,
+      ipRanges: loadIPRanges(),
+      to: [{ operation: { hosts: svHosts, paths: publicPaths['validators'] } }],
+    }),
+    createIstioIpAllowPolicies({
+      namePrefix: 'sv-app-sv-operators-ip-whitelist',
+      namespace: namespace.metadata.name,
+      selector: istioIngressSelector,
+      ipRanges: loadIPRanges(true),
+      to: [{ operation: { hosts: svHosts, paths: publicPaths['sv-operators'] } }],
+    }),
+  ];
 }

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  exposedAudiences,
+  parseSvPublicEndpoints,
+  publicAudiences,
+  svPublicIngressPathsByAudience,
+  toIngressPath,
+} from './svPublicEndpoints';
+
+const svOpenApiFile = path.join(
+  __dirname,
+  '../../../../../apps/sv/src/main/openapi/sv-internal.yaml'
+);
+
+describe('the SV OpenAPI spec', () => {
+  const content = fs.readFileSync(svOpenApiFile, 'utf-8');
+
+  test('declares an x-public-audience for every sv_public endpoint', () => {
+    const endpoints = parseSvPublicEndpoints(content);
+    expect(endpoints.length).toBeGreaterThan(0);
+    endpoints.forEach(endpoint => {
+      expect(publicAudiences).toContain(endpoint.audience);
+    });
+  });
+
+  test('exposes the expected paths per audience', () => {
+    const paths = svPublicIngressPathsByAudience(content);
+    expect(paths['validators']).toContain('/api/sv/v0/onboard/validator');
+    expect(paths['validators']).toContain('/api/sv/v0/dso');
+    expect(paths['sv-operators']).toContain('/api/sv/v0/migration-id');
+    expect(paths['sv-operators']).toContain('/api/sv/v0/onboard/sv/status/*');
+    const allPaths = exposedAudiences.flatMap(audience => paths[audience]);
+    // endpoints with an audience of none must not be whitelisted
+    expect(allPaths).not.toContain('/api/sv/v0/admin/domain/cometbft/status');
+    expect(allPaths).not.toContain('/api/sv/v0/admin/domain/cometbft/json-rpc');
+    // non-public endpoints must not be whitelisted
+    expect(allPaths).not.toContain('/api/sv/v0/admin/sv/votes');
+    expect(allPaths).not.toContain('/api/sv/readyz');
+  });
+});
+
+describe('parseSvPublicEndpoints', () => {
+  const spec = (extra: string) => `
+openapi: 3.0.0
+paths:
+  /v0/foo:
+    get:
+      x-jvm-package: sv_public
+${extra}
+      operationId: getFoo
+      responses:
+        "200":
+          description: ok
+`;
+
+  test('fails if an sv_public endpoint has no x-public-audience', () => {
+    expect(() => parseSvPublicEndpoints(spec(''))).toThrow(/must declare x-public-audience/);
+  });
+
+  test('fails on an unknown x-public-audience', () => {
+    expect(() => parseSvPublicEndpoints(spec('      x-public-audience: everyone'))).toThrow(
+      /must declare x-public-audience/
+    );
+  });
+
+  test('accepts a valid x-public-audience', () => {
+    expect(parseSvPublicEndpoints(spec('      x-public-audience: validators'))).toEqual([
+      { path: '/v0/foo', method: 'get', operationId: 'getFoo', audience: 'validators' },
+    ]);
+  });
+
+  test('accepts an audience of none but does not whitelist the endpoint', () => {
+    const content = spec('      x-public-audience: none');
+    expect(parseSvPublicEndpoints(content)).toEqual([
+      { path: '/v0/foo', method: 'get', operationId: 'getFoo', audience: 'none' },
+    ]);
+    const paths = svPublicIngressPathsByAudience(content);
+    expect(exposedAudiences.flatMap(audience => paths[audience])).toEqual([]);
+  });
+
+  test('rejects x-public-audience on non-public endpoints', () => {
+    const nonPublic = `
+openapi: 3.0.0
+paths:
+  /v0/foo:
+    get:
+      x-jvm-package: sv_operator
+      x-public-audience: validators
+      operationId: getFoo
+`;
+    expect(() => parseSvPublicEndpoints(nonPublic)).toThrow(/only allowed on endpoints/);
+  });
+});
+
+test('toIngressPath replaces path parameters with a wildcard', () => {
+  expect(toIngressPath('/v0/onboard/sv/status/{candidate_party_id_or_name}')).toBe(
+    '/api/sv/v0/onboard/sv/status/*'
+  );
+  expect(toIngressPath('/v0/dso')).toBe('/api/sv/v0/dso');
+});

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
@@ -20,7 +20,7 @@ const svOpenApiFile = path.join(
 describe('the SV OpenAPI spec', () => {
   const content = fs.readFileSync(svOpenApiFile, 'utf-8');
 
-  test('declares an x-public-audience for every sv_public endpoint', () => {
+  test('declares an x-external-audience for every sv_public endpoint', () => {
     const endpoints = parseSvPublicEndpoints(content);
     expect(endpoints.length).toBeGreaterThan(0);
     endpoints.forEach(endpoint => {
@@ -32,8 +32,8 @@ describe('the SV OpenAPI spec', () => {
     const paths = svPublicIngressPathsByAudience(content);
     expect(paths['validators']).toContain('/api/sv/v0/onboard/validator');
     expect(paths['validators']).toContain('/api/sv/v0/dso');
-    expect(paths['sv-operators']).toContain('/api/sv/v0/migration-id');
-    expect(paths['sv-operators']).toContain('/api/sv/v0/onboard/sv/status/*');
+    expect(paths['svs']).toContain('/api/sv/v0/migration-id');
+    expect(paths['svs']).toContain('/api/sv/v0/onboard/sv/status/*');
     const allPaths = exposedAudiences.flatMap(audience => paths[audience]);
     // endpoints with an audience of none must not be whitelisted
     expect(allPaths).not.toContain('/api/sv/v0/admin/domain/cometbft/status');
@@ -58,24 +58,24 @@ ${extra}
           description: ok
 `;
 
-  test('fails if an sv_public endpoint has no x-public-audience', () => {
-    expect(() => parseSvPublicEndpoints(spec(''))).toThrow(/must declare x-public-audience/);
+  test('fails if an sv_public endpoint has no x-external-audience', () => {
+    expect(() => parseSvPublicEndpoints(spec(''))).toThrow(/must declare x-external-audience/);
   });
 
-  test('fails on an unknown x-public-audience', () => {
-    expect(() => parseSvPublicEndpoints(spec('      x-public-audience: everyone'))).toThrow(
-      /must declare x-public-audience/
+  test('fails on an unknown x-external-audience', () => {
+    expect(() => parseSvPublicEndpoints(spec('      x-external-audience: everyone'))).toThrow(
+      /must declare x-external-audience/
     );
   });
 
-  test('accepts a valid x-public-audience', () => {
-    expect(parseSvPublicEndpoints(spec('      x-public-audience: validators'))).toEqual([
+  test('accepts a valid x-external-audience', () => {
+    expect(parseSvPublicEndpoints(spec('      x-external-audience: validators'))).toEqual([
       { path: '/v0/foo', method: 'get', operationId: 'getFoo', audience: 'validators' },
     ]);
   });
 
   test('accepts an audience of none but does not whitelist the endpoint', () => {
-    const content = spec('      x-public-audience: none');
+    const content = spec('      x-external-audience: none');
     expect(parseSvPublicEndpoints(content)).toEqual([
       { path: '/v0/foo', method: 'get', operationId: 'getFoo', audience: 'none' },
     ]);
@@ -83,14 +83,14 @@ ${extra}
     expect(exposedAudiences.flatMap(audience => paths[audience])).toEqual([]);
   });
 
-  test('rejects x-public-audience on non-public endpoints', () => {
+  test('rejects x-external-audience on non-public endpoints', () => {
     const nonPublic = `
 openapi: 3.0.0
 paths:
   /v0/foo:
     get:
       x-jvm-package: sv_operator
-      x-public-audience: validators
+      x-external-audience: validators
       operationId: getFoo
 `;
     expect(() => parseSvPublicEndpoints(nonPublic)).toThrow(/only allowed on endpoints/);

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as fs from 'fs';
+import { load } from 'js-yaml';
+
+export const svApiPathPrefix = '/api/sv';
+
+export const publicAudiences = ['validators', 'sv-operators', 'none'] as const;
+export type PublicAudience = (typeof publicAudiences)[number];
+
+export const exposedAudiences = ['validators', 'sv-operators'] as const;
+export type ExposedAudience = (typeof exposedAudiences)[number];
+
+const httpMethods = ['get', 'put', 'post', 'delete', 'patch', 'head', 'options'];
+
+export type SvPublicEndpoint = {
+  path: string;
+  method: string;
+  operationId?: string;
+  audience: PublicAudience;
+};
+
+function isPublicAudience(value: unknown): value is PublicAudience {
+  return publicAudiences.includes(value as PublicAudience);
+}
+
+/**
+ * Parses the SV OpenAPI spec and returns all endpoints that are exposed without
+ * authentication (`x-jvm-package: sv_public`).
+ *
+ * Throws if an `sv_public` endpoint does not declare a valid `x-public-audience`,
+ * or if a non-public endpoint declares one.
+ */
+export function parseSvPublicEndpoints(openApiContent: string): SvPublicEndpoint[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spec = load(openApiContent) as any;
+  const paths = spec?.paths || {};
+  const endpoints: SvPublicEndpoint[] = [];
+  const errors: string[] = [];
+  for (const path of Object.keys(paths)) {
+    for (const method of httpMethods) {
+      const operation = paths[path]?.[method];
+      if (!operation) {
+        continue;
+      }
+      const audience = operation['x-public-audience'];
+      const isPublic = operation['x-jvm-package'] === 'sv_public';
+      if (!isPublic) {
+        if (audience !== undefined) {
+          errors.push(
+            `${method.toUpperCase()} ${path}: x-public-audience is only allowed on endpoints with x-jvm-package: sv_public`
+          );
+        }
+        continue;
+      }
+      if (!isPublicAudience(audience)) {
+        errors.push(
+          `${method.toUpperCase()} ${path}: sv_public endpoints must declare x-public-audience as one of ${publicAudiences.join(
+            ', '
+          )} but got ${JSON.stringify(audience)}`
+        );
+        continue;
+      }
+      endpoints.push({ path, method, operationId: operation.operationId, audience });
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid SV OpenAPI public endpoint definitions:\n${errors.join('\n')}`);
+  }
+  return endpoints;
+}
+
+export function toIngressPath(openApiPath: string): string {
+  const withWildcards = openApiPath.replace(/\{[^}]+\}/g, '*');
+  return `${svApiPathPrefix}${withWildcards}`;
+}
+
+export function svPublicIngressPathsByAudience(
+  openApiContent: string
+): Record<ExposedAudience, string[]> {
+  const endpoints = parseSvPublicEndpoints(openApiContent);
+  return Object.fromEntries(
+    exposedAudiences.map(audience => [
+      audience,
+      [
+        ...new Set(endpoints.filter(e => e.audience === audience).map(e => toIngressPath(e.path))),
+      ].sort(),
+    ])
+  ) as Record<ExposedAudience, string[]>;
+}
+
+export function readSvPublicIngressPathsByAudience(
+  openApiFile: string
+): Record<ExposedAudience, string[]> {
+  return svPublicIngressPathsByAudience(fs.readFileSync(openApiFile, 'utf-8'));
+}

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
@@ -5,10 +5,10 @@ import { load } from 'js-yaml';
 
 export const svApiPathPrefix = '/api/sv';
 
-export const publicAudiences = ['validators', 'sv-operators', 'none'] as const;
+export const publicAudiences = ['validators', 'svs', 'none'] as const;
 export type PublicAudience = (typeof publicAudiences)[number];
 
-export const exposedAudiences = ['validators', 'sv-operators'] as const;
+export const exposedAudiences = ['validators', 'svs'] as const;
 export type ExposedAudience = (typeof exposedAudiences)[number];
 
 const httpMethods = ['get', 'put', 'post', 'delete', 'patch', 'head', 'options'];
@@ -28,7 +28,7 @@ function isPublicAudience(value: unknown): value is PublicAudience {
  * Parses the SV OpenAPI spec and returns all endpoints that are exposed without
  * authentication (`x-jvm-package: sv_public`).
  *
- * Throws if an `sv_public` endpoint does not declare a valid `x-public-audience`,
+ * Throws if an `sv_public` endpoint does not declare a valid `x-external-audience`,
  * or if a non-public endpoint declares one.
  */
 export function parseSvPublicEndpoints(openApiContent: string): SvPublicEndpoint[] {
@@ -43,19 +43,19 @@ export function parseSvPublicEndpoints(openApiContent: string): SvPublicEndpoint
       if (!operation) {
         continue;
       }
-      const audience = operation['x-public-audience'];
+      const audience = operation['x-external-audience'];
       const isPublic = operation['x-jvm-package'] === 'sv_public';
       if (!isPublic) {
         if (audience !== undefined) {
           errors.push(
-            `${method.toUpperCase()} ${path}: x-public-audience is only allowed on endpoints with x-jvm-package: sv_public`
+            `${method.toUpperCase()} ${path}: x-external-audience is only allowed on endpoints with x-jvm-package: sv_public`
           );
         }
         continue;
       }
       if (!isPublicAudience(audience)) {
         errors.push(
-          `${method.toUpperCase()} ${path}: sv_public endpoints must declare x-public-audience as one of ${publicAudiences.join(
+          `${method.toUpperCase()} ${path}: sv_public endpoints must declare x-external-audience as one of ${publicAudiences.join(
             ', '
           )} but got ${JSON.stringify(audience)}`
         );

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -35,3 +35,5 @@ release-notes:: Upcoming
           given audience need to be reachable from the corresponding networks, and endpoints with
           an audience of ``none``, as well as endpoints without an ``x-external-audience``, do not
           need to be exposed to external traffic at all.
+          Note that endpoints currently marked for exposure to validators will be phased out in the foreseeable future,
+          and replaced by a new limited number of endpoints which should be available only on DevNet.

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -22,3 +22,16 @@ release-notes:: Upcoming
     - Docker
 
         - Updated Docker base image to 1.0.13, which updates gRPC health probe to v0.4.55.
+
+    - SV app
+
+        - The SV app OpenAPI specification now annotates public endpoints
+          (``x-jvm-package: sv_public``) with an ``x-public-audience`` extension, which is one of
+          ``validators`` (endpoints that validator operators need to reach), ``sv-operators``
+          (endpoints that only other SV operators need to reach) or ``none`` (endpoints that do not
+          need to be reachable from outside of the SV node's own deployment, e.g. the CometBFT
+          endpoints). SV operators can use this
+          annotation to restrict the external exposure of their SV app: only the endpoints of a
+          given audience need to be reachable from the corresponding networks, and endpoints with
+          an audience of ``none``, as well as endpoints without an ``x-public-audience``, do not
+          need to be exposed to external traffic at all.

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -25,13 +25,13 @@ release-notes:: Upcoming
 
     - SV app
 
-        - The SV app OpenAPI specification now annotates public endpoints
-          (``x-jvm-package: sv_public``) with an ``x-public-audience`` extension, which is one of
-          ``validators`` (endpoints that validator operators need to reach), ``sv-operators``
-          (endpoints that only other SV operators need to reach) or ``none`` (endpoints that do not
+        - The SV app OpenAPI specification now annotates endpoints
+          (``x-jvm-package: sv_public``) with an ``x-external-audience`` extension, which is one of
+          ``validators`` (endpoints that validator operators need to reach), ``svs``
+          (endpoints that only other SVs need to reach) or ``none`` (endpoints that do not
           need to be reachable from outside of the SV node's own deployment, e.g. the CometBFT
           endpoints). SV operators can use this
           annotation to restrict the external exposure of their SV app: only the endpoints of a
           given audience need to be reachable from the corresponding networks, and endpoints with
-          an audience of ``none``, as well as endpoints without an ``x-public-audience``, do not
+          an audience of ``none``, as well as endpoints without an ``x-external-audience``, do not
           need to be exposed to external traffic at all.


### PR DESCRIPTION
Also extend open api so the other SVs can easily apply the same restriction

[static]

part of https://github.com/DACH-NY/canton-network-internal/issues/743 (still misses cf-docs part)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
