### PR TITLE
Apply custom istio flow control to internal APIs

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -25,11 +25,17 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
+    flowControl:
       # See https://github.com/DACH-NY/canton-network-internal/issues/4901
       # The values are somewhat arbitrary so more fine tuning may be appropriate.
-      initialStreamWindowSize: 524288        # 512 KiB max per stream
-      initialConnectionWindowSize: 52428800  # 50 MiB max per connection
+      public:
+        initialStreamWindowSize: 524288        # 512 KiB max per stream
+        initialConnectionWindowSize: 52428800  # 50 MiB max per connection
+        ports: [5008, 5010]                    # sequencer public api, canton bft
+      internal:
+        initialStreamWindowSize: 1048576        # 1 MiB max per stream
+        initialConnectionWindowSize: 104857600  # 100 MiB max per connection
+        ports: [5001, 5002, 5007, 5009]         #  ledger API, participant admin API, mediator admin API, sequencer admin API
 # configs specific for the pulumi project
 # will be applied to all the stacks in the project
 pulumiProjectConfig:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -32,9 +32,21 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
-      initialConnectionWindowSize: 52428800
-      initialStreamWindowSize: 524288
+    flowControl:
+      internal:
+        initialConnectionWindowSize: 104857600
+        initialStreamWindowSize: 1048576
+        ports:
+          - 5001
+          - 5002
+          - 5007
+          - 5009
+      public:
+        initialConnectionWindowSize: 52428800
+        initialStreamWindowSize: 524288
+        ports:
+          - 5008
+          - 5010
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -32,9 +32,21 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
-      initialConnectionWindowSize: 52428800
-      initialStreamWindowSize: 524288
+    flowControl:
+      internal:
+        initialConnectionWindowSize: 104857600
+        initialStreamWindowSize: 1048576
+        ports:
+          - 5001
+          - 5002
+          - 5007
+          - 5009
+      public:
+        initialConnectionWindowSize: 52428800
+        initialStreamWindowSize: 524288
+        ports:
+          - 5008
+          - 5010
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -32,9 +32,21 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
-      initialConnectionWindowSize: 52428800
-      initialStreamWindowSize: 524288
+    flowControl:
+      internal:
+        initialConnectionWindowSize: 104857600
+        initialStreamWindowSize: 1048576
+        ports:
+          - 5001
+          - 5002
+          - 5007
+          - 5009
+      public:
+        initialConnectionWindowSize: 52428800
+        initialStreamWindowSize: 524288
+        ports:
+          - 5008
+          - 5010
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -32,9 +32,21 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
-      initialConnectionWindowSize: 52428800
-      initialStreamWindowSize: 524288
+    flowControl:
+      internal:
+        initialConnectionWindowSize: 104857600
+        initialStreamWindowSize: 1048576
+        ports:
+          - 5001
+          - 5002
+          - 5007
+          - 5009
+      public:
+        initialConnectionWindowSize: 52428800
+        initialStreamWindowSize: 524288
+        ports:
+          - 5008
+          - 5010
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -32,9 +32,21 @@ infra:
   istio:
     enableIngressAccessLogging: true
     enablePublicTokenRegistry: true
-    sequencerFlowControl:
-      initialConnectionWindowSize: 52428800
-      initialStreamWindowSize: 524288
+    flowControl:
+      internal:
+        initialConnectionWindowSize: 104857600
+        initialStreamWindowSize: 1048576
+        ports:
+          - 5001
+          - 5002
+          - 5007
+          - 5009
+      public:
+        initialConnectionWindowSize: 52428800
+        initialStreamWindowSize: 524288
+        ports:
+          - 5008
+          - 5010
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2304,7 +2304,7 @@
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "EnvoyFilter",
       "metadata": {
-        "name": "sequencer-flow-control",
+        "name": "flow-control",
         "namespace": "cluster-ingress"
       },
       "spec": {
@@ -2331,8 +2331,8 @@
                       "interval": "30s",
                       "timeout": "5s"
                     },
-                    "initial_connection_window_size": 52428800,
-                    "initial_stream_window_size": 524288
+                    "initial_connection_window_size": 104857600,
+                    "initial_stream_window_size": 1048576
                   }
                 }
               }
@@ -2352,14 +2352,6 @@
                   "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
                     "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
                     "use_downstream_protocol_config": {
-                      "http2_protocol_options": {
-                        "connection_keepalive": {
-                          "interval": "30s",
-                          "timeout": "5s"
-                        },
-                        "initial_connection_window_size": 52428800,
-                        "initial_stream_window_size": 524288
-                      },
                       "http_protocol_options": {}
                     }
                   }
@@ -2381,14 +2373,90 @@
                   "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
                     "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
                     "use_downstream_protocol_config": {
-                      "http2_protocol_options": {
-                        "connection_keepalive": {
-                          "interval": "30s",
-                          "timeout": "5s"
-                        },
-                        "initial_connection_window_size": 52428800,
-                        "initial_stream_window_size": 524288
-                      },
+                      "http_protocol_options": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "applyTo": "CLUSTER",
+            "match": {
+              "cluster": {
+                "portNumber": 5001
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_extension_protocol_options": {
+                  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                    "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                    "use_downstream_protocol_config": {
+                      "http_protocol_options": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "applyTo": "CLUSTER",
+            "match": {
+              "cluster": {
+                "portNumber": 5002
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_extension_protocol_options": {
+                  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                    "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                    "use_downstream_protocol_config": {
+                      "http_protocol_options": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "applyTo": "CLUSTER",
+            "match": {
+              "cluster": {
+                "portNumber": 5007
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_extension_protocol_options": {
+                  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                    "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                    "use_downstream_protocol_config": {
+                      "http_protocol_options": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "applyTo": "CLUSTER",
+            "match": {
+              "cluster": {
+                "portNumber": 5009
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_extension_protocol_options": {
+                  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                    "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                    "use_downstream_protocol_config": {
                       "http_protocol_options": {}
                     }
                   }

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -37,6 +37,11 @@ const CloudArmorConfigSchema = z.object({
     )
     .default({}),
 });
+export const flowControlConfigSchema = z.object({
+  initialStreamWindowSize: z.int(),
+  initialConnectionWindowSize: z.int(),
+  ports: z.array(z.number().int().positive()),
+});
 export const InfraConfigSchema = z.object({
   infra: z.object({
     ipWhitelisting: z
@@ -55,9 +60,11 @@ export const InfraConfigSchema = z.object({
       enablePublicTokenRegistry: z.boolean().default(false),
       enableGeneralIpWhitelist: z.boolean().default(false),
       istiodValues: z.object({}).catchall(z.any()).default({}),
-      sequencerFlowControl: z.object({
-        initialStreamWindowSize: z.int(),
-        initialConnectionWindowSize: z.int(),
+      flowControl: z.object({
+        // public APIs like the sequencer
+        public: flowControlConfigSchema,
+        // internal APIs like the participant
+        internal: flowControlConfigSchema,
       }),
     }),
     enableSweetSecurity: z.boolean().default(false),

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -10,6 +10,7 @@ import {
 import { cometBFTExternalPort } from '@canton-network/splice-pulumi-common-sv/src/synchronizer/cometbftConfig';
 import { rateLimitResponseHeaders } from '@canton-network/splice-pulumi-common/src/ratelimit/rateLimitHeaders';
 import { mergeWith } from 'lodash';
+import { z } from 'zod';
 
 import {
   CLUSTER_HOSTNAME,
@@ -24,7 +25,7 @@ import {
   isDevNet,
   isMainNet,
 } from '../../common';
-import { clusterBasename, infraConfig } from './config';
+import { clusterBasename, flowControlConfigSchema, infraConfig } from './config';
 import { configureIstioGatewayPolicies, installAppWhitelisting } from './whitelisting';
 import { loadInternalWhitelistedIps, loadIPRanges } from './whitelisting/ipRanges';
 import { configurePublicInfo } from './whitelisting/publicInfo';
@@ -730,10 +731,6 @@ function configureSequencerHighPerformanceGrpcDestinationRule(
   });
 }
 
-// Ports of the http2 servers that we apply the upstream flow control config to:
-// the sequencer public API and the sequencer BFT P2P API.
-const sequencerFlowControlUpstreamPorts = [5008, 5010];
-
 // Istio proxies lots of client connections over relatively few connections. If one of the client connections gets stuck
 // (e.g. because the client died) buffers will fill up and eventually istio will stop sending connection-level window updates
 // to the sequencer and trigger netty flow control. This surfaces as requests that send back response headers but then nothing else until the client times out.
@@ -746,17 +743,16 @@ const sequencerFlowControlUpstreamPorts = [5008, 5010];
 function configureSequencerFlowControl(
   ingressNs: k8s.core.v1.Namespace
 ): k8s.apiextensions.CustomResource {
-  const http2ProtocolOptions = {
-    initial_stream_window_size: infraConfig.istio.sequencerFlowControl.initialStreamWindowSize,
-    initial_connection_window_size:
-      infraConfig.istio.sequencerFlowControl.initialConnectionWindowSize,
+  const http2ProtocolOptions = (config: z.infer<typeof flowControlConfigSchema>) => ({
+    initial_stream_window_size: config.initialStreamWindowSize,
+    initial_connection_window_size: config.initialConnectionWindowSize,
     connection_keepalive: {
       interval: '30s',
       timeout: '5s',
     },
-  };
-  // istio -> upstream (aka sequencer)
-  const upstreamPatch = (portNumber: number) => ({
+  });
+  // istio sidecar of upstream -> upstream (e.g. sequencer)
+  const upstreamPatch = (portNumber: number, config: z.infer<typeof flowControlConfigSchema>) => ({
     applyTo: 'CLUSTER',
     match: {
       cluster: {
@@ -784,13 +780,13 @@ function configureSequencerFlowControl(
     apiVersion: 'networking.istio.io/v1alpha3',
     kind: 'EnvoyFilter',
     metadata: {
-      name: 'sequencer-flow-control',
+      name: 'flow-control',
       namespace: ingressNs.metadata.name,
     },
     spec: {
       configPatches: [
         {
-          // downstream (aka participant) -> istio
+          // downstream client (e.g. participant) -> istio sidecar of upstream (e.g. sequencer)
           applyTo: 'NETWORK_FILTER',
           match: {
             context: 'SIDECAR_INBOUND',
@@ -808,12 +804,20 @@ function configureSequencerFlowControl(
               typed_config: {
                 '@type':
                   'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
-                http2_protocol_options: http2ProtocolOptions,
+                // This applies to both internal and public so we apply the more conservative internal limit
+                http2_protocol_options: http2ProtocolOptions(
+                  infraConfig.istio.flowControl.internal
+                ),
               },
             },
           },
         },
-        ...sequencerFlowControlUpstreamPorts.map(upstreamPatch),
+        ...infraConfig.istio.flowControl.public.ports.map(p =>
+          upstreamPatch(p, infraConfig.istio.flowControl.public)
+        ),
+        ...infraConfig.istio.flowControl.internal.ports.map(p =>
+          upstreamPatch(p, infraConfig.istio.flowControl.internal)
+        ),
       ],
     },
   });


### PR DESCRIPTION
[static]

Fixes some issues where we saw slow catchup while also not filling up our buffers which seems to have been caused by connection level flow control kicking in.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
