### PR TITLE
Ingest `VestingLocks` in `SvDsoStore`

### DIFF
--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
@@ -30,6 +30,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.{
   expiry as expiryCodegen,
   externalpartyamuletrules as externalpartyamuletrulesCodegen,
   fees as feesCodegen,
+  governancelock as governancelockCodegen,
   round as roundCodegen,
   schedule as scheduleCodegen,
   validatorlicense as validatorLicenseCodegen,
@@ -501,6 +502,54 @@ abstract class StoreTestBase
       payload = template,
     )
   }
+
+  protected def governanceLock(
+      owner: PartyId,
+      amount: BigDecimal,
+      dso: PartyId = dsoParty,
+      svName: String = "sv1",
+      contractId: String = nextCid(),
+  ): Contract[
+    governancelockCodegen.GovernanceLock.ContractId,
+    governancelockCodegen.GovernanceLock,
+  ] =
+    contract(
+      identifier = governancelockCodegen.GovernanceLock.TEMPLATE_ID_WITH_PACKAGE_ID,
+      contractId = new governancelockCodegen.GovernanceLock.ContractId(contractId),
+      payload = new governancelockCodegen.GovernanceLock(
+        dso.toProtoPrimitive,
+        owner.toProtoPrimitive,
+        amount.bigDecimal,
+        new LockedAmulet.ContractId(nextCid()),
+        new governancelockCodegen.GovernanceLockSpecification(
+          new governancelockCodegen.governancelockkind.GLK_SuperValidatorRightsOwner(svName)
+        ),
+      ),
+    )
+
+  protected def vestingLock(
+      owner: PartyId,
+      vestingAmount: BigDecimal,
+      endTime: Instant,
+      dso: PartyId = dsoParty,
+      svName: String = "sv1",
+      contractId: String = nextCid(),
+  ): Contract[governancelockCodegen.VestingLock.ContractId, governancelockCodegen.VestingLock] =
+    contract(
+      identifier = governancelockCodegen.VestingLock.TEMPLATE_ID_WITH_PACKAGE_ID,
+      contractId = new governancelockCodegen.VestingLock.ContractId(contractId),
+      payload = new governancelockCodegen.VestingLock(
+        dso.toProtoPrimitive,
+        owner.toProtoPrimitive,
+        new LockedAmulet.ContractId(nextCid()),
+        new RelTime(1_000_000),
+        endTime,
+        vestingAmount.bigDecimal,
+        new governancelockCodegen.VestingLockSpecification(
+          new governancelockCodegen.governancelockkind.GLK_SuperValidatorRightsOwner(svName)
+        ),
+      ),
+    )
 
   protected def appRewardCoupon(
       round: Int,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanStore.scala
@@ -478,6 +478,16 @@ object ScanStore {
               Some(Timestamp.assertFromInstant(contract.payload.transfer.executeBefore)),
           )
         },
+        mkFilter(splice.governancelock.GovernanceLock.COMPANION)(co => co.payload.dso == dso)(
+          ScanAcsStoreRowData(_)
+        ),
+        mkFilter(splice.governancelock.VestingLock.COMPANION)(co => co.payload.dso == dso) {
+          contract =>
+            ScanAcsStoreRowData(
+              contract = contract,
+              contractExpiresAt = Some(Timestamp.assertFromInstant(contract.payload.endTime)),
+            )
+        },
         mkFilter(splice.externalpartyconfigstate.ExternalPartyConfigState.COMPANION)(
           co => co.payload.dso == dso,
           versionGuard = { case (pkgVersionSupport, now) =>

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
@@ -191,6 +191,43 @@ abstract class ScanStoreTest
       }
     }
 
+    "ingest GovernanceLocks of the DSO and skip those of other parties" in {
+      val wanted = governanceLock(userParty(1), amount = BigDecimal(10))
+      val unwanted = governanceLock(userParty(2), amount = BigDecimal(20), dso = userParty(3))
+      for {
+        store <- mkStore()
+        _ <- dummyDomain.create(wanted)(store.multiDomainAcsStore)
+        _ <- dummyDomain.create(unwanted)(store.multiDomainAcsStore)
+        result <- store.multiDomainAcsStore.listContracts(
+          splice.governancelock.GovernanceLock.COMPANION
+        )
+      } yield {
+        result.map(_.contractId) should contain theSameElementsAs Seq(wanted.contractId)
+      }
+    }
+
+    "ingest VestingLocks of the DSO and skip those of other parties" in {
+      val endTime = Instant.now().plusSeconds(3600).truncatedTo(ChronoUnit.MICROS)
+      val wanted = vestingLock(userParty(1), vestingAmount = BigDecimal(10), endTime = endTime)
+      val unwanted =
+        vestingLock(
+          userParty(2),
+          vestingAmount = BigDecimal(20),
+          endTime = endTime,
+          dso = userParty(3),
+        )
+      for {
+        store <- mkStore()
+        _ <- dummyDomain.create(wanted)(store.multiDomainAcsStore)
+        _ <- dummyDomain.create(unwanted)(store.multiDomainAcsStore)
+        result <- store.multiDomainAcsStore.listContracts(
+          splice.governancelock.VestingLock.COMPANION
+        )
+      } yield {
+        result.map(_.contractId) should contain theSameElementsAs Seq(wanted.contractId)
+      }
+    }
+
     "lookupTransferPreapprovalByParty" should {
       "return the TransferPreapproval contract signed by the specified party if available" in {
         val wanted = transferPreapproval(userParty(1), providerParty(1), time(0), time(1))

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
@@ -753,6 +753,12 @@ trait SvDsoStore
       : ListExpiredContracts[so.SvOnboardingConfirmed.ContractId, so.SvOnboardingConfirmed] =
     multiDomainAcsStore.listExpiredFromPayloadExpiry(so.SvOnboardingConfirmed.COMPANION)
 
+  def listExpiredVestingLocks: ListExpiredContracts[
+    splice.governancelock.VestingLock.ContractId,
+    splice.governancelock.VestingLock,
+  ] =
+    multiDomainAcsStore.listExpiredFromPayloadExpiry(splice.governancelock.VestingLock.COMPANION)
+
   def listExpiredAnsEntries(ignoredPartiesStore: Option[IgnoredPartiesStore]): ListExpiredContracts[
     splice.ans.AnsEntry.ContractId,
     splice.ans.AnsEntry,
@@ -1662,6 +1668,13 @@ object SvDsoStore {
           contract,
           contractExpiresAt = Some(Timestamp.assertFromInstant(contract.payload.expiresAt)),
         )
+      },
+      mkFilter(splice.governancelock.VestingLock.COMPANION)(co => co.payload.dso == dso) {
+        contract =>
+          DsoAcsStoreRowData(
+            contract,
+            contractExpiresAt = Some(Timestamp.assertFromInstant(contract.payload.endTime)),
+          )
       },
     )
 

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
@@ -153,6 +153,47 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
         QueryResult(acsOffset, _)
       )
     )
+    "listExpiredVestingLocks" should {
+
+      "return locks past their endTime, and never those of another DSO" in {
+        val dsoLock =
+          vestingLock(userParty(1), vestingAmount = BigDecimal(10), endTime = time(2).toInstant)
+        val laterDsoLock =
+          vestingLock(userParty(2), vestingAmount = BigDecimal(20), endTime = time(4).toInstant)
+        // 'dso' party of 'otherDsoLock' is different than the one used in
+        // 'mkStore()' below. Thus, 'otherDsoLock' should never be ingested and
+        // must not be discoverable using listExpiredVestingLocks even than time
+        // is greater than 'otherDsoLock(endTime)'.
+        val otherDsoLock = vestingLock(
+          userParty(3),
+          vestingAmount = BigDecimal(30),
+          endTime = time(2).toInstant,
+          dso = userParty(4),
+        )
+        for {
+          store <- mkStore()
+          _ <- MonadUtil.sequentialTraverse(Seq(dsoLock, laterDsoLock, otherDsoLock))(
+            dummyDomain.create(_)(store.multiDomainAcsStore)
+          )
+        } yield {
+          def cidsAt(t: CantonTimestamp) = store
+            .listExpiredVestingLocks(t, PageLimit.tryCreate(10))(TraceContext.empty)
+            .futureValue
+            .map(_.contract.contractId)
+
+          cidsAt(time(1)) should be(empty)
+          // 'contract_expires_at < now' is strict: a lock is not expired at its own endTime.
+          cidsAt(time(2)) should be(empty)
+          cidsAt(time(3)) should contain theSameElementsAs Seq(dsoLock.contractId)
+          cidsAt(time(5)) should contain theSameElementsAs Seq(
+            dsoLock.contractId,
+            laterDsoLock.contractId,
+          )
+        }
+      }
+
+    }
+
     "lookupSvOnboardingConfirmedByParty" should {
       offsetFreeLookupTest(
         create = svOnboardingConfirmed("good", userParty(1), "good-pid"),

--- a/daml/splice-amulet-test/daml/Splice/Scripts/TestGovernanceLocks.daml
+++ b/daml/splice-amulet-test/daml/Splice/Scripts/TestGovernanceLocks.daml
@@ -1,0 +1,215 @@
+module Splice.Scripts.TestGovernanceLocks where
+
+import DA.Action (unless)
+import DA.List.Total
+import DA.Time
+
+import Daml.Script
+import Splice.Amulet
+import Splice.AmuletRules
+import Splice.Api.Token.HoldingV2 qualified as V2
+import Splice.ExternalPartyAmuletRules
+import Splice.ExternalPartyConfigState
+import Splice.GovernanceLock
+import Splice.Scripts.TokenStandard.TestAmuletTokenStandardTestEnv
+import Splice.Testing.Registries.AmuletRegistryV2 qualified as AmuletRegistryV2
+import Splice.Testing.TokenStandard.WalletClientV2 qualified as WalletClientV2
+import Splice.Testing.Utils
+import Splice.TokenStandard.Utils
+
+
+testGovernanceLockHappyPath : Script ()
+testGovernanceLockHappyPath = do
+  env@TestEnv{..} <- setupTest
+
+  let someSvSpec = GovernanceLockSpecification with
+        kind = GLK_SuperValidatorRightsOwner "TestSV"
+
+  AmuletRegistryV2.tapFaucet registriesEnv.amuletV2 alice 180000.0
+  AmuletRegistryV2.tapFaucet registriesEnv.amuletV2 bob 10000.0
+
+  aliceLock <- governanceLockRawChoice env alice 180000.0 someSvSpec
+
+  _bobLock <- governanceLockRawChoice env bob 10000.0 someSvSpec
+
+  now <- getTime
+
+  -- Check that negative allocations are impossible
+  actionMustFail (expectMessageContains "The requirement 'Amount is positive' was not met.") $
+    governanceLockRawChoice' env bob (-10000.0) someSvSpec
+
+  -- Check that we can't unlock with a time in the past
+  actionMustFail (expectMessageContains "Ledger time is at or past deadline 'unlockAt' at") $
+    governanceUnlockRawChoice' env aliceLock (Some 80000.0) (now `addRelTime` days (-60)) [alice]
+
+  -- Check that bob can't unlock for alice - TODO: disclose to bob with explicit disclosure for this.
+  -- actionMustFail (expectMessageContains "noodle") $ governanceUnlockRawChoice' env aliceLock (Some 80000.0) now [bob]
+
+  let unlockTime = now `addRelTime` days 1
+
+  -- Unlock 80k Amulet such that 1/8th should result in 10k Amulet withdrawable after 1/8th year.
+  (aliceVesting, Some aliceLock) <- governanceUnlockRawChoice env aliceLock (Some 80000.0) (unlockTime) [alice]
+
+  actionMustFail (expectMessageContains "'unlockAmount' is not greater than 'zero'") $
+    governanceUnlockRawChoice' env aliceLock (Some $ -80000.0) (unlockTime) [alice]
+
+  -- Assert that we have a lock remaining of 100k Amulet.
+  checkLockedHolding alice aliceLock 100000.0
+
+  -- Check that we can't withdraw immediately, before unlockTime has arrived on-ledger
+  actionMustFail (expectMessageContains "Ledger time is strictly before deadline 'requestedAt' at") $
+    vestingWithdrawRawChoice' env aliceVesting unlockTime [alice]
+
+  passTime (hours 12)
+  now <- getTime
+
+  -- Check that we can't withdraw between now and the unlockTime
+  actionMustFail (expectMessageContains "'withdraw amount' is not greater than 'zero'") $
+    vestingWithdrawRawChoice' env aliceVesting now [alice]
+
+  passTime (days 1)
+
+  -- Check that we can't withdraw exactly at the unlock time (nothing is vested yet).
+  actionMustFail (expectMessageContains "'withdraw amount' is not greater than 'zero'") $
+    vestingWithdrawRawChoice' env aliceVesting (unlockTime) [alice]
+
+  passTime (days 47)
+
+  -- Chosen to be exactly 1/8th of the specified 365.25 year.
+  -- 1/8th and 80k are reliably exactly representible in fixed-point binary
+  -- with at least three fractional places, so the arithmetic is exact and we can
+  -- comfortably use equality.
+
+  let withdrawTime = unlockTime `addRelTime` (days 45 + hours 15 + minutes 45)
+
+  (unlocked, Some newVestingLock) <- vestingWithdrawRawChoice env aliceVesting withdrawTime [alice]
+
+  actionMustFail (expectMessageContains "'withdraw amount' is not greater than 'zero'") $
+    vestingWithdrawRawChoice' env newVestingLock withdrawTime [alice]
+
+  -- Check that we did indeed unlock 10k amulet as expected - 1/8th of the total vesting amount of 80k.
+  checkHolding' alice unlocked 10000.0
+
+  -- And check that we remain with 7/8ths of the vesting amount - 70k.
+  checkLockedHolding alice newVestingLock 70000.0
+
+  passTime (days 365)
+
+  let fullWithdrawTime = unlockTime `addRelTime` days 366
+
+  (unlockedHolding2, None) <- vestingWithdrawRawChoice env newVestingLock fullWithdrawTime [alice]
+
+  -- Check that we withdrew all and exactly the 70k _remaining_ after the above withdrawal.
+  checkHolding' alice unlockedHolding2 70000.0
+  checkIsUnlocked alice unlockedHolding2
+
+
+-- | Polymorphic checkHolding, to avoid repeated toInterfaceContractId when we have a LockedAmulet or Amulet ContractId.
+checkHolding' : Implements a V2.Holding => Party -> ContractId a -> Decimal -> Script ()
+checkHolding' party holding amount = WalletClientV2.checkHolding party (toInterfaceContractId holding) amount
+
+checkIsUnlocked : (Implements a V2.Holding) => Party -> ContractId a -> Script ()
+checkIsUnlocked p holdingCid = do
+  holdingO <- queryInterfaceContractId p $ toInterfaceContractId @V2.Holding holdingCid
+  now <- getTime
+  let holding = case holdingO of
+        None -> error $ "Holding " <> show holdingCid <> " was not found"
+        Some holding -> holding
+  unless (WalletClientV2.isUnlocked now holding.lock) $ fail $ "Holding " <> show holding <> " is not unlocked"
+
+-- | Find the holding for a GovernanceLock or VestingLock, and check that it has the correct amount.
+checkLockedHolding
+  :  (Template t, HasEnsure t, HasField "lockedAmulet" t (ContractId LockedAmulet))
+  => Party
+  -> ContractId t
+  -> Decimal
+  -> Script ()
+checkLockedHolding p lockCid amount = do
+  Some lock <- queryContractId p lockCid
+  checkHolding' p lock.lockedAmulet amount
+
+getExternalPartyTransferContext : Party -> Script (ExternalPartyTransferContext, Disclosures')
+getExternalPartyTransferContext dso = do
+  extPartyConfigs <- query @ExternalPartyConfigState dso
+  let (externalPartyConfigState, _) = case maximumOn (\(_, c) -> c.targetArchiveAfter) extPartyConfigs of
+        None -> error "No ExternalPartyConfigState found: have you initialized the Amulet registry?"
+        Some c -> c
+  ecDD <- queryDisclosure' @ExternalPartyConfigState dso externalPartyConfigState
+  let eptc = ExternalPartyTransferContext with externalPartyConfigState; featuredAppRight = None
+  pure (eptc, ecDD)
+
+
+-- | a couple helpers to make the raw choice implementations easier to write
+submitWithTransferContext : TestEnv -> SubmitOptions -> (ExternalPartyTransferContext -> Commands a) -> Script (Either SubmitError a)
+submitWithTransferContext env options commands = do
+  let dso = env.instrId.admin
+  (context, disclosures) <- getExternalPartyTransferContext dso
+  trySubmit (options <> discloseMany' disclosures) $ commands context
+
+errorIfLeft : (Show e, CanAssert m) => Either e a -> m a
+errorIfLeft (Left e) = assertFail (show e)
+errorIfLeft (Right e) = pure e
+
+governanceLockRawChoice : TestEnv -> Party -> Decimal -> GovernanceLockSpecification -> Script (ContractId GovernanceLock)
+governanceLockRawChoice env owner amount specification = errorIfLeft =<< governanceLockRawChoice' env owner amount specification
+
+governanceLockRawChoice' : TestEnv -> Party -> Decimal -> GovernanceLockSpecification -> Script (Either SubmitError (ContractId GovernanceLock))
+governanceLockRawChoice' env owner amount specification = do
+  let dso = env.instrId.admin
+  [(eparCid, _)] <- query @ExternalPartyAmuletRules dso -- TODO: low priority: determine if there's already a way to call choices on this in the test env.
+  disc <- queryDisclosure' dso eparCid
+  inputs <- WalletClientV2.listUnlockedHoldingCidsFor (basicAccount owner) owner env.instrId
+  result <- submitWithTransferContext env (actAs [owner] <> discloseMany' disc) $
+    \context -> exerciseCmd eparCid ExternalPartyAmuletRules_LockForGovernance with
+      amount
+      inputs = coerceContractId <$> inputs -- These are Amulet and LockedAmulet, but we don't have convenient constraints to show that.
+      specification
+      context
+      owner
+  pure $ (.governanceLock) <$> result
+
+governanceUnlockRawChoice
+  :  TestEnv
+  -> ContractId GovernanceLock
+  -> Optional Decimal
+  -> Time
+  -> [Party]
+  -> Script (ContractId VestingLock, Optional (ContractId GovernanceLock))
+governanceUnlockRawChoice env cid unlockAmount unlockAt actors = errorIfLeft =<< governanceUnlockRawChoice' env cid unlockAmount unlockAt actors
+
+governanceUnlockRawChoice'
+  :  TestEnv
+  -> ContractId GovernanceLock
+  -> Optional Decimal
+  -> Time
+  -> [Party]
+  -> Script (Either SubmitError (ContractId VestingLock, Optional (ContractId GovernanceLock)))
+governanceUnlockRawChoice' env cid unlockAmount unlockAt actors = do
+  result <- submitWithTransferContext env (actAs actors) $ \context -> exerciseCmd cid GovernanceLock_Unlock with
+    unlockAmount
+    context
+    unlockAt
+    actors
+  pure $ ((,) <$> (.vestingLock) <*> (.governanceLock)) <$> result
+
+vestingWithdrawRawChoice
+  :  TestEnv
+  -> ContractId VestingLock
+  -> Time
+  -> [Party]
+  -> Script (ContractId V2.Holding, Optional (ContractId VestingLock))
+vestingWithdrawRawChoice env cid requestedAt actors = errorIfLeft =<< vestingWithdrawRawChoice' env cid requestedAt actors
+
+vestingWithdrawRawChoice'
+  :  TestEnv
+  -> ContractId VestingLock
+  -> Time
+  -> [Party]
+  -> Script (Either SubmitError (ContractId V2.Holding, Optional (ContractId VestingLock)))
+vestingWithdrawRawChoice' env cid requestedAt actors = do
+  result <- submitWithTransferContext env (actAs actors) $ \context -> exerciseCmd cid VestingLock_Withdraw with
+    context
+    requestedAt
+    actors
+  pure $ ((,) <$> upcast . (.vested) <*> (.vestingLock)) <$> result
+

--- a/daml/splice-amulet/daml/Splice/ExternalPartyAmuletRules.daml
+++ b/daml/splice-amulet/daml/Splice/ExternalPartyAmuletRules.daml
@@ -29,6 +29,7 @@ import Splice.AmuletAllocation as AmuletAllocationV1
 import Splice.AmuletAllocationV2 as AmuletAllocationV2
 import Splice.AmuletTransferInstruction
 import Splice.AmuletRules
+import Splice.GovernanceLock
 import Splice.Types
 import Splice.Util
 
@@ -45,6 +46,12 @@ data ExternalPartyAmuletRules_ExpireAmuletAllocationsResult = ExternalPartyAmule
 
 data ExternalPartyAmuletRules_ExpireAmuletAllocationsV2Result = ExternalPartyAmuletRules_ExpireAmuletAllocationsV2Result {}
   -- intentionally no results to save storage space in Scan
+  deriving (Eq, Show, Serializable)
+
+data ExternalPartyAmuletRules_LockForGovernanceResult = ExternalPartyAmuletRules_LockForGovernanceResult
+  with
+    governanceLock : ContractId GovernanceLock
+    changeHolding : Optional (ContractId Amulet)
   deriving (Eq, Show, Serializable)
 
 -- | Rules contract that can be used in transactions that require signatures
@@ -126,6 +133,21 @@ template ExternalPartyAmuletRules
            nonce
            description
          pure (ExternalPartyAmuletRules_CreateTransferCommandResult cmd)
+
+    nonconsuming choice ExternalPartyAmuletRules_LockForGovernance : ExternalPartyAmuletRules_LockForGovernanceResult
+      with
+        amount : Decimal
+        inputs : [ContractId V1.Holding]
+        specification : GovernanceLockSpecification
+        context : ExternalPartyTransferContext
+        owner : Party
+      controller owner
+      do
+        (governanceLock, changeHolding) <- governanceLock_lockForGovernance_impl dso amount inputs specification context owner
+        pure $ ExternalPartyAmuletRules_LockForGovernanceResult with
+          governanceLock
+          changeHolding
+
 
     interface instance Api.Token.TransferInstructionV1.TransferFactory for ExternalPartyAmuletRules where
       view = Api.Token.TransferInstructionV1.TransferFactoryView with

--- a/daml/splice-amulet/daml/Splice/GovernanceLock.daml
+++ b/daml/splice-amulet/daml/Splice/GovernanceLock.daml
@@ -1,0 +1,284 @@
+module Splice.GovernanceLock where
+
+import DA.Assert
+import DA.Optional
+import DA.Time
+
+import Splice.Amulet
+import Splice.Amulet.TwoStepTransfer (holdingToTransferInputs)
+import Splice.AmuletRules
+import Splice.Api.Token.HoldingV1 (Holding)
+import Splice.Api.Token.MetadataV1
+import Splice.Expiry
+import Splice.Fees (relTimeToSeconds)
+import Splice.TokenStandard.Utils hiding (require)
+import Splice.Types
+import Splice.Util
+
+
+data GovernanceLockKind
+  = GLK_FeaturedApp with
+      provider : Party -- ^ Featured app provider party.
+  | GLK_SuperValidatorRightsOwner with
+      svName : Text  -- ^ Name of the SV rights owner for whom the funds are locked.
+  deriving (Eq, Show, Serializable)
+
+-- TODO: add controllers specifications
+data GovernanceLockSpecification
+  = GovernanceLockSpecification with
+      kind : GovernanceLockKind
+  deriving (Eq, Show, Serializable)
+
+data VestingLockSpecification
+  = VestingLockSpecification with
+      kind : GovernanceLockKind
+  deriving (Eq, Show, Serializable)
+
+-- | A lock created to satisfy governance requirements, e.g., locking CC
+-- to retain SV weight or FA rights.
+template GovernanceLock
+  with
+    dso : Party
+    owner : Party  -- ^ Lock owner
+    amount : Decimal  -- ^ Locked amount
+    lockedAmulet : ContractId LockedAmulet
+    specification : GovernanceLockSpecification
+  where
+    signatory dso, owner
+    observer typeExtraObservers specification.kind
+    ensure amount > 0.0
+
+    choice GovernanceLock_Unlock : GovernanceLock_UnlockResult
+      with
+        unlockAmount : Optional Decimal -- ^ Amount to unlock. Defaults to the full amount if not set.
+        unlockAt : Time  -- ^ Time as of which the unlock is to be registered and vesting starts. Must be in the future.
+        context : ExternalPartyTransferContext
+        actors : [Party]
+      controller actors
+      do
+        checkActors actors [[owner]] -- TODO: custom controllers
+        assertWithinDeadline "unlockAt" unlockAt
+
+        let vestingPeriod = vestingDurationFor specification.kind context
+        let endTime = unlockAt `addRelTime` vestingPeriod
+        let specification = governanceToVestingSpecification this.specification
+        let vestingLockProperties = LockProperties with
+              context = describeVestingSpecification specification
+              expiresAt = endTime
+
+        (vestingLockedHolding, governanceLock, vestingAmount) <- case guard (unlockAmount /= Some amount) >> unlockAmount of
+          None -> do -- No split required, relock to change the expireAt and description.
+            newLockedAmulet <- relockAmulet (ForOwner with dso; owner) lockedAmulet vestingLockProperties context
+            pure (newLockedAmulet, None, amount)
+          Some unlockAmount -> do -- Splitting.
+            require' ("unlockAmount", unlockAmount) isGreaterR ("zero", 0.0)
+            require' ("unlockAmount", unlockAmount) isLessR ("amount", amount)
+            (vesting, stillLockedHolding) <- splitLockedAmulet (ForOwner with dso; owner) lockedAmulet (unlockAmount, vestingLockProperties) context
+            governanceLock <- create
+              this with
+                lockedAmulet = stillLockedHolding
+                amount = amount - unlockAmount
+            pure (vesting, Some governanceLock, unlockAmount)
+
+        vestingLock <- create VestingLock with
+          dso
+          owner
+          lockedAmulet = vestingLockedHolding
+          vestingPeriod
+          endTime
+          vestingAmount
+          specification
+
+        pure $ GovernanceLock_UnlockResult with
+          vestingLock
+          governanceLock
+
+  -- TODO: implement V2 Allocation interface on above. Most fields of the view are generated, as they are constants or specific presentations of the above.
+  -- TODO: implement pending V1 transfer for the above, for backwards compatibility.
+  -- TODO: substitution, probably with a loose function for implementation sharing.
+
+data GovernanceLock_UnlockResult
+  = GovernanceLock_UnlockResult with
+      vestingLock : ContractId VestingLock
+      governanceLock : Optional (ContractId GovernanceLock)
+  deriving (Eq, Show, Serializable)
+
+template VestingLock
+  with
+    dso : Party
+    owner : Party
+    lockedAmulet : ContractId LockedAmulet
+    vestingPeriod : RelTime  -- ^ Duration over which the amount vests in a linear fashion.
+    endTime : Time  -- ^ Time at which vesting completes.
+    vestingAmount : Decimal  -- ^ The amount that is vesting.
+    specification : VestingLockSpecification
+  where
+    signatory dso, owner
+    ensure vestingAmount > 0.0 && vestingPeriod >= aunit
+
+    choice VestingLock_Withdraw : VestingLock_WithdrawResult
+      -- ^ Withdraw all funds that have vested since the last withdrawal
+      -- and the time of this request.
+      with
+        requestedAt : Time -- ^ Time to use for determining the funds that have vested. Must be in the past.
+        context : ExternalPartyTransferContext
+        actors : [Party]
+      controller actors
+      do
+        checkActors actors [[owner]] -- TODO: custom controllers
+        assertDeadlineExceeded "requestedAt" requestedAt
+
+        let unvestedAmount = calculateUnvestedAmount requestedAt this
+
+        case unvestedAmount of
+          None -> do -- No split or partial availability, and the holding is already available, so just make a final report and archive.
+            pure VestingLock_WithdrawResult with
+              vestingLock = None
+              vested = toInterfaceContractId lockedAmulet
+          Some stillLockedAmount -> do -- We have a fraction that is not the whole being withdrawn, do a partial unlock.
+            require' ("withdraw amount", vestingAmount - stillLockedAmount) isGreaterR ("zero", 0.0)
+            (locked, unlocked) <- partialUnlock (ForOwner with dso; owner) lockedAmulet stillLockedAmount context
+            vestingLock <- Some <$> create this with
+              lockedAmulet = locked
+              vestingPeriod = endTime `subTime` requestedAt
+              vestingAmount = stillLockedAmount
+            pure VestingLock_WithdrawResult with
+              vestingLock
+              vested = toInterfaceContractId unlocked
+
+  -- TODO: implement V2 Allocation interface on above. Most fields of the view are generated, as they are constants or specific presentations of the above.
+  -- TODO: implement pending V1 transaction for the above, for backwards compatibility.
+  -- TODO: substitution, probably with a loose function for implementation sharing.
+
+data VestingLock_WithdrawResult
+  = VestingLock_WithdrawResult with
+      vestingLock : Optional (ContractId VestingLock)
+        -- ^ Contract ID of the continuing vesting lock with remaining funds.
+      vested : ContractId Holding
+        -- ^ Holding of withdrawn available funds. May be either an Amulet or an expired LockedAmulet if the vesting period has passed. May be already spent in the latter case.
+  deriving (Eq, Show, Serializable)
+
+-- | Uses `None` to represent that no amount remains.
+calculateUnvestedAmount : Time -> VestingLock -> Optional Decimal
+calculateUnvestedAmount currentTime VestingLock{ .. }
+    | currentTime <= (endTime `addRelTime` (- vestingPeriod)) = Some vestingAmount
+    | currentTime >= endTime = None
+    | otherwise = Some $ (vestingAmount * relTimeToSeconds (endTime `subTime` currentTime)) / relTimeToSeconds vestingPeriod
+
+-- | Implementation for the LockForGovernance choice on ExternalPartyAmuletRules and core implementation of token standard v1 and v2 interfaces.
+governanceLock_lockForGovernance_impl
+  : Party
+ -> Decimal
+ -> [ContractId Holding]
+ -> GovernanceLockSpecification
+ -> ExternalPartyTransferContext
+ -> Party
+ -> Update (ContractId GovernanceLock, Optional (ContractId Amulet))
+governanceLock_lockForGovernance_impl dso amount inputs specification context owner = do
+  let lockProperties = LockProperties with
+        context = describeGovernanceSpecification specification
+        expiresAt = maxBound
+  ([lockedAmulet], changeHolding) <- lockAmulet (ForOwner with dso; owner) [(amount, lockProperties)] inputs context
+  governanceLock <- create GovernanceLock with
+    dso
+    owner
+    amount
+    lockedAmulet
+    specification
+  pure $ (governanceLock, changeHolding)
+
+  -- TODO: implement V2 AllocationFactory in terms of above.
+  -- TODO: find and use binding point for "magic address" V1 token standard to above.
+
+typeExtraObservers : GovernanceLockKind -> [Party]
+typeExtraObservers (GLK_FeaturedApp party) = [party]
+typeExtraObservers _ = []
+
+governanceToVestingSpecification : GovernanceLockSpecification -> VestingLockSpecification
+governanceToVestingSpecification GovernanceLockSpecification {..} = VestingLockSpecification {..}
+
+describeGovernanceLockKind : GovernanceLockKind -> Text
+describeGovernanceLockKind (GLK_FeaturedApp with provider) = "Featured App party " <> partyToText provider
+describeGovernanceLockKind (GLK_SuperValidatorRightsOwner with svName) = "SV rights for " <> svName
+
+describeGovernanceSpecification : GovernanceLockSpecification -> Text
+describeGovernanceSpecification lock = "Locked to support " <> describeGovernanceLockKind lock.kind
+
+describeVestingSpecification : VestingLockSpecification -> Text
+describeVestingSpecification lock = "Unlocking from supporting " <> describeGovernanceLockKind lock.kind
+
+-- Lock properties for LockSubject types
+
+-- TODO: make configurable
+vestingDurationFor : GovernanceLockKind -> ExternalPartyTransferContext -> RelTime
+vestingDurationFor (GLK_FeaturedApp _) _ = days 60
+vestingDurationFor (GLK_SuperValidatorRightsOwner _) _ = days 365 + hours 6
+
+-- Helpers for handling LockedAmulet
+-- =================================
+
+-- Invariant: _none_ of these functions move amounts to new parties or modify total amounts of amulet (except when minting from reward coupons).
+
+type LockSpecification = (Decimal, LockProperties)
+data LockProperties = LockProperties with
+  context : Text
+  expiresAt : Time
+
+splitLockedAmulet : ForOwner -> ContractId LockedAmulet -> LockSpecification -> ExternalPartyTransferContext -> Update (ContractId LockedAmulet, ContractId LockedAmulet)
+splitLockedAmulet forOwner lockedAmuletCid amount context = do
+  ([splitLock], remainder) <- multiSplitLockedAmulet forOwner lockedAmuletCid [amount] context
+  pure (splitLock, remainder)
+
+multiSplitLockedAmulet : ForOwner -> ContractId LockedAmulet -> [LockSpecification] -> ExternalPartyTransferContext -> Update ([ContractId LockedAmulet], ContractId LockedAmulet)
+multiSplitLockedAmulet forOwner lockedAmuletCid specs context = do
+  (unlockedCid, (currentAmount, currentLockProps)) <- unlockAmulet forOwner lockedAmuletCid
+  let finalAmount = currentAmount - sum (fst <$> specs)
+  (remainderLock::specifiedLocks, None) <- lockAmulet forOwner ((finalAmount, currentLockProps) :: specs) [toInterfaceContractId unlockedCid] context
+  pure (specifiedLocks, remainderLock)
+
+partialUnlock : ForOwner -> ContractId LockedAmulet -> Decimal -> ExternalPartyTransferContext -> Update (ContractId LockedAmulet, ContractId Amulet)
+partialUnlock forOwner lockedAmuletCid stillLockedAmount context = do
+  (unlockedAmuletCid, (_, lockProps)) <- unlockAmulet forOwner lockedAmuletCid
+  ([newLockedCid], Some unlockedAmulet) <- lockAmulet forOwner [(stillLockedAmount, lockProps)] [toInterfaceContractId $ unlockedAmuletCid] context
+  pure (newLockedCid, unlockedAmulet)
+
+relockAmulet : ForOwner -> ContractId LockedAmulet -> LockProperties -> ExternalPartyTransferContext -> Update (ContractId LockedAmulet)
+relockAmulet forOwner lockedAmuletCid newLockProperties context = do
+  (amuletCid, (currentAmount, _)) <- unlockAmulet forOwner lockedAmuletCid
+  ([newLockedCid], None) <- lockAmulet forOwner [(currentAmount, newLockProperties)] [toInterfaceContractId $ amuletCid] context
+  pure newLockedCid
+
+unlockAmulet : ForOwner -> ContractId LockedAmulet -> Update (ContractId Amulet, LockSpecification)
+unlockAmulet forOwner lockedAmuletCid = do
+  lock <- fetchChecked forOwner lockedAmuletCid
+  unlockResult <- exercise lockedAmuletCid LockedAmulet_UnlockV2
+  return (unlockResult.amuletCid, (lock.amulet.amount.initialAmount, LockProperties with context = fromOptional "governance" lock.lock.optContext; expiresAt = lock.lock.expiresAt))
+
+lockAmulet : ForOwner -> [LockSpecification] -> [ContractId Holding] -> ExternalPartyTransferContext -> Update ([ContractId LockedAmulet], Optional (ContractId Amulet))
+lockAmulet forOwner@ForOwner {..} specs inputHoldingCids context = do
+  -- lock the amulet
+  transferInputs <- holdingToTransferInputs forOwner inputHoldingCids
+  let mkOutput (amount, spec) =
+            TransferOutput with
+              receiver = owner
+              amount = amount
+              receiverFeeRatio = 0.0 -- irrelevant as fees are always zero
+              lock = Some TimeLock with
+                expiresAt = spec.expiresAt -- We don't have any call to isLedgerTimeLE, so we can use the true maxBound here for arbitrary duration.
+                holders = [dso]
+                optContext = Some spec.context
+              meta = Some (reasonToMeta ("lock for " <> spec.context) emptyMetadata)
+  let transfer = Splice.AmuletRules.Transfer with
+        sender = owner
+        provider = owner -- the sender is serving as its own "app provider"
+        outputs = map mkOutput specs
+        inputs = transferInputs
+        beneficiaries = None
+
+  result <- executeExternalPartyTransfer forOwner.dso context transfer
+  let lockedAmulets = (\(TransferResultLockedAmulet lockedAmulet) -> lockedAmulet) <$> result.createdAmulets
+  pure
+    ( lockedAmulets
+    , result.senderChangeAmulet
+    )
+

--- a/scripts/check-daml-warts.sh
+++ b/scripts/check-daml-warts.sh
@@ -27,8 +27,10 @@ for ignored_file in "${ignored_files[@]}"; do
   command+=(":!$ignored_file")
 done
 
-## Ignore matches of comment lines
-ignore_comments=('grep' '-v' '-E' '^.*\.daml:[0-9]*:\s*--')
+## Ignore matches that appear inside Daml comments
+## The negative lookahead '(?:(?!--).)*' makes sure no '--' comes before the match
+## so we skip both full comment lines and end-of-line comments
+ignore_comments=('grep' '-P' '^(?:(?!--).)*(exercise.*_Fetch|fetch|archive)\b')
 
 
 if "${command[@]}" | "${ignore_comments[@]}" &> /dev/null ; then

--- a/token-standard/splice-token-standard-v1-test/daml/Splice/Testing/Utils.daml
+++ b/token-standard/splice-token-standard-v1-test/daml/Splice/Testing/Utils.daml
@@ -14,6 +14,7 @@ module Splice.Testing.Utils
     FailureStatusCheck(..),
     submitMustFail'',
     submitWithDisclosuresMustFail'',
+    actionMustFail,
     expectErrorId,
     expectMessageContains,
     expectUnmetRequirement,
@@ -135,6 +136,16 @@ submitMustFail''
   -> Script ()
 submitMustFail'' check options cmds = do
   result <- trySubmit options cmds
+  checkSubmitFailure check result
+
+-- | Use this to check whether a submitting script fails with the expected 'FailureStatus'
+actionMustFail
+  : Show a
+  => FailureStatusCheck
+  -> Script (Either SubmitError a)
+  -> Script ()
+actionMustFail check action = do
+  result <- action
   checkSubmitFailure check result
 
 -- | Internal helper to validate that a submission failed with the expected 'FailureStatus'.


### PR DESCRIPTION
Also, expose `listExpiredVestingLocks`.

`GovernanceLock` is deliberately not ingested here: unlike Scan, nothing
in the SV app is going to consume it yet---`GovernanceLock`s don't expire.

The test runs the `listExpiredVestingLocks` locks with different `endTime`s
asserting that locks become visible after time becomes greater than their
`endTime`. `otherDsoLock` never becomes visible because only proper `dso` party
locks are ingested.

Fixes [splice#7182](https://github.com/canton-network/splice/issues/7182)

### Tested

```
$ sbt --batch damlDarsLockFileUpdate
...
$ sbt --batch 'apps-sv/testOnly org.lfdecentralizedtrust.splice.store.db.DbSvDsoStoreTest'
...
[info] Total number of tests run: 78
[info] Tests: succeeded 78, failed 0, canceled 0, ignored 0, pending 0
[success] Total time: 242 s (0:04:02.0)
```

#### Negative control

Temporarily edited `SvDsoStore.scala`:

```scala
DsoAcsStoreRowData(
  contract,
  contractExpiresAt = None,   // was Some(Timestamp.assertFromInstant(contract.payload.endTime))
)
```

```
$ sbt --batch 'apps-sv/testOnly org.lfdecentralizedtrust.splice.store.db.DbSvDsoStoreTest -- -z "past their endTime"'
...
[info] - should return locks past their endTime, and never those of another DSO *** FAILED ***
[info]   Vector() did not contain the same elements as List(ContractId(00000...15))
[info]   (SvDsoStoreTest.scala:185)
[info] Tests: succeeded 0, failed 1
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
