### PR TITLE
Widen proposal-details IDs/URLs and show requester party ID (#6915)

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/governance-page.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/governance-page.test.tsx
@@ -220,6 +220,11 @@ describe('Governance Page', () => {
       'proposal-details-requester-party-id'
     );
     expect(requesterInput).toBeInTheDocument();
+    // Resolve SV display name (e.g. Digital-Asset-2) to full party ID for display + copy.
+    expect(
+      within(votingInformationSection).getByTestId('proposal-details-requester-party-id-value')
+        .textContent
+    ).toMatch(/::/);
 
     const votingClosesIso = within(votingInformationSection).getByTestId(
       'proposal-details-voting-closes-value'

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -191,9 +191,12 @@ describe('Proposal Details Content', () => {
     );
     expect(memberInput).toBeInTheDocument();
     expect(memberInput.textContent).toBe('sv2');
+    expect(within(offboardSection).getByTestId('proposal-details-member-party-id')).toHaveStyle({
+      width: '100%',
+    });
     expect(
       within(offboardSection).getByTestId('proposal-details-member-party-id-scroll')
-    ).toHaveStyle({ overflowX: 'auto', maxWidth: '270px' });
+    ).toHaveStyle({ overflowX: 'auto', width: '100%' });
 
     expect(screen.getByTestId('proposal-details-summary-label').textContent).toBe(
       PROPOSAL_SUMMARY_TITLE
@@ -205,18 +208,20 @@ describe('Proposal Details Content', () => {
 
     const url = screen.getByTestId('proposal-details-url');
     expect(url.textContent).toMatch(/https:\/\/example.com/);
+    expect(url).toHaveStyle({ width: '100%' });
     expect(screen.getByTestId('proposal-details-url-scroll')).toHaveStyle({
       overflowX: 'auto',
-      maxWidth: '346px',
+      width: '100%',
     });
 
     // Figma Offboard details order: Action → Member → Proposal Summary → Supporting URL → Contract ID
     expect(screen.getByTestId('proposal-details-contractid-label').textContent).toBe(
       VOTE_PROPOSAL_CONTRACT_ID_LABEL
     );
+    expect(screen.getByTestId('proposal-details-contractid-id')).toHaveStyle({ width: '100%' });
     expect(screen.getByTestId('proposal-details-contractid-id-scroll')).toHaveStyle({
       overflowX: 'auto',
-      maxWidth: '270px',
+      width: '100%',
     });
     const contractIdLabel = screen.getByTestId('proposal-details-contractid-label');
     expect(
@@ -239,8 +244,11 @@ describe('Proposal Details Content', () => {
     expect(requesterInput).toBeInTheDocument();
     expect(requesterInput.textContent).toBe('sv1');
     expect(
+      within(votingInformationSection).getByTestId('proposal-details-requester-party-id')
+    ).toHaveStyle({ width: '100%' });
+    expect(
       within(votingInformationSection).getByTestId('proposal-details-requester-party-id-scroll')
-    ).toHaveStyle({ overflowX: 'auto', maxWidth: '270px' });
+    ).toHaveStyle({ overflowX: 'auto', width: '100%' });
 
     expect(screen.getByTestId('proposal-details-created-at-label').textContent).toBe(
       PROPOSAL_CREATED_LABEL

--- a/apps/sv/frontend/src/components/beta/CopyableUrl.tsx
+++ b/apps/sv/frontend/src/components/beta/CopyableUrl.tsx
@@ -18,32 +18,45 @@ import {
 interface CopyableUrlProps {
   url: string;
   size: CopyableIdentifierSize;
+  /**
+   * Fill the parent width (proposal-details section). Default keeps the compact
+   * Supporting URL slot used elsewhere (~346px).
+   */
+  fullWidth?: boolean;
   'data-testid': string;
 }
 
-const CopyableUrl: React.FC<CopyableUrlProps> = ({ url, size, 'data-testid': testId }) => {
+const CopyableUrl: React.FC<CopyableUrlProps> = ({
+  url,
+  size,
+  fullWidth = false,
+  'data-testid': testId,
+}) => {
   const sanitizedUrl = sanitizeUrl(url);
   const fontSize = size === 'small' ? '14px' : '16px';
   const scrollRef = useRef<HTMLDivElement>(null);
-  const metrics = useHorizontalScrollMetrics(scrollRef, [sanitizedUrl]);
+  const metrics = useHorizontalScrollMetrics(scrollRef, [sanitizedUrl, fullWidth]);
+  const textMaxWidth = fullWidth ? '100%' : URL_COMPACT_MAX_WIDTH_PX;
 
   return (
     <Box
       className="identifier-scroll-area"
       sx={{
-        display: 'inline-flex',
+        display: fullWidth ? 'flex' : 'inline-flex',
         alignItems: 'center',
         color: 'text.light',
         maxWidth: '100%',
         minWidth: 0,
+        width: fullWidth ? '100%' : undefined,
+        overflow: fullWidth ? 'hidden' : undefined,
       }}
       data-testid={testId}
     >
       <Box
         sx={{
-          flex: '0 1 auto',
+          flex: fullWidth ? '1 1 0%' : '0 1 auto',
           minWidth: 0,
-          maxWidth: URL_COMPACT_MAX_WIDTH_PX,
+          maxWidth: textMaxWidth,
           display: 'flex',
           flexDirection: 'column',
           position: 'relative',
@@ -53,8 +66,9 @@ const CopyableUrl: React.FC<CopyableUrlProps> = ({ url, size, 'data-testid': tes
           ref={scrollRef}
           sx={{
             ...scrollContainerSx,
-            maxWidth: URL_COMPACT_MAX_WIDTH_PX,
+            maxWidth: textMaxWidth,
             width: '100%',
+            ...(fullWidth ? { minWidth: 0 } : {}),
           }}
           data-testid={`${testId}-scroll`}
         >

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -44,7 +44,6 @@ import { useDsoInfos } from '../../contexts/SvContext';
 import { DetailItem } from './proposal-details/DetailItem';
 import { CreateUnallocatedUnclaimedActivityRecordSection } from './proposal-details/CreateUnallocatedUnclaimedActivityRecordSection';
 import { CopyableIdentifier, CopyableUrl, MemberIdentifier, VoteStats } from '../beta';
-import { IDENTIFIER_COMPACT_MAX_WIDTH_PX } from '../beta/identifierStyles';
 import { useQuery } from '@tanstack/react-query';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
 import {
@@ -337,6 +336,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
               <CopyableUrl
                 url={proposalDetails.url}
                 size="large"
+                fullWidth
                 data-testid="proposal-details-url"
               />
             }
@@ -349,7 +349,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
               <CopyableIdentifier
                 value={contractId}
                 size="large"
-                maxWidth={IDENTIFIER_COMPACT_MAX_WIDTH_PX}
+                fullWidth
                 data-testid="proposal-details-contractid-id"
               />
             }
@@ -365,7 +365,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
                 partyId={votingInformation.requester}
                 isYou={false}
                 size="large"
-                maxWidth={IDENTIFIER_COMPACT_MAX_WIDTH_PX}
+                fullWidth
                 data-testid="proposal-details-requester-party-id"
               />
             }
@@ -726,7 +726,7 @@ const OffboardMemberSection = ({ memberPartyId }: OffboardMemberSectionProps) =>
             partyId={memberPartyId}
             isYou={false}
             size="large"
-            maxWidth={IDENTIFIER_COMPACT_MAX_WIDTH_PX}
+            fullWidth
             data-testid="proposal-details-member-party-id"
           />
         }
@@ -914,7 +914,7 @@ const UpdateSvRewardWeightSection = ({
               partyId={svToUpdate}
               isYou={false}
               size="large"
-              maxWidth={IDENTIFIER_COMPACT_MAX_WIDTH_PX}
+              fullWidth
               data-testid="proposal-details-member-party-id"
             />
           }

--- a/apps/sv/frontend/src/routes/voteRequestDetails.tsx
+++ b/apps/sv/frontend/src/routes/voteRequestDetails.tsx
@@ -19,6 +19,7 @@ import {
   buildProposal,
   formatBasisPoints,
   getActionValue,
+  getRequesterPartyId,
   getVoteResultStatus,
 } from '../utils/governance';
 import { useDsoInfos } from '../contexts/SvContext';
@@ -73,7 +74,8 @@ export const VoteRequestDetails: React.FC = () => {
   }
 
   const svPartyId = dsoInfosQuery.data?.svPartyId || '';
-  const allSvs = dsoInfosQuery.data?.dsoRules.payload.svs.entriesArray().map(e => e[0]) || [];
+  const svs = dsoInfosQuery.data?.dsoRules.payload.svs;
+  const allSvs = svs?.entriesArray().map(e => e[0]) || [];
   const amuletOrDsoAction = getActionValue(request.action);
 
   // check that amuletOrDsoAction is a supported action
@@ -123,9 +125,10 @@ export const VoteRequestDetails: React.FC = () => {
       ? dayjs(voteResult.outcome.value.effectiveAt).format(dateTimeFormatISO)
       : dayjs(voteResult?.completedAt).format(dateTimeFormatISO);
 
+  const requesterPartyId = getRequesterPartyId(request.requester, svs);
   const votingInformation: ProposalVotingInformation = {
-    requester: request.requester,
-    requesterIsYou: request.requester === svPartyId,
+    requester: requesterPartyId,
+    requesterIsYou: requesterPartyId === svPartyId,
     votingThresholdDeadline: dayjs(request.voteBefore).format(dateTimeFormatISO),
     voteTakesEffect,
     status: hasVoteRequest ? 'In Progress' : getVoteResultStatus(voteResult?.outcome),


### PR DESCRIPTION
## Summary
- On proposal details, Member, Supporting URL, Contract ID, and Requester now fill the full section width instead of compact `maxWidth` caps.
- Requester displays and copies the full party ID (not the SV display name).
- Updates unit tests for the new width and requester party-ID behavior.

Fixes #6915

## Test plan
- [ ] `cd apps/sv/frontend && npm test -- --run src/__tests__/governance/proposal-details-content.test.tsx src/__tests__/governance/governance-page.test.tsx`
- [ ] Open a proposal details page and confirm Member / Supporting URL / Contract ID / Requester span the section width
- [ ] Confirm Requester shows the full party ID and copy uses that ID
- [ ] Add a screenshot of proposal details (required for frontend PRs)

## Screenshots 

<img width="836" height="769" alt="Screenshot 2026-08-25 at 14 31 08" src="https://github.com/user-attachments/assets/c21592b8-8a53-41ca-8bbd-79b5b43e9577" />




### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
