### PR TITLE
Remove log ignore that is stale after #6935

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -61,9 +61,6 @@ Trying to re-register template.*
 # TODO(#975): investigate and remove once fixed
 failed with UNKNOWN/channel closed.*SvAppLedgerApiConnectivityIntegrationTest
 
-# This might be logged between the test finishing and shutdown of the nodes (see #8991)
-Noticed an DsoRules epoch change.*DecentralizedSynchronizerMigrationIntegrationTest
-
 # TODO (#825): this only applies to simtime.
 # In simtime tests where the rounds are advanced too quickly, this trigger might not have enough time to receive the coupon.
 # Nevertheless, it is still useful to have the warning in production environments, where this should never happen.


### PR DESCRIPTION
I thought about this a bit too late / hit merge on #6935 a bit too quickly...

[force] (is fine because that log message doesn't exist anymore)

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
