### PR TITLE
Helm charts hardening: don't mount k8s API tokens by default

### DIFF
--- a/cluster/helm/cn-docs/values.schema.json
+++ b/cluster/helm/cn-docs/values.schema.json
@@ -29,6 +29,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "networkName": {
       "type": "string"
     },

--- a/cluster/helm/splice-cometbft/values.schema.json
+++ b/cluster/helm/splice-cometbft/values.schema.json
@@ -37,6 +37,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "genesis": {
       "type": "object",
       "required": [

--- a/cluster/helm/splice-domain/values.schema.json
+++ b/cluster/helm/splice-domain/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "serviceAccountName": {
+      "type": "string"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "securityContexts": {
       "type": ["object", "null"],
       "properties": {

--- a/cluster/helm/splice-global-domain/values.schema.json
+++ b/cluster/helm/splice-global-domain/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "serviceAccountName": {
+      "type": "string"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "securityContexts": {
       "type": "object",
       "properties": {

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -65,6 +65,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "nginxImage": {
       "type": "string",
       "description": "The Docker image to use for Nginx. Defaults to 'nginx:latest' if not present."

--- a/cluster/helm/splice-load-tester/values.schema.json
+++ b/cluster/helm/splice-load-tester/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "serviceAccountName": {
+      "type": "string"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "securityContexts": {
       "type": ["object", "null"],
       "properties": {

--- a/cluster/helm/splice-participant/values.schema.json
+++ b/cluster/helm/splice-participant/values.schema.json
@@ -33,6 +33,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "imageRepo": {
       "type": "string"
     },

--- a/cluster/helm/splice-party-allocator/values.schema.json
+++ b/cluster/helm/splice-party-allocator/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "serviceAccountName": {
+      "type": "string"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "securityContexts": {
       "type": ["object", "null"],
       "properties": {

--- a/cluster/helm/splice-postgres/values.schema.json
+++ b/cluster/helm/splice-postgres/values.schema.json
@@ -24,6 +24,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "imageRepo": {
       "type": "string"
     },

--- a/cluster/helm/splice-scan/values.schema.json
+++ b/cluster/helm/splice-scan/values.schema.json
@@ -53,6 +53,9 @@
         "serviceAccountName": {
           "type": "string"
         },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
         "imageRepo": {
           "type": "string"
         },

--- a/cluster/helm/splice-splitwell-app/values.schema.json
+++ b/cluster/helm/splice-splitwell-app/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "serviceAccountName": {
+      "type": "string"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "securityContexts": {
       "type": ["object", "null"],
       "properties": {

--- a/cluster/helm/splice-splitwell-web-ui/values.schema.json
+++ b/cluster/helm/splice-splitwell-web-ui/values.schema.json
@@ -24,6 +24,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "imageName": {
       "type": "string"
     },

--- a/cluster/helm/splice-sv-node/values.schema.json
+++ b/cluster/helm/splice-sv-node/values.schema.json
@@ -30,6 +30,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "imageName": {
       "type": "string"
     },

--- a/cluster/helm/splice-util-lib/templates/_helpers.tpl
+++ b/cluster/helm/splice-util-lib/templates/_helpers.tpl
@@ -191,9 +191,10 @@ spec:
   value: {{ .logAsyncFlush | default true | not | quote }}
 {{- end }}
 {{- define "splice-util-lib.service-account" -}}
-{{- if .serviceAccountName -}}
+automountServiceAccountToken: {{ .automountServiceAccountToken | default false }}
+{{- if .serviceAccountName }}
 serviceAccountName: {{ .serviceAccountName }}
-{{- end -}}
+{{- end }}
 {{- end -}}
 # See https://helm.sh/docs/chart_best_practices/labels/#standard-labels
 {{- define "splice-util-lib.standard-labels" -}}

--- a/cluster/helm/splice-validator/values.schema.json
+++ b/cluster/helm/splice-validator/values.schema.json
@@ -22,6 +22,9 @@
     "serviceAccountName": {
       "type": "string"
     },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
     "ansWebUi": {
       "type": "object",
       "required": ["imageName"],

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,6 +7,16 @@
 
 release-notes:: Upcoming
 
+    - Deployment
+
+        - All Splice Helm charts now set ``automountServiceAccountToken: false`` on the pods they
+          deploy. Splice components do not use the Kubernetes API, so pods no longer receive an
+          API-server credential by default; this reduces the impact of a compromised pod in
+          clusters where permissions are bound to the namespace's ``default`` service account.
+          If your deployment relies on the mounted token, for example through a custom service
+          account set via ``serviceAccountName``, you can restore the previous behavior by setting
+          the new ``automountServiceAccountToken`` Helm value to ``true``.
+
     - SV App
 
         - The public ``/v0/dso`` endpoint is deprecated and will be removed in 0.9.0


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/6745

Nothing we deploy uses the Kubernetes API from inside a pod.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
