### PR TITLE
Revert workaround for readiness probes

### DIFF
--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -106,8 +106,6 @@ spec:
           timeoutSeconds: 10
         readinessProbe:
           grpc:
-            # TODO(#7159) Revert back to actual readiness probe.
-            service: liveness
             port: 5061
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -155,8 +155,6 @@ spec:
           readinessProbe:
             grpc:
               port: 5061
-              # TODO(#7159) Revert back to actual readiness probe.
-              service: liveness
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
[static]

Got fixed in Canton, tested a local deploy to confirm the fix.

fixes #7159



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
