### PR TITLE
Don't warn for parties that have no vetted amulet version

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExpiryWithMinimalVettedPackagesIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExpiryWithMinimalVettedPackagesIntegrationTest.scala
@@ -421,33 +421,23 @@ class ExpiryWithNoVettedAmuletVersionIntegrationTest
       }
     }
 
-    loggerFactory.assertLogsSeq(
-      SuppressionRule.forLogger[ExpiredAmuletTrigger] && SuppressionRule.Level(Level.WARN)
+    actAndCheck(timeUntilSuccess = 60.seconds)(
+      "Advance 4 rounds and resume the amulet expiry trigger", {
+        (1 to 4).foreach(_ => advanceRoundsByOneTickViaAutomation())
+        updateExternalPartyConfigStatesViaAutomation()
+        updateExternalPartyConfigStatesViaAutomation()
+        env.svs.local.foreach(
+          _.dsoDelegateBasedAutomation.trigger[ExpiredAmuletTrigger].resume()
+        )
+      },
     )(
-      actAndCheck(timeUntilSuccess = 60.seconds)(
-        "Advance 4 rounds and resume the amulet expiry trigger", {
-          (1 to 4).foreach(_ => advanceRoundsByOneTickViaAutomation())
-          updateExternalPartyConfigStatesViaAutomation()
-          updateExternalPartyConfigStatesViaAutomation()
-          env.svs.local.foreach(
-            _.dsoDelegateBasedAutomation.trigger[ExpiredAmuletTrigger].resume()
-          )
-        },
-      )(
-        "Alice is ignored and her dust amulets are not expired",
-        _ => {
-          val ignored = sv1Backend.dsoDelegateBasedAutomation.unavailablePartiesStore.getAll
-          ignored should contain(alice)
-          ignored should not contain dsoParty
-          aliceWalletClient.list().amulets should have length 2L withClue "dust amulets"
-        },
-      ),
-      entries =>
-        forAtLeast(1, entries) { entry =>
-          entry.warningMessage should include("No vetted Amulet version")
-          entry.warningMessage should include(alice.uid.identifier.str)
-          entry.warningMessage should include("ignoring 1 parties")
-        },
+      "Alice is ignored and her dust amulets are not expired",
+      _ => {
+        val ignored = sv1Backend.dsoDelegateBasedAutomation.unavailablePartiesStore.getAll
+        ignored should contain(alice)
+        ignored should not contain dsoParty
+        aliceWalletClient.list().amulets should have length 2L withClue "dust amulets"
+      },
     )
   }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -3,7 +3,6 @@ package org.lfdecentralizedtrust.splice.integration.tests
 import com.digitalasset.canton.HasExecutionContext
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
-import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.metrics.MetricValue
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.transaction.VettedPackage
@@ -40,7 +39,6 @@ import org.lfdecentralizedtrust.splice.util.{
   WalletTestUtil,
 }
 import org.lfdecentralizedtrust.splice.wallet.automation.AcceptedTransferOfferTrigger
-import org.slf4j.event.Level
 
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
@@ -415,61 +413,53 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
         .toSet
       aliceObservedCoupons should not be empty
 
-      loggerFactory.assertEventuallyLogsSeq(SuppressionRule.Level(Level.WARN))(
-        {
-          unvetV2AmuletOnAlice(aliceParticipantId)
+      unvetV2AmuletOnAlice(aliceParticipantId)
 
-          val couponsBeforeAdvance = sv1Backend.appState.dsoStore
+      val couponsBeforeAdvance = sv1Backend.appState.dsoStore
+        .listRewardCouponsV2()
+        .futureValue
+        .map(_.contractId.contractId)
+        .toSet
+
+      actAndCheck(
+        "Advance past the coupon TTL",
+        advanceTime(Duration.ofHours(37)),
+      )(
+        "ExpireRewardCouponV2Trigger ignores Alice coupons",
+        _ => {
+          sv1Backend.dsoDelegateBasedAutomation
+            .trigger[ExpireRewardCouponV2Trigger]
+            .runOnce()
+            .futureValue
+          val remaining = sv1Backend.appState.dsoStore
             .listRewardCouponsV2()
             .futureValue
             .map(_.contractId.contractId)
             .toSet
-
-          actAndCheck(
-            "Advance past the coupon TTL",
-            advanceTime(Duration.ofHours(37)),
-          )(
-            "ExpireRewardCouponV2Trigger ignores Alice coupons",
-            _ => {
-              sv1Backend.dsoDelegateBasedAutomation
-                .trigger[ExpireRewardCouponV2Trigger]
-                .runOnce()
-                .futureValue
-              val remaining = sv1Backend.appState.dsoStore
-                .listRewardCouponsV2()
-                .futureValue
-                .map(_.contractId.contractId)
-                .toSet
-              aliceObservedCoupons.subsetOf(remaining) shouldBe true
-            },
-          )
-
-          actAndCheck(
-            "Re-vet Alice",
-            revetV2AmuletOnAlice(aliceParticipantId, aliceParty),
-          )(
-            "ExpireRewardCouponV2Trigger archives once Alice is re-vetted",
-            _ => {
-              sv1Backend.dsoDelegateBasedAutomation
-                .trigger[ExpireRewardCouponV2Trigger]
-                .runOnce()
-                .futureValue
-              val remaining = sv1Backend.appState.dsoStore
-                .listRewardCouponsV2()
-                .futureValue
-                .map(_.contractId.contractId)
-                .toSet
-              remaining.intersect(couponsBeforeAdvance) shouldBe empty
-            },
-          )
+          aliceObservedCoupons.subsetOf(remaining) shouldBe true
         },
-        logs => {
-          forAtLeast(1, logs) { entry =>
-            entry.message should include("No vetted Amulet version for")
-          }
+      )
+
+      actAndCheck(
+        "Re-vet Alice",
+        revetV2AmuletOnAlice(aliceParticipantId, aliceParty),
+      )(
+        "ExpireRewardCouponV2Trigger archives once Alice is re-vetted",
+        _ => {
+          sv1Backend.dsoDelegateBasedAutomation
+            .trigger[ExpireRewardCouponV2Trigger]
+            .runOnce()
+            .futureValue
+          val remaining = sv1Backend.appState.dsoStore
+            .listRewardCouponsV2()
+            .futureValue
+            .map(_.contractId.contractId)
+            .toSet
+          remaining.intersect(couponsBeforeAdvance) shouldBe empty
         },
       )
     }
+
   }
 
   private def vettedPackagesOnSv1View(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/BatchedMultiDomainExpiredContractTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/BatchedMultiDomainExpiredContractTrigger.scala
@@ -49,8 +49,7 @@ abstract class BatchedMultiDomainExpiredContractTrigger[
   protected def ignorePartiesWithoutVettedAmulet(
       informees: Set[PartyId],
       contractIds: Seq[String],
-      logAsWarning: Boolean,
-  )(implicit tc: TraceContext): String
+  ): String
 
   override final protected def listReadyTasks(now: CantonTimestamp, limit: Int)(implicit
       tc: TraceContext
@@ -79,7 +78,6 @@ abstract class BatchedMultiDomainExpiredContractTrigger[
             ignorePartiesWithoutVettedAmulet(
               stakeholders,
               contracts.flatten.map(_.contractId.contractId),
-              logAsWarning = true,
             ).discard
             Seq.empty
         }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/FeaturedAppActivityMarkerTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/FeaturedAppActivityMarkerTrigger.scala
@@ -112,7 +112,6 @@ class FeaturedAppActivityMarkerTrigger(
             ignorePartiesWithoutVettedAmulet(
               getInformeesFromContracts(markers.flatten),
               markers.flatten.map(_.contractId.contractId),
-              logAsWarning = true,
             ).discard
             Seq.empty
         }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/IgnoredUnavailablePartiesGuard.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/IgnoredUnavailablePartiesGuard.scala
@@ -67,14 +67,10 @@ trait IgnoredUnavailablePartiesGuard extends NamedLogging {
   protected def ignorePartiesWithoutVettedAmulet(
       informees: Set[PartyId],
       contractIds: Seq[String],
-      logAsWarning: Boolean = false,
-  )(implicit tc: TraceContext): String = {
+  ): String = {
     val toIgnore = withoutDsoParty(informees)
     ignoredPartiesStore.addAll(toIgnore)
-    val msg =
-      s"No vetted Amulet version for $contractIds; ignoring ${toIgnore.size} parties: $toIgnore"
-    if (logAsWarning) logger.warn(msg)
-    msg
+    s"No vetted Amulet version for $contractIds; ignoring ${toIgnore.size} parties: $toIgnore"
   }
 
   private def recoverUnresponsiveParties(


### PR DESCRIPTION
[ci]

I can't come up with a sensible reason why this should be a warning, we also don't warn if you only have old unusable versions vetted. Looking at history it seems like this probably got preserved before we had party ignores so imho totally fine to just not warn.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
