### PR TITLE
Remove log ignore for `Waiting for allocation`

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -154,9 +154,6 @@ Sequencing result message timed out.*mediator=
 # TODO (DACH-NY/canton-network-internal#966) - remove if not necessary anymore
 ACS_COMMITMENT_DEGRADATION
 
-# TODO(#2706) Investigate and remove once fixed
-Waiting for allocation of.*on synchronizer splitwell.*timed out
-
 #Todo(DACH-NY/cn-test-failures/7808)
 The synchronizer Synchronizer 'global' failed the following topology transactions
 


### PR DESCRIPTION
That warning doesn't exist in Canton anymore, see https://github.com/DACH-NY/canton/pull/30310/changes#diff-81c61bdb4b62b057717883fd710a5f662ee23d6769f03115d2db110dfda5829aL127

[ci]

Fixes #2706

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
