### PR TITLE
Mark `splice-domain` Helm chart as deprecated

### DIFF
--- a/cluster/helm/splice-domain/Chart-template.yaml
+++ b/cluster/helm/splice-domain/Chart-template.yaml
@@ -8,6 +8,7 @@ name: splice-domain
 type: application
 version: VERSION_NUMBER
 appVersion: VERSION_NUMBER
+deprecated: true
 
 description: Splice Domain
 

--- a/cluster/helm/splice-domain/Chart-template.yaml
+++ b/cluster/helm/splice-domain/Chart-template.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This Helm Chart is DEPRECATED and scheduled for removal.
+
 apiVersion: v2
 name: splice-domain
 type: application

--- a/cluster/helm/splice-domain/templates/NOTES.txt
+++ b/cluster/helm/splice-domain/templates/NOTES.txt
@@ -1,1 +1,3 @@
 Splice Ledger Domain
+
+This Helm Chart is DEPRECATED and scheduled for removal.

--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This Helm Chart is DEPRECATED and scheduled for removal.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/helm/splice-domain/templates/required.yaml
+++ b/cluster/helm/splice-domain/templates/required.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This Helm Chart is DEPRECATED and scheduled for removal.
+
 {{ $_ := required ".Release.Name is required." .Release.Name }}
 {{ $_ := required ".Release.Namespace is required." .Release.Namespace }}
 

--- a/cluster/helm/splice-domain/tests/synchronizer_test.yaml
+++ b/cluster/helm/splice-domain/tests/synchronizer_test.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This Helm Chart is DEPRECATED and scheduled for removal.
+
 suite: "Domain values"
 templates:
   - domain.yaml

--- a/cluster/helm/splice-domain/values-template.yaml
+++ b/cluster/helm/splice-domain/values-template.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# This Helm Chart is DEPRECATED and scheduled for removal.
+
 imageRepo: "ghcr.io/digital-asset/decentralized-canton-sync/docker"
 imageName: "canton-domain"
 initImageName: "postgres:14"

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,16 +7,6 @@
 
 release-notes:: Upcoming
 
-    - Deployment
-
-        - All Splice Helm charts now set ``automountServiceAccountToken: false`` on the pods they
-          deploy. Splice components do not use the Kubernetes API, so pods no longer receive an
-          API-server credential by default; this reduces the impact of a compromised pod in
-          clusters where permissions are bound to the namespace's ``default`` service account.
-          If your deployment relies on the mounted token, for example through a custom service
-          account set via ``serviceAccountName``, you can restore the previous behavior by setting
-          the new ``automountServiceAccountToken`` Helm value to ``true``.
-
     - SV App
 
         - The public ``/v0/dso`` endpoint is deprecated and will be removed in 0.9.0
@@ -85,8 +75,8 @@ release-notes:: Upcoming
 
         - The development fund allocation form now has a ``Mint After`` field, which sets the
           earliest time at which the beneficiary can mint the coupon. While
-          the ``minDevelopmentFundMintingDelay`` stays unset in the ``AmuletConfig``, the field is 
-          optional and the coupons are allocated without a mint-after 
+          the ``minDevelopmentFundMintingDelay`` stays unset in the ``AmuletConfig``, the field is
+          optional and the coupons are allocated without a mint-after
           constraint.
 
         - The development fund coupon list now shows a ``Mint After`` column.
@@ -118,6 +108,16 @@ release-notes:: Upcoming
           operators moving off ``splice-postgres`` to a self-provisioned or managed Postgres, where a
           ``cnadmin`` superuser and a ``cantonnet`` database may not be available to create. The SV
           charts are not covered yet and still use the hardcoded values.
+
+        - All Splice Helm charts now set ``automountServiceAccountToken: false`` on the pods they
+          deploy. Splice components do not use the Kubernetes API, so pods no longer receive an
+          API-server credential by default; this reduces the impact of a compromised pod in
+          clusters where permissions are bound to the namespace's ``default`` service account.
+          If your deployment relies on the mounted token, for example through a custom service
+          account set via ``serviceAccountName``, you can restore the previous behavior by setting
+          the new ``automountServiceAccountToken`` Helm value to ``true``.
+
+        - The (long unused) `splice-domain` Helm chart is deprecated and will be removed in 0.9.0.
 
     - SV UI
 


### PR DESCRIPTION
Will follow up with a PR to 0.9.0 staging that removes it; here it is: https://github.com/canton-network/splice/pull/7073

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
