### PR TITLE
helm: make the Postgres role and bootstrap database configurable for SV charts

### DIFF
--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -48,6 +48,10 @@ spec:
           value: {{ .Values.defaultJvmOptions }} {{ .Values.additionalJvmOptions }}
         - name: CANTON_DOMAIN_POSTGRES_SERVER
           value: {{ .Values.sequencer.persistence.host }}
+        {{- with .Values.sequencer.persistence.user }}
+        - name: CANTON_DOMAIN_POSTGRES_USER
+          value: {{ . | quote }}
+        {{- end }}
         - name: CANTON_DOMAIN_POSTGRES_PASSWORD
           {{- if ((.Values.sequencer.persistence).secretOverrides).postgresPassword }}
           value: {{ .Values.sequencer.persistence.secretOverrides.postgresPassword | quote }}
@@ -131,7 +135,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.sequencer.persistence.host }} -p {{ .Values.sequencer.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.sequencer.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.sequencer.persistence.host }} -p {{ .Values.sequencer.persistence.port }} --username={{ .Values.sequencer.persistence.user | default "cnadmin" }} --dbname={{ .Values.sequencer.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.sequencer.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.sequencer.persistence.databaseName }} already exists. Done."
                   break
@@ -162,7 +166,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.mediator.persistence.host }} -p {{ .Values.mediator.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.mediator.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.mediator.persistence.host }} -p {{ .Values.mediator.persistence.port }} --username={{ .Values.mediator.persistence.user | default "cnadmin" }} --dbname={{ .Values.mediator.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.mediator.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.mediator.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-domain/values-template.yaml
+++ b/cluster/helm/splice-domain/values-template.yaml
@@ -22,6 +22,10 @@ mediator:
   persistence:
     host: postgres.sv-1.svc.cluster.local
     secretName: "postgres-secrets"
+    # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+    # user: cnadmin
+    # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+    # bootstrapDatabaseName: cantonnet
     # Optional: Provide raw strings to override the default Kubernetes secret injection.
     # This is useful for integrating with external secret management tools.
     # Note: Ensure you have the appropriate mutating webhook/injector installed in your cluster.
@@ -32,6 +36,10 @@ sequencer:
   persistence:
     host: postgres.sv-1.svc.cluster.local
     secretName: "postgres-secrets"
+    # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+    # user: cnadmin
+    # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+    # bootstrapDatabaseName: cantonnet
 #    secretOverrides:
 #      postgresPassword: ""
 

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -62,6 +62,10 @@ spec:
           value: {{ .Values.mediator.persistence.host }}
         - name: CANTON_DOMAIN_POSTGRES_PORT
           value: {{ .Values.mediator.persistence.port | quote }}
+        {{- with .Values.mediator.persistence.user }}
+        - name: CANTON_DOMAIN_POSTGRES_USER
+          value: {{ . | quote }}
+        {{- end }}
         - name: CANTON_DOMAIN_POSTGRES_PASSWORD
           {{- if ((.Values.mediator.persistence).secretOverrides).postgresPassword }}
           value: {{ .Values.mediator.persistence.secretOverrides.postgresPassword | quote }}
@@ -146,7 +150,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.mediator.persistence.host }} -p {{ .Values.mediator.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.mediator.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.mediator.persistence.host }} -p {{ .Values.mediator.persistence.port }} --username={{ .Values.mediator.persistence.user | default "cnadmin" }} --dbname={{ .Values.mediator.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.mediator.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.mediator.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -58,6 +58,10 @@ spec:
               value: {{ .Values.sequencer.persistence.host }}
             - name: CANTON_DOMAIN_POSTGRES_PORT
               value: {{ .Values.sequencer.persistence.port | quote }}
+            {{- with .Values.sequencer.persistence.user }}
+            - name: CANTON_DOMAIN_POSTGRES_USER
+              value: {{ . | quote }}
+            {{- end }}
             - name: CANTON_DOMAIN_POSTGRES_PASSWORD
               {{- if ((.Values.sequencer.persistence).secretOverrides).postgresPassword }}
               value: {{ .Values.sequencer.persistence.secretOverrides.postgresPassword | quote }}
@@ -218,7 +222,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.sequencer.persistence.host }} -p {{ .Values.sequencer.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.sequencer.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.sequencer.persistence.host }} -p {{ .Values.sequencer.persistence.port }} --username={{ .Values.sequencer.persistence.user | default "cnadmin" }} --dbname={{ .Values.sequencer.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.sequencer.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.sequencer.persistence.databaseName }} already exists. Done."
                   break
@@ -232,6 +236,7 @@ spec:
         {{- $dbHost := $p.host | default .Values.sequencer.persistence.host }}
         {{- $dbPort := $p.port | default .Values.sequencer.persistence.port }}
         {{- $dbUser := $p.user | default "cnadmin" }}
+        {{- $dbBootstrap := $p.bootstrapDatabaseName | default (.Values.sequencer.persistence).bootstrapDatabaseName | default "cantonnet" }}
         {{- $dbName := $p.databaseName | default .Values.sequencer.persistence.databaseName }}
         {{- $dbSecret := $p.secretName | default .Values.sequencer.persistence.secretName }}
         - name: pg-init-bft-driver
@@ -261,17 +266,18 @@ spec:
               DB_PORT="{{ $dbPort }}"
               DB_USER="{{ $dbUser }}"
               DB_NAME="{{ $dbName }}"
+              DB_BOOTSTRAP="{{ $dbBootstrap }}"
 
               echo "Waiting for postgres ${DB_HOST}:${DB_PORT} to become reachable...";
-              until psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
+              until psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname="$DB_BOOTSTRAP" -tAc 'SELECT 1' >/dev/null 2>&1; do
                 sleep 2;
               done
 
-              if [ "$(psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'")" = "1" ]; then
+              if [ "$(psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname="$DB_BOOTSTRAP" -tAc "SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'")" = "1" ]; then
                 echo "Database ${DB_NAME} already exists on ${DB_HOST}. Done.";
                 exit 0;
               fi
-              psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -c "CREATE DATABASE \"${DB_NAME}\"";
+              psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname="$DB_BOOTSTRAP" -c "CREATE DATABASE \"${DB_NAME}\"";
               echo "Created empty database ${DB_NAME} on ${DB_HOST}.";
       {{- end }}
       {{- with .Values.priorityClassName }}

--- a/cluster/helm/splice-global-domain/tests/mediator_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/mediator_test.yaml
@@ -327,3 +327,29 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.priorityClassName
+
+  - it: "passes mediator persistence.user to the canton node itself"
+    set:
+      mediator:
+        persistence:
+          user: appuser
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CANTON_DOMAIN_POSTGRES_USER
+            value: appuser
+
+  - it: "omits the canton node DB user when mediator persistence.user is unset"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: CANTON_DOMAIN_POSTGRES_USER

--- a/cluster/helm/splice-global-domain/values-template.yaml
+++ b/cluster/helm/splice-global-domain/values-template.yaml
@@ -26,6 +26,10 @@ sequencer:
   persistence:
     host: postgres.sv-1.svc.cluster.local
     secretName: "postgres-secrets"
+    # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+    # user: cnadmin
+    # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+    # bootstrapDatabaseName: cantonnet
     databaseName: cantonnet_sequencer
     port: 5432
     initImageName: "postgres:14"
@@ -44,6 +48,10 @@ mediator:
   persistence:
     host: postgres.sv-1.svc.cluster.local
     secretName: "postgres-secrets"
+    # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+    # user: cnadmin
+    # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+    # bootstrapDatabaseName: cantonnet
     databaseName: cantonnet_mediator
     port: 5432
     initImageName: "postgres:14"

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -326,7 +326,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-scan/values-template.yaml
+++ b/cluster/helm/splice-scan/values-template.yaml
@@ -31,6 +31,10 @@ persistence:
   port: 5432
   user: cnadmin
   secretName: "postgres-secrets"
+  # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+  # user: cnadmin
+  # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+  # bootstrapDatabaseName: cantonnet
   initImageName: "postgres:14"
 #  secretOverrides:
 #    postgresPassword: ""

--- a/cluster/helm/splice-scan/values.schema.json
+++ b/cluster/helm/splice-scan/values.schema.json
@@ -186,6 +186,9 @@
             "txLogStoreDescriptorUserVersion": {
               "type": "integer"
             },
+            "bootstrapDatabaseName": {
+              "type": "string"
+            },
             "initImageName": {
               "type": "string"
             },

--- a/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
+++ b/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
@@ -125,7 +125,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-splitwell-app/values-template.yaml
+++ b/cluster/helm/splice-splitwell-app/values-template.yaml
@@ -24,6 +24,10 @@ persistence:
   port: 5432
   user: cnadmin
   secretName: "postgres-secrets"
+  # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+  # user: cnadmin
+  # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+  # bootstrapDatabaseName: cantonnet
   initImageName: "postgres:14"
 #  secretOverrides:
 #    postgresPassword: ""

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -619,7 +619,7 @@ spec:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username=cnadmin --dbname=cantonnet -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
+              until errmsg=$(psql -h {{ .Values.persistence.host }} -p {{ .Values.persistence.port }} --username={{ .Values.persistence.user | default "cnadmin" }} --dbname={{ .Values.persistence.bootstrapDatabaseName | default "cantonnet" }} -c 'create database {{ .Values.persistence.databaseName }}' 2>&1); do
                 if [[ $errmsg == *"already exists"* ]]; then
                   echo "Database {{ .Values.persistence.databaseName }} already exists. Done."
                   break

--- a/cluster/helm/splice-sv-node/values-template.yaml
+++ b/cluster/helm/splice-sv-node/values-template.yaml
@@ -47,6 +47,10 @@ persistence:
   port: 5432
   user: cnadmin
   secretName: "postgres-secrets"
+  # Postgres role the charts connect as, including the pg-init containers (default cnadmin)
+  # user: cnadmin
+  # Database the pg-init container connects to in order to CREATE the target database (default cantonnet)
+  # bootstrapDatabaseName: cantonnet
   initImageName: "postgres:14"
 #  secretOverrides:
 #    postgresPassword: ""

--- a/cluster/helm/splice-sv-node/values.schema.json
+++ b/cluster/helm/splice-sv-node/values.schema.json
@@ -564,6 +564,9 @@
               "minimum": 1,
               "maximum": 65535
             },
+            "bootstrapDatabaseName": {
+              "type": "string"
+            },
             "initImageName": {
               "type": "string"
             },

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -109,15 +109,15 @@ release-notes:: Upcoming
           protect a node from eviction under resource pressure. It is unset by default, which leaves
           scheduling behaviour unchanged.
 
-        - The Postgres role and bootstrap database used by the validator and participant charts are
-          no longer hardcoded. ``persistence.user`` and ``persistence.bootstrapDatabaseName`` are now
-          honoured by the ``pg-init`` and wait containers, by the Postgres exporter sidecar, and — for
-          the participant — by the Canton node itself, which previously always connected as
-          ``cnadmin`` regardless of the configured value. They default to ``cnadmin`` and
-          ``cantonnet``, so rendered output is unchanged unless you set them. This matters for
-          operators moving off ``splice-postgres`` to a self-provisioned or managed Postgres, where a
-          ``cnadmin`` superuser and a ``cantonnet`` database may not be available to create. The SV
-          charts are not covered yet and still use the hardcoded values.
+        - The Postgres role and bootstrap database are no longer hardcoded in any of the operator
+          charts. ``persistence.user`` and ``persistence.bootstrapDatabaseName`` are now honoured by
+          the ``pg-init`` and wait containers, by the Postgres exporter sidecar, and — for the
+          participant, domain, mediator and sequencer — by the Canton node itself, which previously
+          always connected as ``cnadmin`` regardless of the configured value. They default to
+          ``cnadmin`` and ``cantonnet``, so rendered output is unchanged unless you set them. This
+          matters for operators moving off ``splice-postgres`` to a self-provisioned or managed
+          Postgres, where a ``cnadmin`` superuser and a ``cantonnet`` database may not be available
+          to create.
 
     - SV UI
 


### PR DESCRIPTION
Follow-up to #6803, as agreed there. That PR was cut down to validator + participant so the validator use case could land early; this carries the parts that were held back.

**No rush on merging this one.** You said you would not merge the SV charts without cluster test coverage for SV deployments, and that such coverage is planned as part of a security-hardening story. This is here so the work is not lost and is ready when that lands — review it whenever it suits you.

## What it covers

`splice-sv-node`, `splice-scan`, `splice-global-domain` (sequencer + mediator), `splice-domain`, and `splice-splitwell-app`.

Same shape as #6803: `persistence.user` and `persistence.bootstrapDatabaseName` replace the hardcoded `cnadmin` role and `cantonnet` bootstrap database, defaulting to those values so **rendered output is byte-identical unless you set them**.

With this, `rg -- '--dbname=cantonnet|--username=cnadmin' cluster/helm/` returns nothing across the whole tree.

## The node-level half

The domain, mediator and sequencer needed the same second fix the participant did: `canton-base`'s `storage.conf` reads `user = ${?CANTON_DOMAIN_POSTGRES_USER}` and the charts never set it, so the node kept connecting as `cnadmin` even with `persistence.user` configured — the half-applied configuration we discussed on #6803.

The sequencer's cantonbft-driver init container was a second instance of the original problem: it already derived host, port and user from values but connected to a hardcoded bootstrap database. It now derives that the same way, via a `$dbBootstrap` template variable exposed as `DB_BOOTSTRAP`, matching the file's own idiom rather than inlining an expression into the shell script.

## Why splitwell is here

It is neither a validator nor an SV component, so it seemed to belong with the batch waiting for new coverage rather than with the one you merged on the strength of the validator testing. Happy to move it if you would rather have had it in #6803.

## Tests

Two tests on the global-domain mediator assert `persistence.user` reaches the node's env and that nothing is emitted when unset; both were checked to fail without the change. Every touched chart's suite gives the same results as `main`.

The release-notes entry from #6803 is extended rather than duplicated, since both ship in the same release.

## Testing this on a cluster

For whenever the SV coverage exists, the setup that made the #6803 validation meaningful was initialising Postgres with `POSTGRES_USER=appuser` / `POSTGRES_DB=bootstrapdb` so that `cnadmin` and `cantonnet` **do not exist** — otherwise the test passes whether or not the values are honoured. The unpatched charts then fail loudly with `password authentication failed for user "cnadmin"`, which is what makes it a real check.