### PR TITLE
Helm: Drop dead `sequencer.driver.type: "postgres"` code from `splice-global-domain`

### DIFF
--- a/cluster/helm/splice-global-domain/templates/required.yaml
+++ b/cluster/helm/splice-global-domain/templates/required.yaml
@@ -11,10 +11,7 @@
 {{ $_ := required ".Values.mediator.persistence.host  is required." .Values.mediator.persistence.host }}
 {{ $_ := required ".Values.mediator.persistence.secretName  is required" .Values.mediator.persistence.secretName }}
 {{ $_ := required ".Values.sequencer.driver.type is required." (.Values.sequencer.driver).type }}
-{{- if eq .Values.sequencer.driver.type "postgres"}}
-{{ $_ := required ".Values.sequencer.driver.address is required." (.Values.sequencer.driver).address }}
-{{ $_ := required ".Values.sequencer.driver.password is required." (.Values.sequencer.driver).password }}
-{{- else if eq .Values.sequencer.driver.type "cometbft"}}
+{{- if eq .Values.sequencer.driver.type "cometbft"}}
 {{ $_ := required ".Values.sequencer.driver.host is required." (.Values.sequencer.driver).host }}
 {{ $_ := required ".Values.sequencer.driver.port is required." (.Values.sequencer.driver).port }}
   {{- else if eq .Values.sequencer.driver.type "cantonbft"}}

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -71,31 +71,7 @@ spec:
             - name: CANTON_SEQUENCER_POSTGRES_DB
               value: {{ .Values.sequencer.persistence.databaseName }}
         {{- end }}
-        {{- if eq .Values.sequencer.driver.type "postgres"}}
-            - name: ADDITIONAL_CONFIG_SEQUENCER_DRIVER_REFERENCE
-              value: |
-                canton.sequencers.sequencer.sequencer {
-                  config {
-                    storage = ${_storage}
-                    storage.config.properties.serverName = ${?SEQUENCER_DRIVER_DATABASE_ADDRESS}
-                    storage.config.properties.password = ${?SEQUENCER_DRIVER_DATABASE_PASSWORD}
-                    storage.config.properties.currentSchema = "sequencer_driver"
-                    storage.config.properties.databaseName = ${?CANTON_SEQUENCER_POSTGRES_DB}
-                  }
-                  type = "reference"
-                }
-            - name: SEQUENCER_DRIVER_DATABASE_ADDRESS
-              value: {{ .Values.sequencer.driver.address }}
-            - name: SEQUENCER_DRIVER_DATABASE_PASSWORD
-              {{- if ((.Values.sequencer.persistence).secretOverrides).postgresPassword }}
-              value: {{ .Values.sequencer.persistence.secretOverrides.postgresPassword | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.sequencer.persistence.secretName }}
-                  key: postgresPassword
-            {{- end }}
-        {{- else if eq .Values.sequencer.driver.type "cometbft"}}
+        {{- if eq .Values.sequencer.driver.type "cometbft"}}
             - name: ADDITIONAL_CONFIG_SEQUENCER_DRIVER_COMETBFT
               value: |
                 canton.sequencers.sequencer.sequencer {

--- a/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
@@ -353,28 +353,6 @@ tests:
           path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].image
           value: "secure-registry.example.com/postgres:14-driver"
 
-  - it: "allows overriding sequencer base database password with raw strings"
-    set:
-      sequencer.driver.type: "postgres"
-      sequencer.driver.address: "mock-driver-address"
-      sequencer.persistence.secretOverrides.postgresPassword: "vault:kv/data/sequencer/postgres-password"
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='CANTON_DOMAIN_POSTGRES_PASSWORD')].value
-          pattern: "vault:kv/data/sequencer/postgres-password"
-      - matchRegex:
-          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='SEQUENCER_DRIVER_DATABASE_PASSWORD')].value
-          pattern: "vault:kv/data/sequencer/postgres-password"
-      - matchRegex:
-          path: spec.template.spec.initContainers[?(@.name=='pg-init')].env[?(@.name=='PGPASSWORD')].value
-          pattern: "vault:kv/data/sequencer/postgres-password"
-      - notExists:
-          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.valueFrom.secretKeyRef)]
-
-
   - it: "allows overriding bft driver database password with raw strings"
     set:
       sequencer.driver.type: "cantonbft"

--- a/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
@@ -353,6 +353,25 @@ tests:
           path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].image
           value: "secure-registry.example.com/postgres:14-driver"
 
+  - it: "allows overriding sequencer base database password with raw strings"
+    set:
+      sequencer.driver.type: "cantonbft"
+      sequencer.driver.address: "mock-driver-address"
+      sequencer.persistence.secretOverrides.postgresPassword: "vault:kv/data/sequencer/postgres-password"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='CANTON_DOMAIN_POSTGRES_PASSWORD')].value
+          pattern: "vault:kv/data/sequencer/postgres-password"
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=='pg-init')].env[?(@.name=='PGPASSWORD')].value
+          pattern: "vault:kv/data/sequencer/postgres-password"
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.valueFrom.secretKeyRef)]
+
+
   - it: "allows overriding bft driver database password with raw strings"
     set:
       sequencer.driver.type: "cantonbft"


### PR DESCRIPTION
Not even going to mention in release notes, because it's broken anyway.

Some context here: https://github.com/DACH-NY/canton/pull/35367#discussion_r3903229558

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
