### PR TITLE
Persist docker compose and Postgres logs

### DIFF
--- a/build-tools/splice-compose.sh
+++ b/build-tools/splice-compose.sh
@@ -21,6 +21,24 @@ export LOG_LEVEL=DEBUG
 mkdir -p "${SPLICE_ROOT}/log"
 exec > >(tee -a "${SPLICE_ROOT}/log/compose.log") 2>&1
 
+function _dump_postgres_logs {
+  local c
+  for c in splice-validator-postgres-splice-1 splice-sv-postgres-splice-sv-1; do
+    if docker container inspect "$c" > /dev/null 2>&1; then
+      _info "Dumping postgres logs for $c"
+      docker logs "$c" > "${SPLICE_ROOT}/log/compose-postgres-${c}.clog" 2>&1 || true
+    fi
+  done
+}
+
+# Dump postgres logs whenever the script exits with a non-zero code
+function _on_error_exit {
+  if [ "$1" -ne 0 ]; then
+    _dump_postgres_logs
+  fi
+}
+trap '_on_error_exit $?' EXIT
+
 function _export_auth0_env_vars {
 
   if [ -z "$GCP_CLUSTER_BASENAME" ]; then

--- a/build-tools/splice-compose.sh
+++ b/build-tools/splice-compose.sh
@@ -18,6 +18,9 @@ SV_DIR="${SPLICE_ROOT}/cluster/compose/sv"
 # we want DEBUG logs for our tests
 export LOG_LEVEL=DEBUG
 
+mkdir -p "${SPLICE_ROOT}/log"
+exec > >(tee -a "${SPLICE_ROOT}/log/compose.log") 2>&1
+
 function _export_auth0_env_vars {
 
   if [ -z "$GCP_CLUSTER_BASENAME" ]; then
@@ -58,7 +61,7 @@ function _export_auth0_env_vars {
 function _do_start_validator {
   "${VALIDATOR_DIR}/start.sh" \
     "$@" \
-      | tee -a "${SPLICE_ROOT}/log/compose.log" 2>&1 || _error "Failed to start validator, please check ${SPLICE_ROOT}/log/compose.log for details"
+      || _error "Failed to start validator, please check ${SPLICE_ROOT}/log/compose.log for details"
 
   for c in validator participant nginx; do
     docker logs -f splice-validator-${c}-1 >> "${SPLICE_ROOT}/log/compose-${c}.clog" 2>&1 &
@@ -70,7 +73,7 @@ function _do_start_validator {
     "${VALIDATOR_DIR}/start.sh" \
       "$@" \
       "-w" \
-        | tee -a "${SPLICE_ROOT}/log/compose-wait.log" 2>&1 || _error "Validator failed to become ready"
+        || _error "Validator failed to become ready"
   fi
 
 }


### PR DESCRIPTION
Fixes #5917 

This addresses the first two points mentioned [here](https://github.com/canton-network/splice/issues/5917#issuecomment-5456933512):

> 1. docker compose command logs should be persisted
> 2. Postgres logs should be persisted on failure

Re: the third point, @nicu-da I think the tests already exit when a container fails its health checks. To confirm, I changed [this healthcheck](https://github.com/canton-network/splice/blob/6ab535819c04174e0e6e55aa7d2c1003436f7d24/cluster/compose/validator/compose.yaml#L191) to be `test: ["CMD", "false"]` so it always fails. When I ran the `DockerComposeValidatorFrontendIntegrationTest`, it failed [here](https://github.com/canton-network/splice/blob/6ab535819c04174e0e6e55aa7d2c1003436f7d24/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DockerComposeValidatorFrontendIntegrationTest.scala#L50) since [the `--wait` flag](https://github.com/canton-network/splice/blob/6ab535819c04174e0e6e55aa7d2c1003436f7d24/cluster/compose/validator/start.sh#L330) waits for services to be running/healthy (described in [the `docker compose up` docs](https://docs.docker.com/reference/cli/docker/compose/up/)).

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
