### PR TITLE
Add endpoint to return latest event record time

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -626,7 +626,7 @@ abstract class ScanAppReference(
     }
   }
 
-  def getLatestEventRecordTime(): Option[String] =
+  def getLatestEventRecordTime(): Option[definitions.EventLatestRecordTimeResponse] =
     consoleEnvironment.run {
       httpCommand(HttpScanAppClient.GetLatestEventRecordTime())
     }

--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -626,6 +626,11 @@ abstract class ScanAppReference(
     }
   }
 
+  def getLatestEventRecordTime(): Option[String] =
+    consoleEnvironment.run {
+      httpCommand(HttpScanAppClient.GetLatestEventRecordTime())
+    }
+
   def getEventById(
       updateId: String,
       damlValueEncoding: Option[definitions.DamlValueEncoding],

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1643,6 +1643,28 @@ paths:
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/400"
         "500":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
+
+  /v0/events/latest-record-time:
+    get:
+      tags: [external, scan]
+      x-jvm-package: scan
+      operationId: "getLatestEventRecordTime"
+      description: |
+        Returns the latest record time for which /v0/events will be able to return events.
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/400"
+        "404":
+          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
+        "500":
+          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
+
   /v0/events/{update_id}:
     get:
       tags: [external, scan]

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1657,7 +1657,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: "#/components/schemas/EventLatestRecordTimeResponse"
         "400":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/400"
         "404":
@@ -4065,6 +4065,16 @@ components:
         app_activity_records:
           $ref: "#/components/schemas/EventHistoryAppActivityRecords"
           nullable: true
+    EventLatestRecordTimeResponse:
+      type: object
+      required:
+        - record_time
+      properties:
+        record_time:
+          description: |
+            The record_time of the latest event.
+          type: string
+          format: date-time
     EventHistoryVerdict:
       type: object
       required:

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -1521,6 +1521,25 @@ object HttpScanAppClient {
     }
   }
 
+  case class GetLatestEventRecordTime()
+      extends InternalBaseCommand[
+        http.GetLatestEventRecordTimeResponse,
+        Option[String],
+      ] {
+    override def submitRequest(
+        client: http.ScanClient,
+        headers: List[HttpHeader],
+    ): EitherT[Future, Either[Throwable, HttpResponse], http.GetLatestEventRecordTimeResponse] =
+      client.getLatestEventRecordTime()
+
+    override def handleOk()(implicit decoder: TemplateJsonDecoder) = {
+      case http.GetLatestEventRecordTimeResponse.OK(response) =>
+        Right(Some(response))
+      case http.GetLatestEventRecordTimeResponse.NotFound(_) =>
+        Right(None)
+    }
+  }
+
   case class GetEventById(
       updateId: String,
       damlValueEncoding: Option[definitions.DamlValueEncoding],

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -1524,7 +1524,7 @@ object HttpScanAppClient {
   case class GetLatestEventRecordTime()
       extends InternalBaseCommand[
         http.GetLatestEventRecordTimeResponse,
-        Option[String],
+        Option[definitions.EventLatestRecordTimeResponse],
       ] {
     override def submitRequest(
         client: http.ScanClient,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -971,7 +971,7 @@ class HttpScanHandler(
       eventStore.getLatestEventRecordTime(updateHistory.domainMigrationId).map {
         case Some(timestamp) =>
           ScanResource.GetLatestEventRecordTimeResponse.OK(
-            ScanHttpEncodings.formatRecordTime(timestamp.toInstant)
+            definitions.EventLatestRecordTimeResponse(Codec.encode(timestamp))
           )
         case None =>
           ScanResource.GetLatestEventRecordTimeResponse.NotFound(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -963,6 +963,24 @@ class HttpScanHandler(
     }
   }
 
+  override def getLatestEventRecordTime(
+      respond: ScanResource.GetLatestEventRecordTimeResponse.type
+  )()(extracted: TraceContext): Future[ScanResource.GetLatestEventRecordTimeResponse] = {
+    implicit val tc = extracted
+    withSpan(s"$workflowId.getLatestEventRecordTime") { _ => _ =>
+      eventStore.getLatestEventRecordTime(updateHistory.domainMigrationId).map {
+        case Some(timestamp) =>
+          ScanResource.GetLatestEventRecordTimeResponse.OK(
+            ScanHttpEncodings.formatRecordTime(timestamp.toInstant)
+          )
+        case None =>
+          ScanResource.GetLatestEventRecordTimeResponse.NotFound(
+            definitions.ErrorResponse("No events found")
+          )
+      }
+    }
+  }
+
   private def toUpdateV2WithHash(update: UpdateHistoryItem): UpdateHistoryItemV2WithHash =
     update match {
       case UpdateHistoryItem.members.UpdateHistoryReassignment(r) =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
@@ -122,6 +122,15 @@ class ScanEventStore(
     }
   }
 
+  def getLatestEventRecordTime(
+      currentMigrationId: Long
+  )(implicit tc: TraceContext): Future[Option[CantonTimestamp]] =
+    resolveCurrentMigrationCap(
+      verdictStore.lastIngestedRecordTime,
+      updateHistory.lastIngestedRecordTime,
+      currentMigrationId,
+    ).map(ts => if (ts == CantonTimestamp.MinValue) None else Some(ts))
+
   def getAppActivityRecords(verdictRowIds: Seq[Long])(implicit
       tc: TraceContext
   ): Future[Map[Long, AppActivityRecordT]] =

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
@@ -908,6 +908,16 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         latest shouldBe None
       }
     }
+
+    "getLatestEventRecordTime returns None when there is only a loose update" in {
+      for {
+        ctx <- newEventStore()
+        _ <- insertUpdate(ctx.updateHistory, CantonTimestamp.now(), "update1")
+        latest <- ctx.eventStore.getLatestEventRecordTime(domainMigrationId)(traceContext)
+      } yield {
+        latest shouldBe None
+      }
+    }
   }
 
   private def newUpdateHistory(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
@@ -867,6 +867,47 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
         allow(mig2, recordTs3) shouldBe false // > after and > cap
       }
     }
+
+    "getLatestEventRecordTime returns the record time of the last event getEvents returns" in {
+      for {
+        ctx <- newEventStore()
+        // update + verdict at ts1
+        ts1 = CantonTimestamp.now()
+        tx1 <- insertUpdate(ctx.updateHistory, ts1, "update1")
+        _ <- insertVerdict(ctx.verdictStore, tx1.getUpdateId, ts1)
+
+        // update + verdict at ts2
+        ts2 = ts1.plusSeconds(1)
+        tx2 <- insertUpdate(ctx.updateHistory, ts2, "update2")
+        _ <- insertVerdict(ctx.verdictStore, tx2.getUpdateId, ts2)
+
+        // loose update at ts3 must be filtered out of getEvents
+        ts3 = ts2.plusSeconds(1)
+        _ <- insertUpdate(ctx.updateHistory, ts3, "update-loose")
+
+        events <- fetchEvents(ctx.eventStore, None, domainMigrationId, pageLimit)
+        latest <- ctx.eventStore.getLatestEventRecordTime(domainMigrationId)(traceContext)
+      } yield {
+        // getEvents caps at ts2, the ts3 loose update is excluded
+        events.nonEmpty shouldBe true
+        val lastReturnedRt = events.last._1
+          .map(_._1.recordTime)
+          .orElse(events.last._2.map(_.update.update.recordTime))
+          .value
+        lastReturnedRt shouldBe ts2
+
+        latest shouldBe Some(lastReturnedRt)
+      }
+    }
+
+    "getLatestEventRecordTime returns None when there are no events" in {
+      for {
+        ctx <- newEventStore()
+        latest <- ctx.eventStore.getLatestEventRecordTime(domainMigrationId)(traceContext)
+      } yield {
+        latest shouldBe None
+      }
+    }
   }
 
   private def newUpdateHistory(

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -6,3 +6,8 @@
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
 release-notes:: Upcoming
+
+    - Scan App
+
+        - Added a new public ``/v0/events/latest-record-time`` endpoint that returns the latest
+          record time for which ``/v0/events`` will be able to return events.


### PR DESCRIPTION
Fixes #3071

Adds a new `/v0/events/latest-record-time` endpoint that finds the latest record time for which `/v0/events` will return events. `ScanEventStore#getLatestEventRecordTime` reuses `resolveCurrentMigrationCap` to ensure it has the same behavior as `getEvents`.

I confirmed that the `/v0/events/latest-record-time` path won't conflict with the parameterized `/v0/events/{update_id}` path -- the Pekko generator for guardrail [sorts routes](https://github.com/guardrail-dev/module-pekko-http/blob/scala-pekko-http-v1.0.0-M1/modules/scala-pekko-http/src/main/scala/dev/guardrail/generators/scala/pekkoHttp/PekkoHttpServerGenerator.scala#L137-L143) so all static paths appear before any parameterized paths.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
