### PR TITLE
Expose SV app `/version` to validators

### DIFF
--- a/apps/sv/src/main/openapi/sv-internal.yaml
+++ b/apps/sv/src/main/openapi/sv-internal.yaml
@@ -14,6 +14,9 @@ paths:
   /status:
     $ref: "../../../../common/src/main/openapi/common-external.yaml#/paths/~1status"
   /version:
+    # Validators and SVs check this endpoint before calling any other one
+    # TODO(DACH-NY/canton-network-internal#6265): make sure this is blocked on non-DevNet once we can
+    x-external-audience: validators
     $ref: "../../../../common/src/main/openapi/common-external.yaml#/paths/~1version"
   /v0/admin/validator/onboarding/ongoing:
     get:

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3051,7 +3051,8 @@
                   "paths": [
                     "/api/sv/v0/devnet/onboard/validator/prepare",
                     "/api/sv/v0/dso",
-                    "/api/sv/v0/onboard/validator"
+                    "/api/sv/v0/onboard/validator",
+                    "/api/sv/version"
                   ]
                 }
               }

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.test.ts
@@ -34,6 +34,8 @@ describe('the SV OpenAPI spec', () => {
     expect(paths['validators']).toContain('/api/sv/v0/dso');
     expect(paths['svs']).toContain('/api/sv/v0/migration-id');
     expect(paths['svs']).toContain('/api/sv/v0/onboard/sv/status/*');
+    // clients check the version before any other call, so /version must be reachable
+    expect(paths['validators']).toContain('/api/sv/version');
     const allPaths = exposedAudiences.flatMap(audience => paths[audience]);
     // endpoints with an audience of none must not be whitelisted
     expect(allPaths).not.toContain('/api/sv/v0/admin/domain/cometbft/status');
@@ -41,6 +43,8 @@ describe('the SV OpenAPI spec', () => {
     // non-public endpoints must not be whitelisted
     expect(allPaths).not.toContain('/api/sv/v0/admin/sv/votes');
     expect(allPaths).not.toContain('/api/sv/readyz');
+    expect(allPaths).not.toContain('/api/sv/livez');
+    expect(allPaths).not.toContain('/api/sv/status');
   });
 });
 
@@ -94,6 +98,68 @@ paths:
       operationId: getFoo
 `;
     expect(() => parseSvPublicEndpoints(nonPublic)).toThrow(/only allowed on endpoints/);
+  });
+});
+
+describe('path-level x-external-audience', () => {
+  const refSpec = (extra: string) => `
+openapi: 3.0.0
+paths:
+  /version:
+${extra}    $ref: "common.yaml#/paths/~1version"
+`;
+
+  test('exposes a $ref path item that declares an audience', () => {
+    const content = refSpec('    x-external-audience: validators\n');
+    expect(parseSvPublicEndpoints(content)).toEqual([
+      { path: '/version', method: '*', audience: 'validators' },
+    ]);
+    expect(svPublicIngressPathsByAudience(content)['validators']).toEqual(['/api/sv/version']);
+  });
+
+  test('ignores a $ref path item without an audience', () => {
+    const content = refSpec('');
+    expect(parseSvPublicEndpoints(content)).toEqual([]);
+    expect(svPublicIngressPathsByAudience(content)['validators']).toEqual([]);
+  });
+
+  test('fails on an unknown path-level audience', () => {
+    expect(() => parseSvPublicEndpoints(refSpec('    x-external-audience: everyone\n'))).toThrow(
+      /must be one of/
+    );
+  });
+
+  test('applies a path-level audience to all inline operations', () => {
+    const content = `
+openapi: 3.0.0
+paths:
+  /v0/foo:
+    x-external-audience: svs
+    get:
+      x-jvm-package: sv_public
+      operationId: getFoo
+    post:
+      x-jvm-package: sv_public
+      operationId: postFoo
+`;
+    expect(parseSvPublicEndpoints(content)).toEqual([
+      { path: '/v0/foo', method: 'get', operationId: 'getFoo', audience: 'svs' },
+      { path: '/v0/foo', method: 'post', operationId: 'postFoo', audience: 'svs' },
+    ]);
+  });
+
+  test('rejects declaring the audience both on the path item and on an operation', () => {
+    const content = `
+openapi: 3.0.0
+paths:
+  /v0/foo:
+    x-external-audience: svs
+    get:
+      x-jvm-package: sv_public
+      x-external-audience: svs
+      operationId: getFoo
+`;
+    expect(() => parseSvPublicEndpoints(content)).toThrow(/both on the path item and/);
   });
 });
 

--- a/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
+++ b/cluster/pulumi/infra/src/whitelisting/svPublicEndpoints.ts
@@ -15,6 +15,7 @@ const httpMethods = ['get', 'put', 'post', 'delete', 'patch', 'head', 'options']
 
 export type SvPublicEndpoint = {
   path: string;
+  // HTTP method or `*` for a `$ref`'d path item
   method: string;
   operationId?: string;
   audience: PublicAudience;
@@ -25,11 +26,21 @@ function isPublicAudience(value: unknown): value is PublicAudience {
 }
 
 /**
- * Parses the SV OpenAPI spec and returns all endpoints that are exposed without
- * authentication (`x-jvm-package: sv_public`).
+ * Parses the SV OpenAPI spec and returns all endpoints that are reachable without
+ * authentication together with the external audience they must be exposed to.
  *
- * Throws if an `sv_public` endpoint does not declare a valid `x-external-audience`,
- * or if a non-public endpoint declares one.
+ * `x-external-audience` can be declared in two places:
+ * - on an operation with `x-jvm-package: sv_public`, where it is mandatory;
+ * - on a path item, where it applies to all operations of that path. This is the form to use
+ *   for path items that `$ref` a shared, unauthenticated endpoint such as `/version`
+ *   (`x-jvm-package: external.common_admin`), which clients call before any other endpoint.
+ *
+ * Path items without a path-level audience whose operations are not `sv_public` (e.g. the
+ * `$ref`'d `/readyz`) are not returned.
+ *
+ * Throws if an `sv_public` operation does not end up with a valid audience, if an audience is
+ * declared on a non-public operation, or if it is declared on both a path item and one of its
+ * operations.
  */
 export function parseSvPublicEndpoints(openApiContent: string): SvPublicEndpoint[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,19 +49,42 @@ export function parseSvPublicEndpoints(openApiContent: string): SvPublicEndpoint
   const endpoints: SvPublicEndpoint[] = [];
   const errors: string[] = [];
   for (const path of Object.keys(paths)) {
-    for (const method of httpMethods) {
-      const operation = paths[path]?.[method];
-      if (!operation) {
+    const pathItem = paths[path] || {};
+    const pathAudience = pathItem['x-external-audience'];
+    if (pathAudience !== undefined && !isPublicAudience(pathAudience)) {
+      errors.push(
+        `${path}: path-level x-external-audience must be one of ${publicAudiences.join(
+          ', '
+        )} but got ${JSON.stringify(pathAudience)}`
+      );
+      continue;
+    }
+    const operationMethods = httpMethods.filter(method => pathItem[method]);
+    if (operationMethods.length === 0) {
+      // A `$ref`'d path item: its operations are defined in the referenced file.
+      if (pathAudience !== undefined) {
+        endpoints.push({ path, method: '*', audience: pathAudience });
+      }
+      continue;
+    }
+    for (const method of operationMethods) {
+      const operation = pathItem[method];
+      const operationAudience = operation['x-external-audience'];
+      const isPublic = operation['x-jvm-package'] === 'sv_public';
+      if (pathAudience !== undefined && operationAudience !== undefined) {
+        errors.push(
+          `${method.toUpperCase()} ${path}: x-external-audience is declared both on the path item and on the operation`
+        );
         continue;
       }
-      const audience = operation['x-external-audience'];
-      const isPublic = operation['x-jvm-package'] === 'sv_public';
-      if (!isPublic) {
-        if (audience !== undefined) {
-          errors.push(
-            `${method.toUpperCase()} ${path}: x-external-audience is only allowed on endpoints with x-jvm-package: sv_public`
-          );
-        }
+      if (!isPublic && operationAudience !== undefined) {
+        errors.push(
+          `${method.toUpperCase()} ${path}: x-external-audience is only allowed on endpoints with x-jvm-package: sv_public`
+        );
+        continue;
+      }
+      const audience = pathAudience ?? operationAudience;
+      if (!isPublic && audience === undefined) {
         continue;
       }
       if (!isPublicAudience(audience)) {


### PR DESCRIPTION
Also adds support for (other) endpoints that are defined in the OpenAPI yaml via `$ref:`.

Tested on scratch; it correctly fixes the authorization policy there.

Part of DACH-NY/canton-network-internal#6966 ; I also want to do a docs fix for this (+ will also just add the release notes there right away as I'm also prepping the next release).

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
