### PR TITLE
update nginx image

### DIFF
--- a/cluster/images/splice-web-ui/Dockerfile
+++ b/cluster/images/splice-web-ui/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:6616de6eaa82bc2ee3541fa287a8fca7dc7271e6374e9402014dbd13f4a980ae
+FROM nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:7d289d4f8935051d213bc3ecee3b4fc2d52f97ea5a954273e031054b633e7934
 
 USER root
 

--- a/cluster/images/splice-web-ui/Dockerfile
+++ b/cluster/images/splice-web-ui/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:7d289d4f8935051d213bc3ecee3b4fc2d52f97ea5a954273e031054b633e7934
+FROM nginxinc/nginx-unprivileged:1.31.5-alpine-slim@sha256:7d289d4f8935051d213bc3ecee3b4fc2d52f97ea5a954273e031054b633e7934
 
 USER root
 


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/6860
```
trivy image nginxinc/nginx-unprivileged:1.31-alpine-slim@sha256:7d289d4f8935051d213bc3ecee3b4fc2d52f97ea5a954273e031054b633e7934
2026-09-03T12:53:01Z    INFO    [vuln] Vulnerability scanning is enabled
2026-09-03T12:53:01Z    INFO    [secret] Secret scanning is enabled
2026-09-03T12:53:01Z    INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2026-09-03T12:53:01Z    INFO    [secret] Please see https://trivy.dev/docs/v0.74/guide/scanner/secret#recommendation for faster secret detection
2026-09-03T12:53:01Z    INFO    Detected OS     family="alpine" version="3.24.1"
2026-09-03T12:53:01Z    WARN    This OS version is not on the EOL list  family="alpine" version="3.24"
2026-09-03T12:53:01Z    INFO    [alpine] Detecting vulnerabilities...   os_version="3.24" repository="3.24" pkg_num=21
2026-09-03T12:53:01Z    INFO    Number of language-specific files       num=0

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                      Target                                      │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ nginxinc/nginx-unprivileged:1.31-alpine-slim@sha256:7d289d4f8935051d213bc3ecee3- │ alpine │        0        │    -    │
│ b4fc2d52f97ea5a954273e031054b633e7934 (alpine 3.24.1)                            │        │                 │         │
└──────────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected
```
lgtm