### PR TITLE
fix(ci): anchor release-line branch check to prevent TODO/FIXME check…

### DIFF
--- a/scripts/todo/src/checkTodos.sc
+++ b/scripts/todo/src/checkTodos.sc
@@ -31,8 +31,18 @@ val baseBranch = {
   }
 }
 val runningInCI = sys.env.contains("CI")
-val releaseLineStr = "release-line"
-val onReleaseLine = baseBranch.exists(_.contains(releaseLineStr)) || branch.contains(releaseLineStr)
+// Release-line branches follow the naming convention `release-line-<major>.<minor>.<patch>`
+// matching the exact contents of the LATEST_RELEASE file (e.g. release-line-0.8.0).
+// See .github/actions/scripts/common_setup.sh, which fetches
+// `refs/heads/release-line-${latest_release}` with no fallback and hard-fails
+// if that exact branch does not exist. Matching must be exact/anchored:
+// a substring check (previously `.contains("release-line")`) would let a PR
+// fully bypass the TODO/FIXME checker (including FIXMEs, which are otherwise
+// hard-blocked) just by naming its branch e.g. `feature/release-line-bypass`.
+val releaseLineRegex = "^release-line-[0-9]+\\.[0-9]+\\.[0-9]+$".r
+val onReleaseLine =
+  baseBranch.exists(b => releaseLineRegex.matches(b.strip())) ||
+    releaseLineRegex.matches(branch)
 val disableTodoChecker = onReleaseLine && runningInCI
 
 if (disableTodoChecker) {

--- a/scripts/todo/src/checkTodos.sc
+++ b/scripts/todo/src/checkTodos.sc
@@ -31,14 +31,6 @@ val baseBranch = {
   }
 }
 val runningInCI = sys.env.contains("CI")
-// Release-line branches follow the naming convention `release-line-<major>.<minor>.<patch>`
-// matching the exact contents of the LATEST_RELEASE file (e.g. release-line-0.8.0).
-// See .github/actions/scripts/common_setup.sh, which fetches
-// `refs/heads/release-line-${latest_release}` with no fallback and hard-fails
-// if that exact branch does not exist. Matching must be exact/anchored:
-// a substring check (previously `.contains("release-line")`) would let a PR
-// fully bypass the TODO/FIXME checker (including FIXMEs, which are otherwise
-// hard-blocked) just by naming its branch e.g. `feature/release-line-bypass`.
 val releaseLineRegex = "^release-line-[0-9]+\\.[0-9]+\\.[0-9]+$".r
 val onReleaseLine =
   baseBranch.exists(b => releaseLineRegex.matches(b.strip())) ||


### PR DESCRIPTION
Fixed a bug where the TODO/FIXME checker used a substring check (.contains("release-line")) to detect release-line branches, allowing any branch whose name merely contained that text (e.g. feature/release-line-bypass) to fully skip the checker, including hard-blocked FIXMEs. Replaced it with an anchored regex matching the actual release-line-<major>.<minor>.<patch> naming convention (confirmed via LATEST_RELEASE and common_setup.sh), so only real release-line branches bypass the check.