### PR TITLE
Expose base traffic remainder in member traffic status

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MemberTrafficIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MemberTrafficIntegrationTest.scala
@@ -133,6 +133,7 @@ class MemberTrafficIntegrationTest
 
       statusAsPerScan.actual.totalConsumed shouldBe actualStateAsPerSequencer.extraTrafficConsumed.value
       statusAsPerScan.actual.totalLimit shouldBe actualStateAsPerSequencer.extraTrafficPurchased.value
+      statusAsPerScan.actual.baseTrafficRemainder shouldBe actualStateAsPerSequencer.baseTrafficRemainder.value
       statusAsPerScan.target.totalPurchased shouldBe actualTotalPurchasedAsPerDso
     }
   }

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -3683,7 +3683,7 @@ components:
           $ref: "#/components/schemas/TargetMemberTrafficState"
     ActualMemberTrafficState:
       type: object
-      required: [ "total_consumed", "total_limit" ]
+      required: [ "total_consumed", "total_limit", "base_traffic_remainder" ]
       properties:
         total_consumed:
           description: |
@@ -3694,6 +3694,12 @@ components:
           description: |
             Current extra traffic limit set for the member on the given synchronizer.
             An extra traffic top-up is complete once total_limit matches total_purchased.
+          type: integer
+          format: int64
+        base_traffic_remainder:
+          description: |
+            Current replenishing base traffic remaining for the member on the
+            given synchronizer. This traffic is consumed before extra traffic.
           type: integer
           format: int64
     TargetMemberTrafficState:

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2302,11 +2302,16 @@ class HttpScanHandler(
           .flatMap(_.getSequencerTrafficControlState(member))
         actualConsumed = actual.extraTrafficConsumed.value
         actualLimit = actual.extraTrafficLimit.value
+        baseTrafficRemainder = actual.baseTrafficRemainder.value
         targetTotalPurchased <- store.getTotalPurchasedMemberTraffic(member, domain)
       } yield {
         definitions.GetMemberTrafficStatusResponse(
           definitions.MemberTrafficStatus(
-            definitions.ActualMemberTrafficState(actualConsumed, actualLimit),
+            definitions.ActualMemberTrafficState(
+              actualConsumed,
+              actualLimit,
+              baseTrafficRemainder,
+            ),
             definitions.TargetMemberTrafficState(targetTotalPurchased),
           )
         )

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,6 +7,12 @@
 
 release-notes:: Upcoming
 
+    - Scan app
+
+        - The member traffic-status response now includes ``base_traffic_remainder`` in
+          ``traffic_status.actual``, exposing the member's current replenishing base
+          traffic alongside its extra-traffic counters.
+
     - Scan & SV App
 
         - The client IP used for per-client-IP HTTP rate limiting is now extracted based on a


### PR DESCRIPTION
## Summary

- add `base_traffic_remainder` to the Scan member traffic-status OpenAPI response
- populate it from the sequencer traffic state
- cover the field in the existing member traffic integration test
- document the observable API addition in upcoming release notes

## Verification

- Static OpenAPI/handler/test consistency verified locally
- Full Scala test suite not run because `sbt` is unavailable in the local environment

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Included the externally observable API addition in `release_notes_upcoming.rst`.
- [x] No frontend screenshot is required.

#### Merge Guidelines
- [x] Commit message is suitable for squash merge.