### PR TITLE
Update `check-daml-warts.sh` to handle end-of-line comments

### DIFF
--- a/scripts/check-daml-warts.sh
+++ b/scripts/check-daml-warts.sh
@@ -27,8 +27,10 @@ for ignored_file in "${ignored_files[@]}"; do
   command+=(":!$ignored_file")
 done
 
-## Ignore matches of comment lines
-ignore_comments=('grep' '-v' '-E' '^.*\.daml:[0-9]*:\s*--')
+## Ignore matches that appear inside Daml comments
+## The negative lookahead '(?:(?!--).)*' makes sure no '--' comes before the match
+## so we skip both full comment lines and end-of-line comments
+ignore_comments=('grep' '-P' '^(?:(?!--).)*(exercise.*_Fetch|fetch|archive)\b')
 
 
 if "${command[@]}" | "${ignore_comments[@]}" &> /dev/null ; then

--- a/scripts/check-daml-warts.sh
+++ b/scripts/check-daml-warts.sh
@@ -21,7 +21,8 @@ ignored_files=(
   'daml/splice-util-batched-markers/'
   'canton/')
 
-command=('git' 'grep' '-n' -E '(exercise.*_Fetch|fetch|archive)\b' '--' '*.daml')
+fetch_archive_pattern='(exercise.*_Fetch|fetch|archive)\b'
+command=('git' 'grep' '-n' -E "$fetch_archive_pattern" '--' '*.daml')
 echo "${command[@]}"
 for ignored_file in "${ignored_files[@]}"; do
   command+=(":!$ignored_file")
@@ -30,7 +31,7 @@ done
 ## Ignore matches that appear inside Daml comments
 ## The negative lookahead '(?:(?!--).)*' makes sure no '--' comes before the match
 ## so we skip both full comment lines and end-of-line comments
-ignore_comments=('grep' '-P' '^(?:(?!--).)*(exercise.*_Fetch|fetch|archive)\b')
+ignore_comments=('grep' '-P' '^(?:(?!--).)*'"$fetch_archive_pattern")
 
 
 if "${command[@]}" | "${ignore_comments[@]}" &> /dev/null ; then


### PR DESCRIPTION
Fixes #7126

This was merged in a feature fork in https://github.com/canton-network/splice-sv-fa-locking/pull/21 but it's worth having upstream as well.

This is necessary to unblock additional commits that build off of `locking/m1`. Otherwise the pre-commit hooks flag [this line](https://github.com/canton-network/splice-sv-fa-locking/blob/locking/m1/daml/splice-amulet/daml/Splice/GovernanceLock.daml#L134) since it contains the word `archive` in a comment.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
