### PR TITLE
[ci] fix race condition in writing s3 objects

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/S3BucketConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/S3BucketConnection.scala
@@ -222,6 +222,14 @@ class S3BucketConnection(
     private val parts = TrieMap.empty[Integer, CompletedPart]
     private val md = MessageDigest.getInstance("SHA-256")
 
+    /** The checksum of the whole object. Computing it via a `lazy val` to support idempotent `finish()` calls.
+      */
+    private lazy val objectChecksum: String = Base64.getEncoder.encodeToString(md.digest())
+
+    /** `lazy val` to ensure that multi-part upload is completed at most once.
+      */
+    private lazy val finishResult: Future[Unit] = doFinish()
+
     /** Call this once before uploading a new part.
       *  The content must already be provided for checksums, but will not be uploaded yet.
       */
@@ -273,7 +281,12 @@ class S3BucketConnection(
       }
     }
 
-    def finish(): Future[Unit] = {
+    /** Completes the multi-part upload and stores the object checksum in the object's metadata.
+      * Idempotent, safe to call more than once (will just return the Future from the first call again).
+      */
+    def finish(): Future[Unit] = finishResult
+
+    private def doFinish(): Future[Unit] = {
       require(numParts.get() > 0)
       require(
         parts.size == numParts.get(),
@@ -297,7 +310,7 @@ class S3BucketConnection(
         _ <- s3Client.completeMultipartUpload(completeRequest).asScala
 
         // Copy-in-place of the object to add the final checksum to its metadata
-        metadata = Map("splice-checksum" -> Base64.getEncoder.encodeToString(md.digest()))
+        metadata = Map("splice-checksum" -> objectChecksum)
 
         copyReq = CopyObjectRequest
           .builder()

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
@@ -63,7 +63,7 @@ class BulkStorageCommitFromStaging[T](
               )
             if (consensusChecksums.length == objects.length && !consensus) {
               logger.error(
-                s"All objects are known to the BFT peers, but the checksums do not match. This indicates an error in the actual data generated for bulk storage. Expected: ${objects
+                s"All objects are known to the BFT peers, but the checksums do not match, when checking objects: ${objects.map(_.key).mkString(", ")}. This indicates an error in the actual data generated for bulk storage. Expected: ${objects
                     .map(_.checksum)
                     .mkString(", ")}, got: ${consensusChecksums.mkString(", ")}"
               )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
@@ -63,9 +63,9 @@ class BulkStorageCommitFromStaging[T](
               )
             if (consensusChecksums.length == objects.length && !consensus) {
               logger.error(
-                s"All objects are known to the BFT peers, but the checksums do not match, when checking objects: ${objects.map(_.key).mkString(", ")}. This indicates an error in the actual data generated for bulk storage. Expected: ${objects
+                s"All objects are known to the BFT peers, but the checksums do not match, when checking objects: ${objects.map(_.key).mkString(", ")}. This indicates an error in the actual data generated for bulk storage. My checksums are: ${objects
                     .map(_.checksum)
-                    .mkString(", ")}, got: ${consensusChecksums.mkString(", ")}"
+                    .mkString(", ")}, consensus checksums are: ${consensusChecksums.mkString(", ")}"
               )
             }
             consensus

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/GroupedWeightS3ObjectFlow.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/GroupedWeightS3ObjectFlow.scala
@@ -83,6 +83,15 @@ case class GroupedWeightS3ObjectFlow(
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       private var state = State.initial()
 
+      // True between the moment we call finish() on the current object and the moment finishCallback
+      // advances `state` to the next object. Without this guard, `onUpstreamFinish` can arrive in that
+      // window (upstream completion is delivered eagerly, regardless of demand) and trigger a second
+      // finish() on the very same object. The object's content would be correct, but its
+      // `splice-checksum` metadata would be overwritten with the checksum of an empty input,
+      // because MessageDigest.digest() resets the digest.
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
+      private var finishingObject = false
+
       private def objectDone = state.currentObjectSize >= maxObjectSize || isClosed(in)
 
       private val uploadCallback = getAsyncCallback[Unit] { _ =>
@@ -111,6 +120,7 @@ case class GroupedWeightS3ObjectFlow(
 
       private val finishCallback = getAsyncCallback[Unit] { _ =>
         logger.debug(s"Finished uploading and finalizing object ${state.currentObject.key}")
+        finishingObject = false
         push(out, state.currentObject.key)
         if (isClosed(in)) {
           logger.trace("Upstream completed, completing too.")
@@ -156,13 +166,24 @@ case class GroupedWeightS3ObjectFlow(
       }
 
       private def finishCurrentObject(): Unit =
-        state.currentObject.finish().onComplete {
-          case Success(_) => finishCallback.invoke(())
-          case Failure(ex) => failCallback.invoke(ex)
+        if (finishingObject) {
+          logger.debug(
+            s"Object ${state.currentObject.key} is already being finished, not finishing it again"
+          )
+        } else {
+          finishingObject = true
+          state.currentObject.finish().onComplete {
+            case Success(_) => finishCallback.invoke(())
+            case Failure(ex) => failCallback.invoke(ex)
+          }
         }
 
       override def onUpstreamFinish(): Unit = {
-        if (state.numPendingPartUploads == 0) {
+        if (finishingObject) {
+          logger.debug(
+            s"Upstream finished while object ${state.currentObject.key} is being finished, waiting for it to complete"
+          )
+        } else if (state.numPendingPartUploads == 0) {
           if (state.currentObjectSize > 0) {
             logger.debug(
               s"Upstream finished, finishing current object ${state.currentObject.key} with size ${state.currentObjectSize}"

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/GroupedWeightS3ObjectFlow.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/GroupedWeightS3ObjectFlow.scala
@@ -83,12 +83,11 @@ case class GroupedWeightS3ObjectFlow(
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       private var state = State.initial()
 
-      // True between the moment we call finish() on the current object and the moment finishCallback
-      // advances `state` to the next object. Without this guard, `onUpstreamFinish` can arrive in that
-      // window (upstream completion is delivered eagerly, regardless of demand) and trigger a second
-      // finish() on the very same object. The object's content would be correct, but its
-      // `splice-checksum` metadata would be overwritten with the checksum of an empty input,
-      // because MessageDigest.digest() resets the digest.
+      // Guards against finishing the same object twice, which can otherwise happen because finish()
+      // is triggered both from uploadCallback and from onUpstreamFinish.
+      // At the time of writing, a duplicate finish is actually harmless, as it calls
+      // AppendWriteObject.finish() which is idempotent. We guard against it anyway, to protect against
+      // future changes that would make finishing an object non-idempotent.
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       private var finishingObject = false
 

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3UploadTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3UploadTest.scala
@@ -42,10 +42,10 @@ class S3UploadTest extends StoreTestBase with HasS3Mock {
     }
 
     "not corrupt the checksum if finish() is called more than once" in {
-      val content = "idempotency test"
+      val expectedContent = "idempotency test"
       val bucketConnection = new S3BucketConnectionForUnitTests(s3ConfigMock(), loggerFactory)
       val o = bucketConnection.newAppendWriteObject("finish-twice")
-      val part = ByteBuffer.wrap(content.getBytes("UTF-8"))
+      val part = ByteBuffer.wrap(expectedContent.getBytes("UTF-8"))
 
       o.prepareUploadNext(part)
       for {
@@ -58,7 +58,7 @@ class S3UploadTest extends StoreTestBase with HasS3Mock {
       } yield {
         checksumAfterFirstFinish.map(_.checksum) should not contain emptyDigest
         checksumAfterSecondFinish shouldBe checksumAfterFirstFinish
-        new String(content.toArray, "UTF-8") shouldBe content
+        new String(content.toArray, "UTF-8") shouldBe expectedContent
       }
     }
   }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3UploadTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3UploadTest.scala
@@ -6,14 +6,20 @@ package org.lfdecentralizedtrust.splice.scan.store.bulk
 import org.apache.pekko.stream.scaladsl.Keep
 import org.apache.pekko.stream.testkit.scaladsl.{TestSink, TestSource}
 import org.apache.pekko.util.ByteString
+import org.lfdecentralizedtrust.splice.config.S3Config
 import org.lfdecentralizedtrust.splice.store.{HasS3Mock, S3BucketConnection, StoreTestBase}
+import com.digitalasset.canton.logging.NamedLoggerFactory
 
 import scala.util.Random
 import scala.concurrent.duration.*
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.jdk.CollectionConverters.*
 import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicInteger
 
 class S3UploadTest extends StoreTestBase with HasS3Mock {
+
+  private val emptyDigest = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
 
   "S3 multipart uploads" should {
     "work" in {
@@ -32,6 +38,27 @@ class S3UploadTest extends StoreTestBase with HasS3Mock {
         content <- bucketConnection.readFullObject("test")
       } yield {
         new String(content.toArray, "UTF-8") shouldBe "helloworld"
+      }
+    }
+
+    "not corrupt the checksum if finish() is called more than once" in {
+      val content = "idempotency test"
+      val bucketConnection = new S3BucketConnectionForUnitTests(s3ConfigMock(), loggerFactory)
+      val o = bucketConnection.newAppendWriteObject("finish-twice")
+      val part = ByteBuffer.wrap(content.getBytes("UTF-8"))
+
+      o.prepareUploadNext(part)
+      for {
+        _ <- o.upload(1, part)
+        _ <- o.finish()
+        checksumAfterFirstFinish <- bucketConnection.getChecksums(Seq("finish-twice"))
+        _ <- o.finish()
+        checksumAfterSecondFinish <- bucketConnection.getChecksums(Seq("finish-twice"))
+        content <- bucketConnection.readFullObject("finish-twice")
+      } yield {
+        checksumAfterFirstFinish.map(_.checksum) should not contain emptyDigest
+        checksumAfterSecondFinish shouldBe checksumAfterFirstFinish
+        new String(content.toArray, "UTF-8") shouldBe content
       }
     }
   }
@@ -116,6 +143,77 @@ class S3UploadTest extends StoreTestBase with HasS3Mock {
       sub.expectError()
       succeed
     }
+
+    "not finish an object twice when upstream completes while the object is being finished" in {
+      // Regression test for the race that produced correct object content with a wrong checksum:
+      // an object that is done by size starts being finished from uploadCallback; `state` is only
+      // advanced later, in the async finishCallback. Upstream completion is delivered eagerly
+      // (independently of demand), so onUpstreamFinish could land in that window and call finish()
+      // a second time on the very same object.
+      val bucketConnection = new GatedFinishS3Connection(s3ConfigMock(), loggerFactory)
+
+      val (pub, sub) = TestSource
+        .probe[ByteString]
+        .via(
+          GroupedWeightS3ObjectFlow(
+            bucketConnection,
+            getObjectKey = i => s"race_$i",
+            maxObjectSize = 10L,
+            maxParallelPartUploads = 2,
+            loggerFactory,
+          )
+        )
+        .toMat(TestSink.probe[String])(Keep.both)
+        .run()
+
+      sub.request(5)
+      // Exactly hits maxObjectSize, so the object is done by size and finish() is started
+      // from uploadCallback as soon as the single part upload completes.
+      pub.sendNext(ByteString(Random.nextBytes(10)))
+
+      // Wait until the flow is blocked inside finish()
+      eventually() {
+        bucketConnection.finishCount.get() shouldBe 1
+      }
+
+      // Complete upstream while finish() is still in flight
+      pub.sendComplete()
+      always(durationOfSuccess = 2.seconds) {
+        bucketConnection.finishCount.get() shouldBe 1
+      }
+
+      bucketConnection.releaseFinish()
+      sub.expectNext(20.seconds) shouldBe "race_0"
+      sub.expectComplete()
+
+      val checksums = bucketConnection.getChecksums(Seq("race_0")).futureValue
+      checksums should have size 1
+      checksums.map(_.checksum) should not contain emptyDigest
+      succeed
+    }
+  }
+
+  /** An S3 connection whose `finish()` blocks until [[releaseFinish]] is called, and which counts
+    * how many times `finish()` was invoked.
+    */
+  private class GatedFinishS3Connection(
+      s3Config: S3Config,
+      loggerFactory: NamedLoggerFactory,
+  ) extends S3BucketConnectionForUnitTests(s3Config, loggerFactory) {
+    val finishCount = new AtomicInteger(0)
+    private val gate = Promise[Unit]()
+
+    def releaseFinish(): Unit = { val _ = gate.trySuccess(()) }
+
+    override def newAppendWriteObject(
+        key: String
+    )(implicit ec: ExecutionContext): AppendWriteObject =
+      new AppendWriteObjectForUnitTests(key) {
+        override def finish(): Future[Unit] = {
+          val _ = finishCount.incrementAndGet()
+          gate.future.flatMap(_ => super.finish())
+        }
+      }
   }
 
   "S3BucketConnection" should {


### PR DESCRIPTION


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
