### PR TITLE
SV app: Remove deprecated public `/v0/dso`

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AppUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AppUpgradeIntegrationTest.scala
@@ -26,7 +26,6 @@ import org.lfdecentralizedtrust.splice.wallet.store.BalanceChangeTxLogEntry
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
-import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.store.TimeQuery.HeadState
 import monocle.macros.syntax.lens.*
@@ -209,13 +208,10 @@ class AppUpgradeIntegrationTest
             sv2Wallet.tap(1003)
             sv2Wallet.balance().unlockedQty should be > BigDecimal(2000)
             // p2p transfer between an upgraded validator (alice's) and a non-upgraded (sv-1's).
-            // Note: we cannot use sv1's (authenticated, current-version) /v1/dso to look up its
-            // party here, as sv1 is still running the old release at this point.
-            // TODO(DACH-NY/canton-network-internal#2106) clean this up once the old release is new enough
             p2pTransfer(
               bobValidatorWalletClient,
               sv1WalletClient,
-              PartyId.tryFromProtoPrimitive(sv1WalletClient.userStatus().party),
+              sv1Client.getDsoInfo().svParty,
               501,
             )
             sv1WalletClient.balance().unlockedQty should be > BigDecimal(400)

--- a/apps/sv/src/main/openapi/sv-internal.yaml
+++ b/apps/sv/src/main/openapi/sv-internal.yaml
@@ -518,22 +518,6 @@ paths:
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
         "501":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/501"
-  /v0/dso:
-    get:
-      tags: [sv]
-      # Deprecated in favor of /v1/dso, which requires authorization as SV operator.
-      # TODO(DACH-NY/canton-network-internal#2106) Remove in 0.8.0
-      deprecated: true
-      x-jvm-package: sv_public
-      x-external-audience: validators
-      operationId: "getDsoInfo"
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema:
-                "$ref": "../../../../common/src/main/openapi/common-internal.yaml#/components/schemas/GetDsoInfoResponse"
 
   /v1/dso:
     get:

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
@@ -466,7 +466,6 @@ class SvApp(
         }
 
       publicHandler = new HttpSvPublicHandler(
-        config.ledgerApiUser,
         svAutomation,
         dsoAutomation,
         isDevNet,
@@ -485,7 +484,6 @@ class SvApp(
           loggerFactory,
         ),
         loggerFactory,
-        initialRound,
       )
 
       operatorHandler = new HttpSvOperatorHandler(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
@@ -39,7 +39,7 @@ import org.lfdecentralizedtrust.splice.sv.onboarding.sponsor.DsoPartyMigration
 import org.lfdecentralizedtrust.splice.sv.store.{SvDsoStore, SvSvStore}
 import org.lfdecentralizedtrust.splice.sv.util.{Secrets, SvOnboardingToken}
 import org.lfdecentralizedtrust.splice.sv.util.SvUtil.generateRandomOnboardingSecret
-import org.lfdecentralizedtrust.splice.util.{Codec, Contract, DsoInfo}
+import org.lfdecentralizedtrust.splice.util.{Codec, Contract}
 
 import java.util.Base64
 import scala.concurrent.{ExecutionContext, Future}
@@ -47,7 +47,6 @@ import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
 class HttpSvPublicHandler(
-    svUserName: String,
     svStoreWithIngestion: AppStoreWithIngestion[SvSvStore],
     dsoStoreWithIngestion: AppStoreWithIngestion[SvDsoStore],
     isDevNet: Boolean,
@@ -58,7 +57,6 @@ class HttpSvPublicHandler(
     retryProvider: RetryProvider,
     dsoPartyMigration: DsoPartyMigration,
     protected val loggerFactory: NamedLoggerFactory,
-    initialRound: String,
 )(implicit
     ec: ExecutionContext,
     protected val tracer: Tracer,
@@ -351,34 +349,6 @@ class HttpSvPublicHandler(
           )
         )
       }
-    }
-  }
-
-  /** Deprecated in favor of `getDsoInfoV1` in [[HttpSvOperatorHandler]], which requires
-    * authorization as SV operator. Kept public for backwards compatibility.
-    * TODO(DACH-NY/canton-network-internal#2106): Remove in 0.9.0
-    */
-  override def getDsoInfo(
-      respond: r0.GetDsoInfoResponse.type
-  )()(extracted: TraceContext): Future[r0.GetDsoInfoResponse] = {
-    implicit val traceContext: TraceContext = extracted
-    withSpan(s"$workflowId.getDsoInfo") { _ => _ =>
-      for {
-        latestOpenMiningRound <- dsoStore.getLatestActiveOpenMiningRound()
-        amuletRules <- dsoStore.getAssignedAmuletRules()
-        rulesAndStates <- dsoStore.getDsoRulesWithStateWithSvNodeStates()
-        dsoRules = rulesAndStates.dsoRules
-      } yield DsoInfo(
-        svUser = svUserName,
-        svParty = svParty,
-        dsoParty = dsoParty,
-        votingThreshold = Thresholds.requiredNumVotes(dsoRules),
-        latestMiningRound = latestOpenMiningRound.toContractWithState,
-        amuletRules = amuletRules.toContractWithState,
-        dsoRules = dsoRules,
-        svNodeStates = rulesAndStates.svNodeStates,
-        initialRound = Some(initialRound),
-      ).toHttp
     }
   }
 

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -1430,8 +1430,7 @@ subcommand_whitelist[wait_for_daml_upgrade]="Waits for daml upgrade after a vote
 
 function subcmd_wait_for_daml_upgrade() {
     _info "Fetching DSO rules"
-    token=$(subcmd_get_token sv-1 sv)
-    dso=$(curl -s "https://sv.sv-2.${GCP_CLUSTER_HOSTNAME}/api/sv/v0/dso" -H "authorization: Bearer ${token}")
+    dso=$(curl -s "https://scan.sv-2.${GCP_CLUSTER_HOSTNAME}/api/scan/v0/dso")
     # get the first futureValue's effective date, which corresponds to the vote from DamlCIUpgradeVotePreflightTest
     effective_date=$(jq -r '.amulet_rules.payload.configSchedule.futureValues[0]._1' <<< "$dso")
 
@@ -1986,7 +1985,7 @@ function subcmd_list_sv_cometbft_addresses() {
 
   pubkey_sv=$(mktemp)
   pubkey_address=$(mktemp)
-  curl -sSLf "https://sv.$sv.${GCP_CLUSTER_HOSTNAME}/api/sv/v0/dso" | jq '[.sv_node_states[] | .contract.payload as $payload | .contract.payload.state.synchronizerNodes[] | select(.[0] | startswith("global"))[1].cometBft.nodes[]|{ sv: $payload.svName, pub_key: .[1].validatorPubKey, peer_id: .[0]}]' > "$pubkey_sv"
+  curl -sSLf "https://scan.$sv.${GCP_CLUSTER_HOSTNAME}/api/scan/v0/dso" | jq '[.sv_node_states[] | .contract.payload as $payload | .contract.payload.state.synchronizerNodes[] | select(.[0] | startswith("global"))[1].cometBft.nodes[]|{ sv: $payload.svName, pub_key: .[1].validatorPubKey, peer_id: .[0]}]' > "$pubkey_sv"
   curl -sSLf --header "Content-Type: application/json" -X POST -d '{"id": 0, "method": "validators"}' "https://sv.$sv.${GCP_CLUSTER_HOSTNAME}/api/sv/v0/admin/domain/cometbft/json-rpc" | \
     jq '[.result.validators[] | { address: .address, pub_key:  .pub_key.value}] | to_entries | map({index: .key, pub_key: .value.pub_key, address: .value.address})' > "$pubkey_address"
 

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2934,7 +2934,6 @@
                   ],
                   "paths": [
                     "/api/sv/v0/devnet/onboard/validator/prepare",
-                    "/api/sv/v0/dso",
                     "/api/sv/v0/onboard/validator"
                   ]
                 }

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
@@ -31,7 +31,6 @@ describe('the SV OpenAPI spec', () => {
   test('exposes the expected paths per audience', () => {
     const paths = svPublicIngressPathsByAudience(content);
     expect(paths['validators']).toContain('/api/sv/v0/onboard/validator');
-    expect(paths['validators']).toContain('/api/sv/v0/dso');
     expect(paths['svs']).toContain('/api/sv/v0/migration-id');
     expect(paths['svs']).toContain('/api/sv/v0/onboard/sv/status/*');
     const allPaths = exposedAudiences.flatMap(audience => paths[audience]);
@@ -41,6 +40,8 @@ describe('the SV OpenAPI spec', () => {
     // non-public endpoints must not be whitelisted
     expect(allPaths).not.toContain('/api/sv/v0/admin/sv/votes');
     expect(allPaths).not.toContain('/api/sv/readyz');
+    // deprecated endpoints must not be whitelisted
+    expect(paths['validators']).not.toContain('/api/sv/v0/dso');
   });
 });
 
@@ -101,5 +102,5 @@ test('toIngressPath replaces path parameters with a wildcard', () => {
   expect(toIngressPath('/v0/onboard/sv/status/{candidate_party_id_or_name}')).toBe(
     '/api/sv/v0/onboard/sv/status/*'
   );
-  expect(toIngressPath('/v0/dso')).toBe('/api/sv/v0/dso');
+  expect(toIngressPath('/v0/onboard/validator')).toBe('/api/sv/v0/onboard/validator');
 });

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -9,14 +9,5 @@ release-notes:: Upcoming
 
     - SV App
 
-        - The public ``/v0/dso`` endpoint is deprecated and will be removed in 0.9.0
-          (see also the release notes for 0.5.5 for the original deprecation notice).
-          Use the public ``/v0/dso`` endpoint in the scan app if you need to fetch DSO info
-          without SV operator credentials.
-          A new ``/v1/dso`` endpoint has been added that returns the same response as ``/v0/dso``
-          but requires authorization as SV operator.
-
-        - Joining SVs now fetch DSO info during onboarding from a scan instance
-          (typically the sponsor's) instead of the sponsor SV app's deprecated public
-          ``/v0/dso`` endpoint. The scan is configured via the new ``.joinWithKeyOnboarding.sponsorScanUrl`` Helm value.
-          SVs who set the ``.joinWithKeyOnboarding`` key config must set it before upgrading.
+        - The deprecated (in 0.8.0) public ``/v0/dso`` endpoint has been removed.
+          Use the public ``/v0/dso`` endpoint in the scan app if you need to fetch DSO info without SV operator credentials.


### PR DESCRIPTION
Fixes DACH-NY/canton-network-internal#2106 (last bit)

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
