### PR TITLE
Add release notes for fixed missing TSV2 endpoints in scan proxy

### DIFF
--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -8,3 +8,7 @@
 release-notes:: Upcoming
 
  - bump base image to full-1.0.14
+
+ - Validator App
+
+  - Fix a bug where the Scan proxy was missing Token Standard V2 endpoints for allocation-instruction and transfer-instruction.


### PR DESCRIPTION
Which should've been added in https://github.com/canton-network/splice/pull/7275/changes
