### PR TITLE
Remove ANSI escape codes when checking sbt output

### DIFF
--- a/.github/actions/scripts/check-sbt-output.sh
+++ b/.github/actions/scripts/check-sbt-output.sh
@@ -23,7 +23,7 @@ SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 source "$SRCDIR"/io-utils.sh
 
 read_sbt_output() {
-  grep -v -E "$@" "$SBT_OUTPUT_FILE"
+  sed $'s/\e\\[[0-9;]*m//g' "$SBT_OUTPUT_FILE" | grep -v -E "$@"
 }
 
 filter_errors() {

--- a/project/ignore-patterns/sbt-output.ignore.txt
+++ b/project/ignore-patterns/sbt-output.ignore.txt
@@ -70,7 +70,7 @@ npm error
 .*o.o.codegen.TemplateManager - writing file .*JsCantonError.ts
 
 # Output by guardrail if the yaml file changes because we cache the previous generated code
-^.\[31mWarning:.\[0m$
+^Warning:$
 .*contained different content than was expected.*
 
 # This suffix is used to mark ignored errors reported by check-logs.sh as part of our sbt build.


### PR DESCRIPTION
This fixes an issue seen in https://github.com/canton-network/splice/pull/7175#issuecomment-5585786274 where the text of the problematic sbt output matches one of the regexes in `sbt-output.ignore.txt`, but the ANSI escape codes in the output aren't matched by `.*` in the regex. Removing the ANSI escape codes before checking the output allows all the regexes to match as-is and lets us keep `sbt-output.ignore.txt` ignorant of the escapes.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
