### PR TITLE
Upgrade Canton to 3.6.0-snapshot.20260909.20251.0.v0a9e6e25

### DIFF
--- a/canton/community/base/src/main/scala/com/digitalasset/canton/version/ProtocolVersion.scala
+++ b/canton/community/base/src/main/scala/com/digitalasset/canton/version/ProtocolVersion.scala
@@ -248,7 +248,7 @@ object ProtocolVersion {
     )
 
   val stable: NonEmpty[List[StableProtocolVersion]] =
-    NonEmpty.mk(List, ProtocolVersion.v34, ProtocolVersion.v35)
+    NonEmpty.mk(List, ProtocolVersion.v34, ProtocolVersion.v35, ProtocolVersion.v36)
 
   // LF versions that should only be used with alpha/beta protocol versions
   val alphaOnlyLfVersions: NonEmpty[List[LanguageVersion]] =
@@ -265,7 +265,7 @@ object ProtocolVersion {
     s"stable protocol versions $stable should be in sync with build info $releaseStable",
   )
 
-  val alpha: List[AlphaProtocolVersion] = List(ProtocolVersion.v36)
+  val alpha: List[AlphaProtocolVersion] = List(almostDev)
 
   val beta: List[BetaProtocolVersion] =
     parseFromBuildInfo(BuildInfo.betaProtocolVersions)
@@ -305,6 +305,9 @@ object ProtocolVersion {
       .map(ProtocolVersion.tryCreate)
       .getOrElse(ProtocolVersion.latest)
 
+  lazy val almostDev: ProtocolVersionWithStatus[ProtocolVersionAnnotation.Alpha] =
+    ProtocolVersion.createAlpha(Int.MaxValue - 1)
+
   lazy val dev: ProtocolVersionWithStatus[ProtocolVersionAnnotation.Alpha] =
     ProtocolVersion.createAlpha(Int.MaxValue)
 
@@ -314,8 +317,8 @@ object ProtocolVersion {
   lazy val v35: ProtocolVersionWithStatus[ProtocolVersionAnnotation.Stable] =
     ProtocolVersion.createStable(35)
 
-  lazy val v36: ProtocolVersionWithStatus[ProtocolVersionAnnotation.Alpha] =
-    ProtocolVersion.createAlpha(36)
+  lazy val v36: ProtocolVersionWithStatus[ProtocolVersionAnnotation.Stable] =
+    ProtocolVersion.createStable(36)
 
   // Minimum stable protocol version introduced
   lazy val minimum: ProtocolVersion = v34

--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.6.0-snapshot.20260909.20247.0.v207c27f6",
-  "oss_sha256": "sha256:0na1ra5y130jm4hdj1z0wsaiq80qpwlf54s5c6gl6rhpggkix0ma",
-  "canton_base_image_sha256": "sha256:fc2b8aa379506b820fde0c7df93363c3f5288e1f30d77856c4e51b0a840e1461",
-  "canton_participant_image_sha256": "sha256:5369b480c20bb231df6df1d8378de7f1bf5460811924a02a652346d22f3d6395",
-  "canton_mediator_image_sha256": "sha256:55c2edf69357b641c264437ab884ca7d3a27fcbfb22925b77facdd02fba32b5a",
-  "canton_sequencer_image_sha256": "sha256:2b302095ec23274a3707506ff9d018909cb33ca34dfe333493f24ac61156aeeb"
+  "version": "3.6.0-snapshot.20260909.20251.0.v0a9e6e25",
+  "oss_sha256": "sha256:0n5vwcpyrmh735bh88jccfayqq0308jnh1lby5vq0a9ppcf588k1",
+  "canton_base_image_sha256": "sha256:3738efd6df5d809a765866cec7f2b0fdd59560a32f413ce7afd96e54d890cbfb",
+  "canton_participant_image_sha256": "sha256:f47009a44ac864c670063d0fe158fbaba6af734e65943ecae4d2893d5a8a7ccd",
+  "canton_mediator_image_sha256": "sha256:036eaea917c866bed2273256e78ecbb3f7a74067fef0f88a470933d502f2729d",
+  "canton_sequencer_image_sha256": "sha256:456534c65cd93d7cb8255718b1da4e132f3444cbbebf22e44daafdd6829c6a82"
 }

--- a/project/BuildCommon.scala
+++ b/project/BuildCommon.scala
@@ -574,7 +574,7 @@ object BuildCommon {
           // We don't actually care about the damlLibrariesVersion but some of the Canton code needs it to compile.
           // We just set it to the canton version which isn't right but seems less annoying than having to maintain the actual version.
           BuildInfoKey("damlLibrariesVersion" -> CantonDependencies.canton_library_version),
-          BuildInfoKey("stableProtocolVersions" -> List("34", "35")),
+          BuildInfoKey("stableProtocolVersions" -> List("34", "35", "36")),
           BuildInfoKey("betaProtocolVersions" -> List()),
         ),
         buildInfoPackage := "com.digitalasset.canton.buildinfo",


### PR DESCRIPTION
[ci]

Should have stable PV 36 now.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
