### PR TITLE
Revert "Backport PR #6902 to release-line-0.7.0 (#6903)"

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -32,10 +32,6 @@ multiValidator:
     - name: MULTI_PARTICIPANT_ADDITIONAL_CONFIG_MAX_CONNECTIONS
       value: canton.participants.participant_INDEX.storage.parameters.max-connections = 33
 sv:
-  cometbft:
-    watchdog:
-      threshold: 2
-      evaluationIntervalSeconds: 900
   synchronizer:
     skipInitialization: true
   scan:

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1631,16 +1631,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-7-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-7-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-1-cometbft-global-domain-7",
     "provider": "",
@@ -1750,16 +1743,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-8-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-8-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-1-cometbft-global-domain-8",
     "provider": "",
@@ -5004,16 +4990,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-7-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-7-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-cometbft-global-domain-7",
     "provider": "",
@@ -5120,16 +5099,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-8-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-8-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-cometbft-global-domain-8",
     "provider": "",
@@ -5240,16 +5212,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-7-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-7-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-da-1-cometbft-global-domain-7",
     "provider": "",
@@ -5360,16 +5325,9 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ],
-        "watchdog": {
-          "enabled": true,
-          "evaluationIntervalSeconds": 900,
-          "mediatorMetricsUrl": "http://global-domain-8-mediator:10013/metrics",
-          "sequencerMetricsUrl": "http://global-domain-8-sequencer:10013/metrics",
-          "threshold": 2
-        }
+        ]
       },
-      "version": "0.7.4"
+      "version": "0.3.20"
     },
     "name": "sv-da-1-cometbft-global-domain-8",
     "provider": "",

--- a/cluster/pulumi/common-sv/src/config.ts
+++ b/cluster/pulumi/common-sv/src/config.ts
@@ -102,18 +102,6 @@ export const SvConfigSchema = z.object({
         .object({
           volumeSize: z.string().optional(),
           protected: z.boolean().optional(),
-          watchdog: z
-            .object({
-              disabled: z.boolean().default(false),
-              threshold: z.number().optional(),
-              evaluationIntervalSeconds: z.number().optional(),
-              pollIntervalSeconds: z.number().optional(),
-              scrapeTimeoutSeconds: z.number().optional(),
-              startupGraceSeconds: z.number().optional(),
-              cooldownSeconds: z.number().optional(),
-            })
-            .strict()
-            .optional(),
         })
         .optional(),
       scan: z

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -5,7 +5,6 @@ import * as _ from 'lodash';
 import {
   activeVersion,
   appsAffinityAndTolerations,
-  ChartValues,
   CLUSTER_BASENAME,
   CLUSTER_HOSTNAME,
   clusterSmallDisk,
@@ -144,7 +143,6 @@ export function installCometBftNode(
     extraLogLevelFlags: svConfiguration.logging?.cometbftExtraLogLevelFlags,
     serviceAccountName: imagePullServiceAccountName,
     resources: svConfiguration.cometbft?.resources,
-    watchdog: watchdogValues(migrationId),
   });
   if (svConfiguration.cometbft?.additionalHelmValues) {
     _.merge(cometbftChartValues, svConfiguration.cometbft.additionalHelmValues);
@@ -155,7 +153,7 @@ export function installCometBftNode(
     `cometbft-global-domain-${migrationId}`,
     `splice-cometbft`,
     cometbftChartValues,
-    { type: 'remote', version: '0.7.4' }, // Hardcoded to a newer version to get the cometbft watchdog.
+    version,
     // support old runbook names, can be removed once the runbooks are all reset and latest release is >= 0.2.x
     {
       ...withAddedDependencies(opts, keysSecret ? [keysSecret] : []),
@@ -167,27 +165,6 @@ export function installCometBftNode(
     appsAffinityAndTolerations
   );
   return { rpcServiceName: `${nodeConfig.identifier}-cometbft-rpc`, release };
-}
-
-const CANTON_METRICS_PORT = 10013;
-
-function watchdogValues(migrationId: DomainMigrationIndex): ChartValues {
-  const watchdog = svsConfig?.cometbft?.watchdog;
-  if (watchdog?.disabled) {
-    return { enabled: false };
-  }
-  const synchronizer = `global-domain-${migrationId}`;
-  return {
-    enabled: true,
-    sequencerMetricsUrl: `http://${synchronizer}-sequencer:${CANTON_METRICS_PORT}/metrics`,
-    mediatorMetricsUrl: `http://${synchronizer}-mediator:${CANTON_METRICS_PORT}/metrics`,
-    threshold: watchdog?.threshold,
-    evaluationIntervalSeconds: watchdog?.evaluationIntervalSeconds,
-    pollIntervalSeconds: watchdog?.pollIntervalSeconds,
-    scrapeTimeoutSeconds: watchdog?.scrapeTimeoutSeconds,
-    startupGraceSeconds: watchdog?.startupGraceSeconds,
-    cooldownSeconds: watchdog?.cooldownSeconds,
-  };
 }
 
 function installCometBftKeysSecret(


### PR DESCRIPTION
[static]

Currently this causes the watchdog to be deployed on the legacy migration on DevNet, which just causes a lot of noise.

Revert this seems like the easiest way to denoise until we're ready to take down those nodes.

See https://daholdings.slack.com/archives/C09LHGB8GUB/p1787881032667409

This reverts commit c023a98d94b06c2cfd203ce9476b272f8816f784.
