### PR TITLE
[ci] Retry the create-secret click in the SV UI preflight

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvUiPreflightIntegrationTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvUiPreflightIntegrationTestUtil.scala
@@ -111,35 +111,35 @@ trait SvUiPreflightIntegrationTestUtil extends TestCommon {
               if (secretsItr.hasNext) Some(secretsItr.next().text) else None
             },
           )
-          actAndCheck(timeUntilSuccess = 2.minutes)(
-            "fill the party hint field and eventuallyClickOn(id(the button to create an onboarding secret", {
-              clue("fill party hint") {
-                inside(find(id("create-party-hint"))) { case Some(element) =>
-                  element.underlying.sendKeys("splice-client-10")
+          clue("fill party hint") {
+            inside(find(id("create-party-hint"))) { case Some(element) =>
+              element.underlying.sendKeys("splice-client-10")
+            }
+          }
+
+          // The UI drops the 429 from this rate-limited POST silently, so a click can create
+          // nothing. Retry the click, not just the table read. Re-clicking is safe: a surplus
+          // secret is unused and expires.
+          eventually(timeUntilSuccess = 2.minutes, maxPollInterval = 5.seconds) {
+            clue("wait for the create button to become enabled") {
+              find(id("create-validator-onboarding-secret")).value.isEnabled shouldBe true
+            }
+
+            clue("click the create validator onboarding secret button") {
+              eventuallyClickOn(id("create-validator-onboarding-secret"))
+            }
+
+            clue("we see that this SV has created an onboarding secret") {
+              eventually(timeUntilSuccess = 15.seconds) {
+                val secretsItr = findAll(className("onboarding-secret-table-secret"))
+                val firstSecret = if (secretsItr.hasNext) Some(secretsItr.next().text) else None
+                firstSecret should not be oldFirstSecret
+                inside(firstSecret) { case Some(s) =>
+                  s should not be ""
                 }
               }
-
-              clue("wait for the create button to become enabled") {
-                eventually() {
-                  find(id("create-validator-onboarding-secret")).value.isEnabled shouldBe true
-                }
-              }
-
-              clue("click the create validator onboarding secret button") {
-                eventuallyClickOn(id("create-validator-onboarding-secret"))
-              }
-            },
-          )(
-            s"We see that this SV has created an onboarding secret",
-            _ => {
-              val secretsItr = findAll(className("onboarding-secret-table-secret"))
-              val firstSecret = if (secretsItr.hasNext) Some(secretsItr.next().text) else None
-              firstSecret should not be oldFirstSecret
-              inside(firstSecret) { case Some(s) =>
-                s should not be ""
-              }
-            },
-          )
+            }
+          }
         }
       }
 


### PR DESCRIPTION
The UI drops a 429 from the create POST silently, and actAndCheck retries only the check, so one rejected click failed the test against an unchanging table. Retry the click itself.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/10067

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
