### PR TITLE
[ci] shorten TTL to fix flake in UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -32,6 +32,7 @@ import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.{
   ExpireRewardCouponV2Trigger,
   UnhideRewardCouponV2Trigger,
 }
+import org.lfdecentralizedtrust.splice.sv.config.InitialRewardConfig
 import org.lfdecentralizedtrust.splice.util.{
   ChoiceContextWithDisclosures,
   TimeTestUtil,
@@ -56,6 +57,10 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
     with HasExecutionContext
     with WalletTestUtil
     with TimeTestUtil {
+
+  // Short TTL so expiring reward coupons only requires advancing time by a few ticks
+  // thus preventing flakes caused due to round automation never able to catch up.
+  private val rewardCouponTtl = 30.minutes
 
   // Version where V2 was introduced, or the current minimum initialization version if higher
   private val minV2AmuletVersion =
@@ -132,6 +137,15 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
         )(config)
       )
       .addConfigTransform((_, config) =>
+        ConfigTransforms.withRewardConfig(
+          InitialRewardConfig(
+            mintingVersion = "RewardVersion_TrafficBasedAppRewards",
+            dryRunVersion = None,
+            rewardCouponTimeToLiveMicros = rewardCouponTtl.toMicros,
+          )
+        )(config)
+      )
+      .addConfigTransform((_, config) =>
         ConfigTransforms.updateAllSvAppConfigs_(svConfig =>
           svConfig.copy(
             packageVettingCache = svConfig.packageVettingCache.copy(
@@ -199,7 +213,7 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
 
       actAndCheck(
         "Advance past the coupon TTL while Alice is unvetted",
-        advanceTime(Duration.ofHours(37)),
+        advanceTime(Duration.ofMinutes(rewardCouponTtl.toMinutes + 10)),
       )(
         "ExpireRewardCouponV2Trigger archives Alice's hidden and Bob's coupons while she is unvetted",
         _ => sv1Backend.appState.dsoStore.listRewardCouponsV2().futureValue shouldBe empty,
@@ -426,7 +440,7 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
 
       actAndCheck(
         "Advance past the coupon TTL",
-        advanceTime(Duration.ofHours(37)),
+        advanceTime(Duration.ofMinutes(rewardCouponTtl.toMinutes + 10)),
       )(
         "ExpireRewardCouponV2Trigger ignores Alice coupons",
         _ => {


### PR DESCRIPTION
Fixes #7206 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
