### PR TITLE
CometBFT watchdog improvements

### DIFF
--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -128,10 +128,10 @@ watchdog:
   imageName: "cometbft-watchdog"
   resources:
     limits:
-      memory: 128Mi
+      memory: 512Mi
     requests:
-      cpu: 0.05
-      memory: 64Mi
+      cpu: 0.5
+      memory: 256Mi
 
 securityContexts:
   pod:

--- a/cluster/images/cometbft-watchdog/restart-watchdog.py
+++ b/cluster/images/cometbft-watchdog/restart-watchdog.py
@@ -96,7 +96,7 @@ def parse_samples(text, metric, required_labels, source):
 def scrape(url, metric, required_labels, timeout):
     try:
         request = urllib.request.Request(
-            url, headers={"Accept": "text/plain"}
+            f"{url}?name[]={metric}", headers={"Accept": "text/plain"}
         )
         with urllib.request.urlopen(request, timeout=timeout) as response:
             charset = response.headers.get_content_charset() or "utf-8"

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -30,3 +30,7 @@ release-notes:: Upcoming
           (typically the sponsor's) instead of the sponsor SV app's deprecated public
           ``/v0/dso`` endpoint. The scan is configured via the new ``.joinWithKeyOnboarding.sponsorScanUrl`` Helm value.
           SVs who set the ``.joinWithKeyOnboarding`` key config must set it before upgrading.
+
+    - CometBFT
+
+        - Increased default resources of watchdog and made it only query for metrics it needs.


### PR DESCRIPTION
- Bump resources
- Filter for metrics (a bit faster and uses less memory)

I have tested the metrics query using `curl`. I haven't tested the full chart yet. My plan was to get this reviewed and merged and then try a helm upgrade to a snapshot temporarily to try it out before the release to make sure nothing goes wrong.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
