### PR TITLE
bulk storage: Add debug capabilities

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -254,24 +254,27 @@ class ScanApp(
       )
       kvStore <- ScanKeyValueStore(dsoParty, participantId, storage, loggerFactory)
       kvProvider = new ScanKeyValueProvider(kvStore, loggerFactory)
-      bulkStorage = (config.bulkStorage.staging, config.bulkStorage.committed).tupled.map(_ =>
-        BulkStorage(
-          scanStorageConfigV1,
-          config.bulkStorage,
-          acsSnapshotStore,
-          updateHistory,
-          currentMigrationId = domainMigrationId,
-          kvProvider,
-          retryProvider.metricsFactory,
-          config.automation,
-          backoffClock = new WallClock(retryProvider.timeouts, loggerFactory),
-          store,
-          svName,
-          ledgerClient,
-          amuletAppParameters.upgradesConfig,
-          retryProvider,
-          loggerFactory,
-        )
+      bulkStorage <- (config.bulkStorage.staging, config.bulkStorage.committed).tupled.traverse(
+        _ =>
+          appInitStep("Initialize bulk storage") {
+            BulkStorage(
+              scanStorageConfigV1,
+              config.bulkStorage,
+              acsSnapshotStore,
+              updateHistory,
+              currentMigrationId = domainMigrationId,
+              kvProvider,
+              retryProvider.metricsFactory,
+              config.automation,
+              backoffClock = new WallClock(retryProvider.timeouts, loggerFactory),
+              store,
+              svName,
+              ledgerClient,
+              amuletAppParameters.upgradesConfig,
+              retryProvider,
+              loggerFactory,
+            )
+          }
       )
       appActivityRecordStore = new DbAppActivityRecordStore(
         storage,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -254,27 +254,26 @@ class ScanApp(
       )
       kvStore <- ScanKeyValueStore(dsoParty, participantId, storage, loggerFactory)
       kvProvider = new ScanKeyValueProvider(kvStore, loggerFactory)
-      bulkStorage <- (config.bulkStorage.staging, config.bulkStorage.committed).tupled.traverse(
-        _ =>
-          appInitStep("Initialize bulk storage") {
-            BulkStorage(
-              scanStorageConfigV1,
-              config.bulkStorage,
-              acsSnapshotStore,
-              updateHistory,
-              currentMigrationId = domainMigrationId,
-              kvProvider,
-              retryProvider.metricsFactory,
-              config.automation,
-              backoffClock = new WallClock(retryProvider.timeouts, loggerFactory),
-              store,
-              svName,
-              ledgerClient,
-              amuletAppParameters.upgradesConfig,
-              retryProvider,
-              loggerFactory,
-            )
-          }
+      bulkStorage <- (config.bulkStorage.staging, config.bulkStorage.committed).tupled.traverse(_ =>
+        appInitStep("Initialize bulk storage") {
+          BulkStorage(
+            scanStorageConfigV1,
+            config.bulkStorage,
+            acsSnapshotStore,
+            updateHistory,
+            currentMigrationId = domainMigrationId,
+            kvProvider,
+            retryProvider.metricsFactory,
+            config.automation,
+            backoffClock = new WallClock(retryProvider.timeouts, loggerFactory),
+            store,
+            svName,
+            ledgerClient,
+            amuletAppParameters.upgradesConfig,
+            retryProvider,
+            loggerFactory,
+          )
+        }
       )
       appActivityRecordStore = new DbAppActivityRecordStore(
         storage,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -57,7 +57,7 @@ final case class BulkStorageConfig(
       *   this before starting to prune data.
       */
     debugForceStartFromGenesis: Boolean = false,
-    /** A list of objects that this instance should not save to the committed bucket, and instead only
+    /** A list of S3 object keys that this instance should not save to the committed bucket, and instead only
       * delete from staging. To be used only in extreme cases where we decide to accept a BFT disagreement,
       * and have the (minority of) disagreeing instances simply skip the broken objects.
       * Should typically be used in test environments only.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -49,18 +49,20 @@ final case class BulkStorageConfig(
     committed: Option[S3Config] = None,
     bftCheckEnabled: Boolean = true,
     /** When enabled, the app will reset all progress markers thus force recomputing data from genesis.
-     * Note that this does not delete any existing data, you usually would want to do that before setting
-     * this flag. Also, after restarting the app once with this flag enabled, you'd want to disable it back
-     * to avoid having the markers reset on every restart.
-     * TODO(scan-pruning): this makes sense for initial stages of testing&deploying bulk storage, in case of
-     *   encountered issues, but will not make sense when we start pruning the data from scan. We should remove
-     *   this before starting to prune data. */
+      * Note that this does not delete any existing data, you usually would want to do that before setting
+      * this flag. Also, after restarting the app once with this flag enabled, you'd want to disable it back
+      * to avoid having the markers reset on every restart.
+      * TODO(scan-pruning): this makes sense for initial stages of testing&deploying bulk storage, in case of
+      *   encountered issues, but will not make sense when we start pruning the data from scan. We should remove
+      *   this before starting to prune data.
+      */
     debugForceStartFromGenesis: Boolean = false,
     /** A list of objects that this instance should not save to the committed bucket, and instead only
-     * delete from staging. To be used only in extreme cases where we decide to accept a BFT disagreement,
-     * and have the (minority of) disagreeing instances simply skip the broken objects.
-     * Should typically be used in test environments only. */
-    debugObjectsToNotCommit: Seq[String] = Seq.empty
+      * delete from staging. To be used only in extreme cases where we decide to accept a BFT disagreement,
+      * and have the (minority of) disagreeing instances simply skip the broken objects.
+      * Should typically be used in test environments only.
+      */
+    debugObjectsToNotCommit: Seq[String] = Seq.empty,
 )
 
 /** @param miningRoundsCacheTimeToLiveOverride Intended only for testing!

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -52,7 +52,7 @@ final case class BulkStorageConfig(
       * Note that this does not delete any existing data, you usually would want to do that before setting
       * this flag. Also, after restarting the app once with this flag enabled, you'd want to disable it back
       * to avoid having the markers reset on every restart.
-      * TODO(scan-pruning): this makes sense for initial stages of testing&deploying bulk storage, in case of
+      * TODO(#6251): this makes sense for initial stages of testing&deploying bulk storage, in case of
       *   encountered issues, but will not make sense when we start pruning the data from scan. We should remove
       *   this before starting to prune data.
       */

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -48,13 +48,13 @@ final case class BulkStorageConfig(
     staging: Option[S3Config] = None,
     committed: Option[S3Config] = None,
     bftCheckEnabled: Boolean = true,
-    /** A debug config that, when enabled, on app start ignores the persisted progress and starts
-     * processing bulk storage from genesis. Note that it does not delete existing data, nor does
-     * it immediately move the progress markers (those will be updated only when new data is written
-     * to each bucket) typically you'd want to do that manually before starting the app in this mode.
-     * After enabling it once and accumulating some data in every bucket (so that all progress markers
-     * are reset), you'd typically want to disable this back, to avoid the next app restart
-     * from resetting again. */
+    /** When enabled, the app will reset all progress markers thus force recomputing data from genesis.
+     * Note that this does not delete any existing data, you usually would want to do that before setting
+     * this flag. Also, after restarting the app once with this flag enabled, you'd want to disable it back
+     * to avoid having the markers reset on every restart.
+     * TODO(scan-pruning): this makes sense for initial stages of testing&deploying bulk storage, in case of
+     *   encountered issues, but will not make sense when we start pruning the data from scan. We should remove
+     *   this before starting to prune data. */
     debugForceStartFromGenesis: Boolean = false,
     /** A list of objects that this instance should not save to the committed bucket, and instead only
      * delete from staging. To be used only in extreme cases where we decide to accept a BFT disagreement,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -48,6 +48,19 @@ final case class BulkStorageConfig(
     staging: Option[S3Config] = None,
     committed: Option[S3Config] = None,
     bftCheckEnabled: Boolean = true,
+    /** A debug config that, when enabled, on app start ignores the persisted progress and starts
+     * processing bulk storage from genesis. Note that it does not delete existing data, nor does
+     * it immediately move the progress markers (those will be updated only when new data is written
+     * to each bucket) typically you'd want to do that manually before starting the app in this mode.
+     * After enabling it once and accumulating some data in every bucket (so that all progress markers
+     * are reset), you'd typically want to disable this back, to avoid the next app restart
+     * from resetting again. */
+    debugForceStartFromGenesis: Boolean = false,
+    /** A list of objects that this instance should not save to the committed bucket, and instead only
+     * delete from staging. To be used only in extreme cases where we decide to accept a BFT disagreement,
+     * and have the (minority of) disagreeing instances simply skip the broken objects.
+     * Should typically be used in test environments only. */
+    debugObjectsToNotCommit: Seq[String] = Seq.empty
 )
 
 /** @param miningRoundsCacheTimeToLiveOverride Intended only for testing!

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorage.scala
@@ -79,6 +79,16 @@ class AcsSnapshotBulkStoragePersistentProgress(
     kvProvider.store.readValueAndLogOnDecodingFailure(firstSnapshotKvStoreKey).value
   }
 
+  def reset(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Unit] = {
+    for {
+      _ <- kvProvider.store.deleteKey(latestSnapshotKvStoreKey)
+      _ <- kvProvider.store.deleteKey(firstSnapshotKvStoreKey)
+    } yield {}
+  }
+
   def persistLatestProcessedSnapshotTimestamp(ts: TimestampWithMigrationId)(implicit
       tc: TraceContext,
       ec: ExecutionContext,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorage.scala
@@ -22,6 +22,7 @@ import org.lfdecentralizedtrust.splice.scan.store.{
 import org.lfdecentralizedtrust.splice.store.{HistoryMetrics, S3BucketConnection, UpdateHistory}
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import com.digitalasset.canton.discard.Implicits.DiscardOps
 import cats.implicits.*
 import org.apache.pekko.stream.scaladsl.Source
 import org.lfdecentralizedtrust.splice.PekkoRetryableService
@@ -196,9 +197,29 @@ class BulkStorage(
     loggerFactory,
   )
 
-  private val services =
+  // Services are only started once initialization has completed.
+  private lazy val services =
     Seq[PekkoRetryableService[?]](acsStaging, acsCommitted, updatesStaging, updatesCommitted)
       .map(_.asPekkoRetryingService(automationConfig, backoffClock, retryProvider))
+
+  private def initialize(): Future[BulkStorage] = {
+    val resetAll =
+      if (appConfig.debugForceStartFromGenesis) {
+        logger.warn(
+          "debugForceStartFromGenesis is set to true, resetting all bulk storage progress and starting from genesis"
+        )
+        for {
+          _ <- acsStagingProgress.reset
+          _ <- acsCommittedProgress.reset
+          _ <- updatesStagingProgress.reset
+          _ <- updatesCommittedProgress.reset
+        } yield ()
+      } else Future.unit
+    resetAll.map { _ =>
+      services.discard
+      this
+    }
+  }
 
   final override def closeAsync(): Seq[AsyncOrSyncCloseable] = {
     LifeCycle.close(scanConnection)(logger)
@@ -237,7 +258,7 @@ object BulkStorage {
       tracer: Tracer,
       httpClient: HttpClient,
       templateJsonDecoder: TemplateJsonDecoder,
-  ): BulkStorage = {
+  ): Future[BulkStorage] = {
     val logger = loggerFactory.getTracedLogger(classOf[BulkStorage])
 
     (appConfig.staging, appConfig.committed).tupled.fold {
@@ -264,7 +285,7 @@ object BulkStorage {
         upgradesConfig,
         retryProvider,
         loggerFactory,
-      )
+      ).initialize()
     }
   }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
@@ -71,7 +71,7 @@ class BulkStorageCommitFromStaging[T](
                 bftChecksums.checksums.filter(_.value.isDefined).map(_.value) == objects.map(oc =>
                   Some(oc.checksum)
                 )
-              if (!consensus)    {
+              if (!consensus) {
                 logger.error(
                   s"Checksums do not match for objects ${objects.map(_.key).mkString(", ")}. My checksums are: ${objects
                       .map(_.checksum)
@@ -80,27 +80,31 @@ class BulkStorageCommitFromStaging[T](
 
                 if (appConfig.debugObjectsToNotCommit.intersect(objects.map(_.key)).nonEmpty) {
                   logger.debug(
-                    s"Some relevant objects are listed in debugObjectsToNotCommit, will ignore them for the consensus check. Ignored objects: ${
-                      appConfig.debugObjectsToNotCommit
+                    s"Some relevant objects are listed in debugObjectsToNotCommit, will ignore them for the consensus check. Ignored objects: ${appConfig.debugObjectsToNotCommit
                         .intersect(objects.map(_.key))
-                        .mkString(", ")
-                    }"
+                        .mkString(", ")}"
                   )
                   val objectsWithConsensusChecksums = objects.zip(consensusChecksums)
                   // Filter out objects for which the key is listed in appConfig.debugObjectsToNotCommit
-                  val unignoredObjectsWithTheirConsensusChecksums = objectsWithConsensusChecksums.filter {
-                    case (obj, _) => !appConfig.debugObjectsToNotCommit.contains(obj.key)
-                  }
-                  val unignoredObjectsWithMyChecksums = objects.filter(obj => !appConfig.debugObjectsToNotCommit.contains(obj.key))
+                  val unignoredObjectsWithTheirConsensusChecksums =
+                    objectsWithConsensusChecksums.filter { case (obj, _) =>
+                      !appConfig.debugObjectsToNotCommit.contains(obj.key)
+                    }
+                  val unignoredObjectsWithMyChecksums =
+                    objects.filter(obj => !appConfig.debugObjectsToNotCommit.contains(obj.key))
                   // recheck consensus, but now only on the unignored objects. The comparison should be similar to val consensus above
                   val unignoredConsensus =
-                    unignoredObjectsWithTheirConsensusChecksums.filter(_._2.value.isDefined).map(_._2.value) == unignoredObjectsWithMyChecksums.map(oc =>
+                    unignoredObjectsWithTheirConsensusChecksums
+                      .filter(_._2.value.isDefined)
+                      .map(_._2.value) == unignoredObjectsWithMyChecksums.map(oc =>
                       Some(oc.checksum)
                     )
 
                   if (!unignoredConsensus) {
                     logger.error(
-                      s"Checksums still do not match for unignored objects ${unignoredObjectsWithMyChecksums.map(_.key).mkString(", ")}. Expected: ${unignoredObjectsWithMyChecksums
+                      s"Checksums still do not match for unignored objects ${unignoredObjectsWithMyChecksums
+                          .map(_.key)
+                          .mkString(", ")}. Expected: ${unignoredObjectsWithMyChecksums
                           .map(_.checksum)
                           .mkString(", ")}, got: ${unignoredObjectsWithTheirConsensusChecksums.map(_._2.value).mkString(", ")}"
                     )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStaging.scala
@@ -57,18 +57,72 @@ class BulkStorageCommitFromStaging[T](
             logger.debug(
               s"Consensus achieved on ${consensusChecksums.length} out of ${objects.length} objects"
             )
-            val consensus =
-              bftChecksums.checksums.filter(_.value.isDefined).map(_.value) == objects.map(oc =>
-                Some(oc.checksum)
+
+            if (consensusChecksums.length < objects.length) {
+              logger.debug(
+                s"Not all objects are known to the BFT peers yet. Will retry after delay."
               )
-            if (consensusChecksums.length == objects.length && !consensus) {
-              logger.error(
-                s"All objects are known to the BFT peers, but the checksums do not match. This indicates an error in the actual data generated for bulk storage. Expected: ${objects
-                    .map(_.checksum)
-                    .mkString(", ")}, got: ${consensusChecksums.mkString(", ")}"
+              false
+            } else {
+              logger.debug(
+                s"All objects are known to the BFT peers. Checking if checksums match."
               )
+              val consensus =
+                bftChecksums.checksums.filter(_.value.isDefined).map(_.value) == objects.map(oc =>
+                  Some(oc.checksum)
+                )
+              if (!consensus)    {
+                logger.error(
+                  s"Checksums do not match for objects ${objects.map(_.key).mkString(", ")}. Expected: ${objects
+                      .map(_.checksum)
+                      .mkString(", ")}, got: ${consensusChecksums.mkString(", ")}"
+                )
+
+                if (appConfig.debugObjectsToNotCommit.intersect(objects.map(_.key)).nonEmpty) {
+                  logger.debug(
+                    s"Some relevant objects are listed in debugObjectsToNotCommit, will ignore them for the consensus check. Ignored objects: ${
+                      appConfig.debugObjectsToNotCommit
+                        .intersect(objects.map(_.key))
+                        .mkString(", ")
+                    }"
+                  )
+                  val objectsWithConsensusChecksums = objects.zip(consensusChecksums)
+                  // Filter out objects for which the key is listed in appConfig.debugObjectsToNotCommit
+                  val unignoredObjectsWithTheirConsensusChecksums = objectsWithConsensusChecksums.filter {
+                    case (obj, _) => !appConfig.debugObjectsToNotCommit.contains(obj.key)
+                  }
+                  val unignoredObjectsWithMyChecksums = objects.filter(obj => !appConfig.debugObjectsToNotCommit.contains(obj.key))
+                  // recheck consensus, but now only on the unignored objects. The comparison should be similar to val consensus above
+                  val unignoredConsensus =
+                    unignoredObjectsWithTheirConsensusChecksums.filter(_._2.value.isDefined).map(_._2.value) == unignoredObjectsWithMyChecksums.map(oc =>
+                      Some(oc.checksum)
+                    )
+
+                  if (!unignoredConsensus) {
+                    logger.error(
+                      s"Checksums still do not match for unignored objects ${unignoredObjectsWithMyChecksums.map(_.key).mkString(", ")}. Expected: ${unignoredObjectsWithMyChecksums
+                          .map(_.checksum)
+                          .mkString(", ")}, got: ${unignoredObjectsWithTheirConsensusChecksums.map(_._2.value).mkString(", ")}"
+                    )
+                  } else {
+                    logger.debug(
+                      s"After ignoring objects from the config, Checksums match ${unignoredObjectsWithMyChecksums.map(_.key).mkString(", ")}. Proceeding with commit."
+                    )
+                  }
+                  unignoredConsensus
+                } else {
+                  logger.trace(
+                    s"No relevant objects are listed in debugObjectsToNotCommit, will not ignore any objects for the consensus check."
+                  )
+                  consensus
+                }
+              } else {
+                logger.trace(
+                  s"Checksums match for all objects ${objects.map(_.key).mkString(", ")}. Proceeding with commit."
+                )
+                true
+              }
             }
-            consensus
           case None =>
             false
         }
@@ -78,7 +132,6 @@ class BulkStorageCommitFromStaging[T](
       Future.successful(true)
     }
   }
-  // TODO(#5884): implement the BFT check
 
   private def waitForBftAgreement: Flow[
     (T, Seq[ObjectKeyAndChecksum]),
@@ -120,8 +173,15 @@ class BulkStorageCommitFromStaging[T](
         )
         Future.unit
       case false =>
-        logger.debug(s"Copying object ${obj.key} from staging to committed storage")
-        committedS3Connection.copyObject(stagingS3Connection.bucketName, obj.key)
+        if (appConfig.debugObjectsToNotCommit.contains(obj.key)) {
+          logger.debug(
+            s"Object ${obj.key} is listed in debugObjectsToNotCommit, skipping copy to committed storage"
+          )
+          Future.unit
+        } else {
+          logger.debug(s"Copying object ${obj.key} from staging to committed storage")
+          committedS3Connection.copyObject(stagingS3Connection.bucketName, obj.key)
+        }
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorage.scala
@@ -67,6 +67,10 @@ class UpdateHistoryBulkStoragePersistentProgress(
         )
       })
   }
+
+  def reset(implicit tc: TraceContext): Future[Unit] = {
+    kvProvider.store.deleteKey(kvStoreKey)
+  }
 }
 
 /** An abstract class for pipelines that process update history for bulk storage.

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStagingTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStagingTest.scala
@@ -188,7 +188,7 @@ class BulkStorageCommitFromStagingTest
         logEntries =>
           forAtLeast(1, logEntries)(
             _.message should include(
-              "All objects are known to the BFT peers, but the checksums do not match"
+              "Checksums do not match for objects"
             )
           ),
       )

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStagingTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageCommitFromStagingTest.scala
@@ -194,6 +194,51 @@ class BulkStorageCommitFromStagingTest
       )
     }
 
+    "ignore digest mismatches for objects listed in debugObjectsToNotCommit and not copy them to the committed bucket" in {
+      val (stagingS3Connection, committedS3Connection, objsWithDigests) = setupTest
+
+      val ignoredObject = objsWithDigests(1)
+
+      val mockScanConnections = new MockScanConnections(objsWithDigests)
+      // all peers disagree with us on the digest of the ignored object only
+      Seq.range(0, 7).foreach(i => mockScanConnections.scanDisagreesOnDigest(i, 1))
+
+      val flow = newCopyFlow(
+        stagingS3Connection,
+        committedS3Connection,
+        objsWithDigests,
+        mockScanConnections,
+        appConfig.copy(debugObjectsToNotCommit = Seq(ignoredObject.key)),
+      )
+
+      loggerFactory.assertLogsSeq(SuppressionRule.LevelAndAbove(Level.ERROR))(
+        {
+          triggerCopyFlowAndAssertCompletion(flow)
+        },
+        logEntries =>
+          forAll(logEntries)(
+            _.message should include("Checksums do not match for objects")
+          ),
+      )
+
+      val expectedCommittedObjects = objsWithDigests.filterNot(_.key == ignoredObject.key)
+
+      clue("All objects have been deleted from staging") {
+        stagingS3Connection.listObjects.futureValue.contents().asScala shouldBe empty
+      }
+      clue("Only the non-ignored objects have been copied to the committed bucket") {
+        committedS3Connection.listObjects.futureValue
+          .contents()
+          .asScala
+          .map(_.key()) should contain theSameElementsAs expectedCommittedObjects.map(_.key)
+      }
+      clue("Checksums of objects in committed S3 bucket match the expected digests") {
+        committedS3Connection
+          .getChecksums(expectedCommittedObjects.map(_.key))
+          .futureValue should contain theSameElementsAs expectedCommittedObjects
+      }
+    }
+
     class MockScanConnections(
         objsWithDigests: Seq[ObjectKeyAndChecksum]
     ) {
@@ -292,12 +337,13 @@ class BulkStorageCommitFromStagingTest
         committedS3Connection: S3BucketConnectionForUnitTests,
         objsWithDigests: Seq[ObjectKeyAndChecksum],
         mockScanConnections: MockScanConnections,
+        config: BulkStorageConfig = appConfig,
     ) = {
       new BulkStorageCommitFromStaging[String](
         stagingS3Connection,
         committedS3Connection,
         _ => Future.successful(objsWithDigests),
-        appConfig,
+        config,
         mockScanConnections.peerBftConnection,
         loggerFactory,
       ).getFlow


### PR DESCRIPTION
- Got tired of manually deleting DBs in CILR to restart from genesis after every BFT fix, so making it easier
- We know of some e.g. broken (in terms of BFT) ACS snapshots in CILR, so adding support for skipping those. Hopefully will not be useful for prod, but who knows...

Fixes #6960 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
