### PR TITLE
bump resources for deployment tests

### DIFF
--- a/.github/workflows/build.deployment_test.yml
+++ b/.github/workflows/build.deployment_test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deployment_test:
-    runs-on: self-hosted-k8s-x-small
+    runs-on: self-hosted-k8s-small
 
     container:
       image: us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/splice-test-ci:0.3.12


### PR DESCRIPTION
Saw this job failing a couple of times today with runners disappearing, which is often the symptom of OOMs. Admittedly, I haven't dug very deep to find proof of an OOM, but it definitely seems tight on memory:
<img width="572" height="418" alt="Screenshot from 2026-08-27 17-56-21" src="https://github.com/user-attachments/assets/f009819a-1d79-4622-b012-8686d6a0336f" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
