### PR TITLE
Set linear canton bft blaklisting on scratches

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -343,14 +343,19 @@ final case class SvParticipantClientConfig(
 ) extends BaseParticipantClientConfig(adminApi, ledgerApi)
 
 final case class BftSequencingParameters(
-    pbftViewChangeTimeout: PositiveFiniteDuration,
-    segmentLength: PositiveLong,
-    blacklistLeaderSelectionPolicyConfig: BlacklistLeaderSelectionPolicyConfig,
-    maxRequestsInBatch: Short,
-    maxBatchesPerBlockProposal: Short,
-    pbftViewChangeTimeoutStep: NonNegativeFiniteDuration,
-    pbftViewChangeTimeoutUpperBound: NonNegativeFiniteDuration,
-    stricterDetectionOfRequestsPotentiallyChangingOrderingTopology: Boolean,
+    pbftViewChangeTimeout: PositiveFiniteDuration =
+      BftSequencingParameters.default.pbftViewChangeTimeout,
+    segmentLength: PositiveLong = BftSequencingParameters.default.segmentLength,
+    blacklistLeaderSelectionPolicyConfig: BlacklistLeaderSelectionPolicyConfig =
+      BftSequencingParameters.default.blacklistLeaderSelectionPolicyConfig,
+    maxRequestsInBatch: Short = BftSequencingParameters.default.maxRequestsInBatch,
+    maxBatchesPerBlockProposal: Short = BftSequencingParameters.default.maxBatchesPerBlockProposal,
+    pbftViewChangeTimeoutStep: NonNegativeFiniteDuration =
+      BftSequencingParameters.default.pbftViewChangeTimeoutStep,
+    pbftViewChangeTimeoutUpperBound: NonNegativeFiniteDuration =
+      BftSequencingParameters.default.pbftViewChangeTimeoutUpperBound,
+    stricterDetectionOfRequestsPotentiallyChangingOrderingTopology: Boolean =
+      BftSequencingParameters.default.stricterDetectionOfRequestsPotentiallyChangingOrderingTopology,
 ) {
   import com.digitalasset.canton.synchronizer.sequencer.block.bftordering.framework.data.topology.SequencingParameters
   def toInternal(protocolVersion: ProtocolVersion): SequencingParameters =

--- a/cluster/configs/shared/ci-sv.yaml
+++ b/cluster/configs/shared/ci-sv.yaml
@@ -1,0 +1,8 @@
+svApp:
+  additionalEnvVars:
+    - name: ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING
+      value: |
+        canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {
+          type=linear
+          maximum-epoch-blacklisted=62
+        }

--- a/cluster/configs/shared/scratchnet-sv.yaml
+++ b/cluster/configs/shared/scratchnet-sv.yaml
@@ -15,23 +15,9 @@ svApp:
     # complaining that all the other keys are missing
     - name: ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING
       value: |
-        canton.sv-apps.sv.canton-bft-sequencing-parameters {
-          blacklist-leader-selection-policy-config {
-              how-long-to-blacklist {
-                  # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.
-                  maximum-epoch-blacklisted=62
-                  type=linear
-              }
-              how-many-can-we-blacklist=num-faults-tolerated
-          }
-          # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.
-          segment-length=40
-          max-requests-in-batch=32
-          max-batches-per-block-proposal=16
-          pbft-view-change-timeout="5 seconds"
-          pbft-view-change-timeout-step="2 seconds"
-          pbft-view-change-timeout-upper-bound="30 seconds"
-          stricter-detection-of-requests-potentially-changing-ordering-topology=true
+        canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {
+          type=linear
+          maximum-epoch-blacklisted=62
         }
 
 scanApp:

--- a/cluster/configs/shared/scratchnet-sv.yaml
+++ b/cluster/configs/shared/scratchnet-sv.yaml
@@ -10,6 +10,30 @@ svApp:
     requests:
       cpu: "1"
       memory: 2Gi
+  additionalEnvVars:
+    # A naive `canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist.type=linear` doesn't work,
+    # complaining that all the other keys are missing
+    - name: ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING
+      value: |
+        canton.sv-apps.sv.canton-bft-sequencing-parameters {
+          blacklist-leader-selection-policy-config {
+              how-long-to-blacklist {
+                  # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.
+                  maximum-epoch-blacklisted=62
+                  type=linear
+              }
+              how-many-can-we-blacklist=num-faults-tolerated
+          }
+          # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.
+          segment-length=40
+          max-requests-in-batch=32
+          max-batches-per-block-proposal=16
+          pbft-view-change-timeout="5 seconds"
+          pbft-view-change-timeout-step="2 seconds"
+          pbft-view-change-timeout-upper-bound="30 seconds"
+          stricter-detection-of-requests-potentially-changing-ordering-topology=true
+        }
+
 scanApp:
   resources:
     limits:

--- a/cluster/configs/shared/scratchnet-sv.yaml
+++ b/cluster/configs/shared/scratchnet-sv.yaml
@@ -1,4 +1,4 @@
-!include(base-sv.yaml)
+!include(base-sv.yaml;ci-sv.yaml)
 pruning:
   cometbft:
     retainBlocks: 2000 # corresponds to a retention period of ~2 hours
@@ -10,15 +10,6 @@ svApp:
     requests:
       cpu: "1"
       memory: 2Gi
-  additionalEnvVars:
-    # A naive `canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist.type=linear` doesn't work,
-    # complaining that all the other keys are missing
-    - name: ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING
-      value: |
-        canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {
-          type=linear
-          maximum-epoch-blacklisted=62
-        }
 
 scanApp:
   resources:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -416,7 +416,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -494,7 +494,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -572,7 +572,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -650,7 +650,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -728,7 +728,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -806,7 +806,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -884,7 +884,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -962,7 +962,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1040,7 +1040,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1118,7 +1118,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1196,7 +1196,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1274,7 +1274,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1352,7 +1352,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1430,7 +1430,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1508,7 +1508,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1586,7 +1586,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1664,7 +1664,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1746,7 +1746,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -414,6 +414,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -489,6 +492,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -564,6 +570,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -639,6 +648,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -714,6 +726,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -789,6 +804,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -864,6 +882,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -939,6 +960,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1014,6 +1038,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1089,6 +1116,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1164,6 +1194,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1239,6 +1272,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1314,6 +1350,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1389,6 +1428,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1464,6 +1506,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1539,6 +1584,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1614,6 +1662,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1693,6 +1744,9 @@ svs:
           memory: '2Gi'
     subdomain: 'sv-1'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -416,7 +416,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -494,7 +494,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -572,7 +572,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -650,7 +650,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -728,7 +728,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -806,7 +806,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -884,7 +884,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -962,7 +962,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1040,7 +1040,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1118,7 +1118,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1196,7 +1196,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1274,7 +1274,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1352,7 +1352,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1430,7 +1430,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1508,7 +1508,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1586,7 +1586,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1664,7 +1664,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1746,7 +1746,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -414,6 +414,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -489,6 +492,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -564,6 +570,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -639,6 +648,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -714,6 +726,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -789,6 +804,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -864,6 +882,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -939,6 +960,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1014,6 +1038,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1089,6 +1116,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1164,6 +1194,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1239,6 +1272,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1314,6 +1350,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1389,6 +1428,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1464,6 +1506,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1539,6 +1584,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1614,6 +1662,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1693,6 +1744,9 @@ svs:
           memory: '2Gi'
     subdomain: 'sv-1'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -416,7 +416,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -494,7 +494,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -572,7 +572,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -650,7 +650,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -728,7 +728,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -806,7 +806,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -884,7 +884,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -962,7 +962,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1040,7 +1040,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1118,7 +1118,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1196,7 +1196,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1274,7 +1274,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1352,7 +1352,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1430,7 +1430,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1508,7 +1508,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1586,7 +1586,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1664,7 +1664,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1746,7 +1746,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -414,6 +414,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -489,6 +492,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -564,6 +570,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -639,6 +648,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -714,6 +726,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -789,6 +804,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -864,6 +882,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -939,6 +960,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1014,6 +1038,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1089,6 +1116,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1164,6 +1194,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1239,6 +1272,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1314,6 +1350,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1389,6 +1428,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1464,6 +1506,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1539,6 +1584,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1614,6 +1662,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1693,6 +1744,9 @@ svs:
           memory: '2Gi'
     subdomain: 'sv-1'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -420,7 +420,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -498,7 +498,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -576,7 +576,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -654,7 +654,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -732,7 +732,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -810,7 +810,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -888,7 +888,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -966,7 +966,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1044,7 +1044,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1122,7 +1122,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1200,7 +1200,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1278,7 +1278,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1356,7 +1356,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1434,7 +1434,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1512,7 +1512,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1590,7 +1590,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1668,7 +1668,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1750,7 +1750,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -418,6 +418,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -493,6 +496,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -568,6 +574,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -643,6 +652,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -718,6 +730,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -793,6 +808,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -868,6 +886,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -943,6 +964,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1018,6 +1042,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1093,6 +1120,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1168,6 +1198,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1243,6 +1276,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1318,6 +1354,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1393,6 +1432,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1468,6 +1510,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1543,6 +1588,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1618,6 +1666,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1697,6 +1748,9 @@ svs:
           memory: '2Gi'
     subdomain: 'sv-1'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -416,7 +416,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -494,7 +494,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -572,7 +572,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -650,7 +650,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -728,7 +728,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -806,7 +806,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -884,7 +884,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -962,7 +962,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1040,7 +1040,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1118,7 +1118,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1196,7 +1196,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1274,7 +1274,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1352,7 +1352,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1430,7 +1430,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1508,7 +1508,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1586,7 +1586,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1664,7 +1664,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1746,7 +1746,7 @@ svs:
     svApp:
       additionalEnvVars:
         - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
-          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters.blacklist-leader-selection-policy-config.how-long-to-blacklist {\n  type=linear\n  maximum-epoch-blacklisted=62\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -414,6 +414,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -489,6 +492,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -564,6 +570,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -639,6 +648,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -714,6 +726,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -789,6 +804,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -864,6 +882,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -939,6 +960,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1014,6 +1038,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1089,6 +1116,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1164,6 +1194,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1239,6 +1272,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1314,6 +1350,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1389,6 +1428,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1464,6 +1506,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1539,6 +1584,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1614,6 +1662,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       resources:
         limits:
           cpu: '3'
@@ -1693,6 +1744,9 @@ svs:
           memory: '2Gi'
     subdomain: 'sv-1'
     svApp:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_CANTONBFT_EXPONENTIAL_BLACKLISTING'
+          value: "canton.sv-apps.sv.canton-bft-sequencing-parameters {\n  blacklist-leader-selection-policy-config {\n      how-long-to-blacklist {\n          # Reduced from the default of 250 by 4x to match the increase in 4x in segment length.\n          maximum-epoch-blacklisted=62\n          type=linear\n      }\n      how-many-can-we-blacklist=num-faults-tolerated\n  }\n  # Increased by 4x as there is a synchronization point at the end of each epoch which can be expensive.\n  segment-length=40\n  max-requests-in-batch=32\n  max-batches-per-block-proposal=16\n  pbft-view-change-timeout=\"5 seconds\"\n  pbft-view-change-timeout-step=\"2 seconds\"\n  pbft-view-change-timeout-upper-bound=\"30 seconds\"\n  stricter-detection-of-requests-potentially-changing-ordering-topology=true\n}\n"
       auth0:
         clientId: 'bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7'
       resources:


### PR DESCRIPTION
...before setting it on cimain/ciperiodic
Part of https://github.com/DACH-NY/cn-test-failures/issues/10057

[preflight](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/81831/details?job=8886f6a4-eae5-4baf-ac50-aedf54a102e8&workflowId=71d6bb3d-8bef-4939-8a06-b8aa290378bf&buildNumber=492535&jobType=build)