### PR TITLE
Move standalone mediator ignores where they're picked up

### DIFF
--- a/project/ignore-patterns/canton-standalone-mediator-offboarding.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-mediator-offboarding.ignore.txt
@@ -16,3 +16,5 @@ Failed to send result to sequencer for request.*Unregistered recipients.*unregis
 Member MED::sv4SvOffboarding.* access is disabled
 
 Could not send a time-advancing message
+
+Request failed for server.*Sequencer.* Is the server running?

--- a/project/ignore-patterns/canton-standalone-mediator-offboarding_before_shutdown.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-mediator-offboarding_before_shutdown.ignore.txt
@@ -1,1 +1,0 @@
-Request failed for server.*Sequencer.* Is the server running?

--- a/project/ignore-patterns/canton-standalone-sv4-reonboarding.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-sv4-reonboarding.ignore.txt
@@ -26,3 +26,5 @@ Member MED::sv4SvReonboarding.* access is disabled
 Request failed for server-DefaultSequencer-0.*sv4
 
 SEQUENCER_SUBMISSION_REQUEST_MALFORMED.*MED::sv4SvReonboarding.* is not part of the mediator group
+
+Request failed for server.*Sequencer.* Is the server running?

--- a/project/ignore-patterns/canton-standalone-sv4-reonboarding_before_shutdown.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-sv4-reonboarding_before_shutdown.ignore.txt
@@ -1,1 +1,0 @@
-Request failed for server.*Sequencer.* Is the server running?


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9518

See https://github.com/DACH-NY/cn-test-failures/issues/9518#issuecomment-5427158330 for which files actually get picked up

(We could also add support for them to get picked up, but I don't see much value in it)