### PR TITLE
Docker mirror: move cache fix to the right place...

### DIFF
--- a/cluster/pulumi/gha/src/dockerMirror.ts
+++ b/cluster/pulumi/gha/src/dockerMirror.ts
@@ -55,16 +55,16 @@ export function installDockerRegistryMirror(): k8s.helm.v3.Release {
           size: '20Gi',
         },
         configData: {
-          // Protection against https://github.com/distribution/distribution/issues/2966
-          cache: {
-            blobdescriptor: '',
-          },
-          // Enable blob/manifest deletion so the proxy's built-in TTL-based
-          // scheduler can remove expired cached content.
-          // See: https://distribution.github.io/distribution/recipes/mirror/
           storage: {
+            // Enable blob/manifest deletion so the proxy's built-in TTL-based
+            // scheduler can remove expired cached content.
+            // See: https://distribution.github.io/distribution/recipes/mirror/
             delete: {
               enabled: true,
+            },
+            // Protection against https://github.com/distribution/distribution/issues/2966
+            cache: {
+              blobdescriptor: '',
             },
           },
         },


### PR DESCRIPTION
Follow-up to #7148 ... so part of DACH-NY/canton-network-internal#4580

Yes I should be fired for not noticing this during my testing...

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
