### PR TITLE
make party allocator version configurable

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -448,6 +448,7 @@ validators:
       parallelism: 321
       preapprovalRetries: 9876
       preapprovalRetryDelayMs: 42
+      version: '1.2.3'
     participantPruningSchedule:
       cron: "0 /10 * * * ?" # Run every 10min
       maxDuration: "5m"

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -572,7 +572,7 @@
           }
         ]
       },
-      "version": "0.3.20"
+      "version": "1.2.3"
     },
     "name": "validator-party-allocator",
     "provider": "",

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -8,6 +8,7 @@ import {
   LogLevelSchema,
 } from '@canton-network/splice-pulumi-common/src/config';
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
+import { CnChartVersionSchema } from '@canton-network/splice-pulumi-common/src/config/versionSchema';
 import { z } from 'zod';
 
 export const SynchronizerConfigSchema = z.union([
@@ -128,6 +129,7 @@ export const PartyAllocatorConfigSchema = z.object({
   preapprovalRetries: z.number().default(120),
   preapprovalRetryDelayMs: z.number().default(1000),
   pvcSize: z.string().optional(),
+  version: CnChartVersionSchema.optional(),
 });
 export type PartyAllocatorConfig = z.infer<typeof PartyAllocatorConfigSchema>;
 

--- a/cluster/pulumi/validator-runbook/src/partyAllocator.ts
+++ b/cluster/pulumi/validator-runbook/src/partyAllocator.ts
@@ -53,7 +53,7 @@ export function installPartyAllocator(
         name: 'party-allocator-keys-hd-pvc',
       },
     },
-    activeVersion,
+    config.version || activeVersion,
     { dependsOn }
   );
 }


### PR DESCRIPTION
[static]

That should allow us to apply
https://github.com/canton-network/splice/pull/7120 properly on devnet before the next release.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
